### PR TITLE
refactor(tensor_parallel): remove platform backend dependency

### DIFF
--- a/hyper_parallel/collectives/cc.py
+++ b/hyper_parallel/collectives/cc.py
@@ -12,13 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-"""Distributed process group API"""
+"""PyTorch distributed process group API."""
 from datetime import timedelta
-from typing import Optional, Any, Union
+from typing import Any, Optional, Union
 
-from hyper_parallel import get_platform
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
 
-platform = get_platform()
+
+_EXISTING_COMM_GROUPS: dict[str, ProcessGroup] = {}
+
+
+def _group_key(ranks: list[int]) -> str:
+    """Build a stable cache key from process-group ranks."""
+    return str(tuple(sorted(ranks)))
 
 
 def init_process_group(
@@ -45,24 +52,36 @@ def init_process_group(
         pg_options: Process group options for backend-specific configurations
         device_id: Specific device this process will work on
     """
-    platform.init_process_group(backend=backend, init_method=init_method, timeout=timeout, world_size=world_size,
-                                rank=rank, store=store, pg_options=pg_options, device_id=device_id)
+    dist.init_process_group(
+        backend=backend,
+        init_method=init_method,
+        timeout=timeout,
+        world_size=world_size,
+        rank=rank,
+        store=store,
+        pg_options=pg_options,
+        device_id=device_id,
+    )
 
 
-def destroy_process_group(group=None) -> None:
+def destroy_process_group(group: Optional[ProcessGroup] = None) -> None:
     """
     Destroy a given process group.
 
     Args:
         group: The process group to be destroyed. If None, destroys the default group.
 
-    Raises:
-        NotImplementedError: This method must be implemented by subclasses
     """
-    platform.destroy_process_group(group=group)
+    if group is None:
+        _EXISTING_COMM_GROUPS.clear()
+    else:
+        keys_to_destroy = [key for key, cached_group in _EXISTING_COMM_GROUPS.items() if cached_group == group]
+        for key in keys_to_destroy:
+            del _EXISTING_COMM_GROUPS[key]
+    dist.destroy_process_group(group)
 
 
-def get_process_group_ranks(group=None) -> list[int]:
+def get_process_group_ranks(group: Optional[ProcessGroup] = None) -> list[int]:
     """
     Get rank list of the given process group.
 
@@ -72,13 +91,12 @@ def get_process_group_ranks(group=None) -> list[int]:
     Returns:
         List of ranks in the specified process group.
 
-    Raises:
-        NotImplementedError: This method must be implemented by subclasses
     """
-    return platform.get_process_group_ranks(group=group)
+    resolved_group = group if group is not None else dist.group.WORLD
+    return dist.get_process_group_ranks(resolved_group)
 
 
-def get_backend(group=None):
+def get_backend(group: Optional[ProcessGroup] = None) -> str:
     """
     Get the backend of the given process group.
     Args:
@@ -87,38 +105,50 @@ def get_backend(group=None):
     Returns:
         The backend name of the specified process group.
 
-    Raises:
-        NotImplementedError: This method must be implemented by subclasses
     """
-    return platform.get_backend(group=group)
+    return dist.get_backend(group)
 
 
-def split_group(parent_pg: Any = None,
+def split_group(parent_pg: Optional[ProcessGroup] = None,
                 split_ranks: Optional[list] = None,
                 timeout: Optional[timedelta] = None,
                 pg_options: Optional[Any] = None,
                 group_desc: Optional[str] = None,
-                ) -> Any:
+                ) -> Optional[ProcessGroup]:
     """
     Create split group relative to the parent process group.
     """
-    return platform.split_group(parent_pg=parent_pg, split_ranks=split_ranks, timeout=timeout, pg_options=pg_options,
-                                group_desc=group_desc)
+    del parent_pg, timeout, pg_options, group_desc
+    if not split_ranks:
+        raise ValueError("split_ranks cannot be None or empty")
+
+    current_rank = dist.get_rank()
+    current_group = None
+    for ranks in split_ranks:
+        key = _group_key(ranks)
+        group = _EXISTING_COMM_GROUPS.get(key)
+        if group is None:
+            group = dist.new_group(ranks=ranks)
+            _EXISTING_COMM_GROUPS[key] = group
+        if current_rank in ranks:
+            current_group = group
+    return current_group
 
 
-def get_group_local_rank(group=None) -> int:
+def get_group_local_rank(group: Optional[ProcessGroup] = None) -> int:
     """get group local rank id"""
-    return platform.get_group_local_rank(group=group)
+    return dist.get_rank(group)
 
 
-def mark_created_groups(process_group: Union[Any, list[Any]]):
+def mark_created_groups(process_group: Union[ProcessGroup, list[ProcessGroup]]) -> None:
     """
     mark created groups
 
     Args:
         process_group (Union[Any, list[Any]]): A process group or a list of process groups.
 
-    Returns:
-        group corresponding to rank list if it exists, else None
     """
-    return platform.mark_created_groups(process_group=process_group)
+    groups = process_group if isinstance(process_group, list) else [process_group]
+    for group in groups:
+        ranks = dist.get_process_group_ranks(group)
+        _EXISTING_COMM_GROUPS[_group_key(ranks)] = group

--- a/hyper_parallel/core/tensor_parallel/_ce_op_registry.py
+++ b/hyper_parallel/core/tensor_parallel/_ce_op_registry.py
@@ -14,7 +14,7 @@
 # ============================================================================
 """CE operator name registry.
 
-Set of operator names on the CE decomposition path; elements are platform.get_op_name results.
+Set of canonical PyTorch operator names on the CE decomposition path.
 Allows extension via register_loss_parallel_op_names (for test injection).
 """
 
@@ -87,7 +87,7 @@ def register_loss_parallel_op_names(*names: str) -> None:
     """Extend CE operator name set (for test injection).
 
     Args:
-        *names: Operator names to register (platform.get_op_name results).
+        *names: Canonical PyTorch operator names to register.
     """
     _EXTENDED_CE_OP_NAMES.update(names)
 
@@ -105,7 +105,7 @@ def is_loss_parallel_op(op_name: str) -> bool:
     """Check if operator is a CE entry point (e.g., cross_entropy).
 
     Args:
-        op_name: Operator name (platform.get_op_name result).
+        op_name: Canonical PyTorch operator name.
 
     Returns:
         bool: Whether operator is a CE entry point.
@@ -117,7 +117,7 @@ def is_decomposed_ce_op(op_name: str) -> bool:
     """Check if operator is a decomposed CE op (e.g., log_softmax, nll_loss).
 
     Args:
-        op_name: Operator name (platform.get_op_name result).
+        op_name: Canonical PyTorch operator name.
 
     Returns:
         bool: Whether operator is a decomposed CE op.

--- a/hyper_parallel/core/tensor_parallel/api.py
+++ b/hyper_parallel/core/tensor_parallel/api.py
@@ -20,21 +20,17 @@ from contextlib import contextmanager
 from fnmatch import fnmatch
 from typing import Iterator, Optional, Union
 
+from torch import nn
+
 from hyper_parallel.core.dtensor.device_mesh import DeviceMesh, _mesh_resources
 from hyper_parallel.core.tensor_parallel.style import ParallelStyle
-from hyper_parallel.platform import get_platform
-
-platform = get_platform()
-Module = platform.Module
 
 __all__ = ["parallelize_module"]
 
 
-def _named_children(module: Module):
-    """Immediate child modules: PyTorch ``nn.Module.named_children`` or MindSpore ``Cell.name_cells``."""
-    if hasattr(module, "named_children"):
-        return module.named_children()
-    return module.name_cells().items()
+def _named_children(module: nn.Module):
+    """Return the immediate named children of a PyTorch module."""
+    return module.named_children()
 
 
 @contextmanager
@@ -58,12 +54,12 @@ def _validate_tp_mesh_dim(device_mesh: DeviceMesh) -> None:
 
 
 def parallelize_module(  # type: ignore[return]
-    module: Module,
+    module: nn.Module,
     device_mesh: Optional[DeviceMesh] = None,
     parallelize_plan: Optional[Union[ParallelStyle, dict[str, ParallelStyle]]] = None,
     *,
     src_data_rank: Optional[int] = 0,
-) -> Module:
+) -> nn.Module:
     """Apply parallel styles to *module* or submodules (PyTorch-compatible interface).
 
     Behaviour follows ``torch.distributed.tensor.parallel.parallelize_module``:
@@ -113,7 +109,7 @@ def parallelize_module(  # type: ignore[return]
     if isinstance(parallelize_plan, dict):
 
         def _apply_path(
-            current_module: Module,
+            current_module: nn.Module,
             atoms: list[str],
             style: ParallelStyle,
             src_rank: Optional[int],

--- a/hyper_parallel/core/tensor_parallel/loss_parallel_ops_common.py
+++ b/hyper_parallel/core/tensor_parallel/loss_parallel_ops_common.py
@@ -14,8 +14,7 @@
 # ============================================================================
 """Common utilities for loss_parallel operations.
 
-This module contains platform-agnostic helper functions and validation logic
-shared between PyTorch and MindSpore implementations.
+This module contains PyTorch helper functions and validation logic.
 """
 
 from __future__ import annotations

--- a/hyper_parallel/core/tensor_parallel/mc2.py
+++ b/hyper_parallel/core/tensor_parallel/mc2.py
@@ -45,9 +45,6 @@ from torch import nn
 
 from hyper_parallel.core.dtensor.dtensor import DTensor
 from hyper_parallel.core.dtensor.placement_types import Shard
-from hyper_parallel.platform import get_platform
-
-platform = get_platform()
 
 __all__ = [
     "get_hcomm_info",
@@ -117,7 +114,7 @@ def _move_front_to_dim(tensor: torch.Tensor, dim: int) -> torch.Tensor:
     return tensor.permute(*order).contiguous()
 
 
-class AllGatherMatmulFunction(platform.Function):
+class AllGatherMatmulFunction(torch.autograd.Function):
     """Column-parallel fused all-gather + matmul with custom backward.
 
     Forward (local view): ``out = AllGather_m(x) @ w^T``.
@@ -171,7 +168,7 @@ class AllGatherMatmulFunction(platform.Function):
         return grad_x, grad_w, None, None, grad_bias
 
 
-class MatmulReduceScatterFunction(platform.Function):
+class MatmulReduceScatterFunction(torch.autograd.Function):
     """Row-parallel fused matmul + reduce-scatter with custom backward.
 
     Forward (local view): ``out = ReduceScatter_m(x @ w^T)``.

--- a/hyper_parallel/core/tensor_parallel/mc2_style.py
+++ b/hyper_parallel/core/tensor_parallel/mc2_style.py
@@ -34,8 +34,6 @@ def _replace_with_mc2_linear(
     sequence_dim: int,
 ) -> MC2Linear:
     """Replace ``nn.Linear`` with configured ``MC2Linear`` in place."""
-    # Torch-only check: get_platform() is a process singleton and mixed UT may
-    # already have cached MindSpore, whose is_linear_module rejects nn.Linear.
     if not isinstance(module, nn.Linear):
         raise NotImplementedError(
             f"MC2 parallel style only supports Linear modules, but got {type(module).__name__}."

--- a/hyper_parallel/core/tensor_parallel/style.py
+++ b/hyper_parallel/core/tensor_parallel/style.py
@@ -22,6 +22,9 @@ Provides :class:`ParallelStyle` (ABC) and concrete implementations
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional, Tuple, Union
 
+import torch
+from torch import nn
+
 from hyper_parallel.core.dtensor.device_mesh import DeviceMesh
 from hyper_parallel.core.dtensor.dtensor import (
     DTensor,
@@ -33,10 +36,13 @@ from hyper_parallel.core.dtensor.dtensor import (
     _distribute_module_set_param,
 )
 from hyper_parallel.core.dtensor.placement_types import Partial, Placement, Replicate, Shard
-from hyper_parallel.platform import get_platform
 
-platform = get_platform()
-Module = platform.Module
+
+def _cast_fp_tensor(dtype: torch.dtype, tensor: torch.Tensor) -> torch.Tensor:
+    """Cast a floating-point tensor to ``dtype`` while preserving other tensors."""
+    if not torch.is_floating_point(tensor) or tensor.dtype == dtype:
+        return tensor
+    return tensor.to(dtype)
 
 
 def _src_data_rank_for_tensor(tensor: Any, src_data_rank: Optional[int]) -> Optional[int]:
@@ -72,7 +78,7 @@ class ParallelStyle(ABC):
     src_data_rank: Optional[int] = 0
 
     @abstractmethod
-    def apply(self, module: Module, device_mesh: DeviceMesh) -> Module:
+    def apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
         """Apply this parallel style to *module* in-place and return it.
 
         Args:
@@ -87,8 +93,7 @@ class ParallelStyle(ABC):
 class ColwiseParallel(ParallelStyle):
     """Partition a compatible module in a column-wise fashion.
 
-    Currently supports Linear and Embedding modules (framework-agnostic via
-    ``platform.is_linear_module`` / ``platform.is_embedding_module``).
+    Currently supports PyTorch ``Linear`` and ``Embedding`` modules.
     Compose with :class:`RowwiseParallel` to shard MLP or Attention blocks.
 
     Keyword Args:
@@ -205,7 +210,7 @@ class ColwiseParallel(ParallelStyle):
             return outputs.to_local()
         return outputs
 
-    def apply(self, module: Module, device_mesh: DeviceMesh) -> Module:
+    def apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
         """Apply column-wise parallelism to *module*.
 
         Args:
@@ -218,12 +223,12 @@ class ColwiseParallel(ParallelStyle):
         Raises:
             NotImplementedError: If *module* is not a supported type.
         """
-        if platform.is_linear_module(module):
+        if isinstance(module, nn.Linear):
 
             def partition_fn(submodule_path, submodule, device_mesh):
                 self._partition_linear_fn(submodule, device_mesh)
 
-        elif platform.is_embedding_module(module):
+        elif isinstance(module, nn.Embedding):
 
             def partition_fn(submodule_path, submodule, device_mesh):
                 self._partition_embedding_fn(submodule, device_mesh)
@@ -261,8 +266,7 @@ class ColwiseParallel(ParallelStyle):
 class RowwiseParallel(ParallelStyle):
     """Partition a compatible module in a row-wise fashion.
 
-    Currently supports Linear and Embedding modules (framework-agnostic via
-    ``platform.is_linear_module`` / ``platform.is_embedding_module``).
+    Currently supports PyTorch ``Linear`` and ``Embedding`` modules.
     Compose with :class:`ColwiseParallel` to shard MLP or Attention blocks.
 
     Keyword Args:
@@ -374,14 +378,14 @@ class RowwiseParallel(ParallelStyle):
         use_local_output: bool,
         outputs: Any,
         device_mesh: DeviceMesh,
-        module: Optional[Module] = None,
+        module: Optional[nn.Module] = None,
         reduce_dtype: Optional[Any] = None,
     ) -> Any:
         """Redistribute partial output and optionally convert to local."""
         if not isinstance(outputs, DTensor):
             # ``nn.Embedding.forward`` returns a plain tensor even when weight is sharded;
             # treat the local values as partial along the TP mesh (sum) before redistributing.
-            if module is not None and platform.is_embedding_module(module):
+            if module is not None and isinstance(module, nn.Embedding):
                 outputs = DTensor.from_local(outputs, device_mesh, [Partial("sum")])
             else:
                 raise TypeError(
@@ -389,7 +393,7 @@ class RowwiseParallel(ParallelStyle):
                     f"got {type(outputs)}. If this is an unsupported module, extend I/O hooks."
                 )
         if reduce_dtype is not None and tuple(outputs.placements) != tuple(output_layouts):
-            local_output = platform.cast_fp_tensor(reduce_dtype, outputs.to_local())
+            local_output = _cast_fp_tensor(reduce_dtype, outputs.to_local())
             outputs = DTensor.from_local(local_output, outputs.device_mesh, outputs.placements)
         if tuple(outputs.placements) != tuple(output_layouts):
             outputs = outputs.redistribute(device_mesh, output_layouts)
@@ -397,7 +401,7 @@ class RowwiseParallel(ParallelStyle):
             return outputs.to_local()
         return outputs
 
-    def apply(self, module: Module, device_mesh: DeviceMesh) -> Module:
+    def apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
         """Apply row-wise parallelism to *module*.
 
         Args:
@@ -410,13 +414,13 @@ class RowwiseParallel(ParallelStyle):
         Raises:
             NotImplementedError: If *module* is not a supported type.
         """
-        if platform.is_linear_module(module):
+        if isinstance(module, nn.Linear):
 
             def partition_fn(submodule_path, submodule, device_mesh):
                 self._partition_linear_fn(submodule, device_mesh)
 
             self.desired_input_layouts = (Shard(-1),)
-        elif platform.is_embedding_module(module):
+        elif isinstance(module, nn.Embedding):
 
             def partition_fn(submodule_path, submodule, device_mesh):
                 self._partition_embedding_fn(submodule, device_mesh)
@@ -504,7 +508,7 @@ class SequenceParallel(ParallelStyle):
     @staticmethod
     def _prepare_input_fn(
         sequence_sharding: Tuple[Placement, ...],
-        mod: Module,
+        mod: nn.Module,
         inputs: Any,
         device_mesh: DeviceMesh,
     ) -> Any:
@@ -513,7 +517,7 @@ class SequenceParallel(ParallelStyle):
         if isinstance(input_tensor, DTensor):
             if tuple(input_tensor.placements) != tuple(sequence_sharding):
                 input_tensor = input_tensor.redistribute(device_mesh, sequence_sharding)
-        elif platform.is_tensor(input_tensor):
+        elif torch.is_tensor(input_tensor):
             input_tensor = DTensor.from_local(input_tensor, device_mesh, sequence_sharding)
         else:
             raise ValueError(
@@ -527,7 +531,7 @@ class SequenceParallel(ParallelStyle):
             return outputs.to_local()
         return outputs
 
-    def apply(self, module: Module, device_mesh: DeviceMesh) -> Module:
+    def apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
         """Apply sequence-parallel hooks and replicate parameters via ``distribute_module``.
 
         Args:
@@ -633,7 +637,7 @@ class PrepareModuleInput(ParallelStyle):
             if isinstance(input_obj, DTensor):
                 dt_inp = input_obj
             else:
-                if not platform.is_tensor(input_obj):
+                if not torch.is_tensor(input_obj):
                     raise AssertionError("expecting input to be a framework tensor!")
                 dt_inp = DTensor.from_local(input_obj, mesh, (input_layout,))
 
@@ -677,21 +681,19 @@ class PrepareModuleInput(ParallelStyle):
             )
         return (prepared_arg_inputs, prepared_kwarg_inputs)
 
-    def apply(self, module: Module, device_mesh: DeviceMesh) -> Module:
+    def apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
         if self.with_kwargs:
 
             def _pre_hook(_mod, inputs, kwargs):
                 return self._prepare_input_kwarg_fn(inputs, kwargs, device_mesh)
 
-            platform.register_forward_pre_hook(
-                module, _pre_hook, prepend=False, with_kwargs=True,
-            )
+            module.register_forward_pre_hook(_pre_hook, prepend=False, with_kwargs=True)
         else:
 
             def _pre_hook(_mod, inputs):
                 return self._prepare_input_fn(inputs, device_mesh)
 
-            platform.register_forward_pre_hook(module, _pre_hook, prepend=False)
+            module.register_forward_pre_hook(_pre_hook, prepend=False)
         return module
 
     def __repr__(self) -> str:
@@ -767,7 +769,7 @@ class PrepareModuleOutput(ParallelStyle):
                     and has_partial_output
                     and out_layout != desired_out_layout
                 ):
-                    local_out = platform.cast_fp_tensor(self.reduce_dtype, dt_out.to_local())
+                    local_out = _cast_fp_tensor(self.reduce_dtype, dt_out.to_local())
                     dt_out = DTensor.from_local(local_out, dt_out.device_mesh, dt_out.placements)
                 if out_layout != desired_out_layout:
                     dt_out = dt_out.redistribute(device_mesh, (desired_out_layout,))
@@ -780,7 +782,7 @@ class PrepareModuleOutput(ParallelStyle):
             return prepared_outputs[0]
         return tuple(prepared_outputs)
 
-    def apply(self, module: Module, device_mesh: DeviceMesh) -> Module:
+    def apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
 
         def _hook(_mod, _inputs, outputs):
             return self._prepare_out_fn(outputs, device_mesh)
@@ -835,7 +837,7 @@ class PrepareModuleInputOutput(ParallelStyle):
             use_local_output=use_local_output,
         )
 
-    def apply(self, module: Module, device_mesh: DeviceMesh) -> Module:
+    def apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
         self.prepare_module_input.apply(module, device_mesh)
         self.prepare_module_output.apply(module, device_mesh)
         return module
@@ -984,11 +986,11 @@ class NoParallel(ParallelStyle):
             return outputs.to_local()
         return outputs
 
-    def apply(self, module: Module, device_mesh: DeviceMesh) -> Module:
+    def apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
         """Apply no-parallel style: replicate params/buffers and attach I/O hooks.
 
         Args:
-            module: Any ``nn.Module`` or MindSpore ``Cell`` to wrap.
+            module: PyTorch ``nn.Module`` to wrap.
             device_mesh: 1-D device mesh for tensor parallelism.
 
         Returns:

--- a/tests/ut/collectives/test_cc.py
+++ b/tests/ut/collectives/test_cc.py
@@ -12,49 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-"""Unit tests for ``hyper_parallel.collectives.cc`` process-group API wrappers.
-
-The collectives module is a thin delegation layer over :func:`get_platform()`.
-Tests mock ``hyper_parallel.collectives.cc.platform`` and verify argument forwarding
-and return-value propagation without initializing a real distributed backend.
-"""
-from __future__ import annotations
-
+"""Unit tests for the PyTorch distributed process-group wrappers."""
+from datetime import timedelta
 import os
 import unittest
-from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import call, MagicMock, patch
 
 os.environ["HYPER_PARALLEL_PLATFORM"] = "torch"
 
 from hyper_parallel.collectives import cc as collectives_cc
-from hyper_parallel.collectives.cc import (
-    destroy_process_group,
-    get_backend,
-    get_group_local_rank,
-    get_process_group_ranks,
-    init_process_group,
-    mark_created_groups,
-    split_group,
-)
 
 
-@patch("hyper_parallel.collectives.cc.platform")
-class TestInitProcessGroup(unittest.TestCase):
-    """Tests for :func:`init_process_group`."""
+@patch("hyper_parallel.collectives.cc.dist")
+class TestProcessGroupWrappers(unittest.TestCase):
+    """Verify direct delegation to ``torch.distributed``."""
 
-    def test_forwards_all_keyword_arguments(self, mock_platform: MagicMock) -> None:
-        """
-        Feature: init_process_group delegates to the active platform
-        Description: call with backend, init_method, timeout, world_size, rank, store, pg_options, device_id
-        Expectation: platform.init_process_group receives the same keyword arguments
-        """
+    def setUp(self) -> None:
+        collectives_cc._EXISTING_COMM_GROUPS.clear()
+
+    def tearDown(self) -> None:
+        collectives_cc._EXISTING_COMM_GROUPS.clear()
+
+    def test_init_process_group_forwards_all_arguments(self, mock_dist: MagicMock) -> None:
+        """Initialization forwards every supported argument unchanged."""
         timeout = timedelta(minutes=30)
         store = MagicMock(name="store")
         pg_options = MagicMock(name="pg_options")
-        device_id = 0
 
-        init_process_group(
+        collectives_cc.init_process_group(
             "hccl",
             init_method="env://",
             timeout=timeout,
@@ -62,10 +47,10 @@ class TestInitProcessGroup(unittest.TestCase):
             rank=2,
             store=store,
             pg_options=pg_options,
-            device_id=device_id,
+            device_id=2,
         )
 
-        mock_platform.init_process_group.assert_called_once_with(
+        mock_dist.init_process_group.assert_called_once_with(
             backend="hccl",
             init_method="env://",
             timeout=timeout,
@@ -73,18 +58,14 @@ class TestInitProcessGroup(unittest.TestCase):
             rank=2,
             store=store,
             pg_options=pg_options,
-            device_id=device_id,
+            device_id=2,
         )
 
-    def test_forwards_defaults_when_only_backend_given(self, mock_platform: MagicMock) -> None:
-        """
-        Feature: init_process_group default parameters
-        Description: call with backend only
-        Expectation: platform receives default world_size=-1 and rank=-1
-        """
-        init_process_group("gloo")
+    def test_init_process_group_forwards_defaults(self, mock_dist: MagicMock) -> None:
+        """Initialization preserves the public wrapper defaults."""
+        collectives_cc.init_process_group("gloo")
 
-        mock_platform.init_process_group.assert_called_once_with(
+        mock_dist.init_process_group.assert_called_once_with(
             backend="gloo",
             init_method=None,
             timeout=None,
@@ -95,203 +76,113 @@ class TestInitProcessGroup(unittest.TestCase):
             device_id=None,
         )
 
+    def test_destroy_process_group_forwards_group_and_evicts_cache(self, mock_dist: MagicMock) -> None:
+        """Destroying a group removes its cached rank-list entry."""
+        group = MagicMock(name="group")
+        collectives_cc._EXISTING_COMM_GROUPS["(0, 1)"] = group
 
-@patch("hyper_parallel.collectives.cc.platform")
-class TestDestroyProcessGroup(unittest.TestCase):
-    """Tests for :func:`destroy_process_group`."""
+        collectives_cc.destroy_process_group(group)
 
-    def test_destroy_default_group(self, mock_platform: MagicMock) -> None:
-        """
-        Feature: destroy_process_group with implicit default group
-        Description: call without a group argument
-        Expectation: platform.destroy_process_group is called with group=None
-        """
-        destroy_process_group()
-        mock_platform.destroy_process_group.assert_called_once_with(group=None)
+        mock_dist.destroy_process_group.assert_called_once_with(group)
+        self.assertEqual(collectives_cc._EXISTING_COMM_GROUPS, {})
 
-    def test_destroy_explicit_group(self, mock_platform: MagicMock) -> None:
-        """
-        Feature: destroy_process_group with an explicit group
-        Description: pass a process group handle
-        Expectation: platform receives the same group object
-        """
-        group = MagicMock(name="pg")
-        destroy_process_group(group)
-        mock_platform.destroy_process_group.assert_called_once_with(group=group)
+    def test_destroy_default_process_group_clears_cache(self, mock_dist: MagicMock) -> None:
+        """Destroying the default group clears all locally cached groups."""
+        collectives_cc._EXISTING_COMM_GROUPS["(0, 1)"] = MagicMock()
 
+        collectives_cc.destroy_process_group()
 
-@patch("hyper_parallel.collectives.cc.platform")
-class TestGetProcessGroupRanks(unittest.TestCase):
-    """Tests for :func:`get_process_group_ranks`."""
+        mock_dist.destroy_process_group.assert_called_once_with(None)
+        self.assertEqual(collectives_cc._EXISTING_COMM_GROUPS, {})
 
-    def test_returns_platform_rank_list(self, mock_platform: MagicMock) -> None:
-        """
-        Feature: get_process_group_ranks return value
-        Description: platform returns a sorted rank list for the default group
-        Expectation: API returns the same list unchanged
-        """
-        mock_platform.get_process_group_ranks.return_value = [0, 1, 2, 3]
-        ranks = get_process_group_ranks()
-        self.assertEqual(ranks, [0, 1, 2, 3])
-        mock_platform.get_process_group_ranks.assert_called_once_with(group=None)
+    def test_get_process_group_ranks_uses_world_for_none(self, mock_dist: MagicMock) -> None:
+        """The default rank query resolves to ``dist.group.WORLD``."""
+        mock_dist.get_process_group_ranks.return_value = [0, 1]
 
-    def test_forwards_explicit_group(self, mock_platform: MagicMock) -> None:
-        """
-        Feature: get_process_group_ranks with explicit group
-        Description: pass a subgroup handle
-        Expectation: platform is queried with that group
-        """
-        group = MagicMock(name="sub_pg")
-        mock_platform.get_process_group_ranks.return_value = [2, 3]
-        ranks = get_process_group_ranks(group)
-        self.assertEqual(ranks, [2, 3])
-        mock_platform.get_process_group_ranks.assert_called_once_with(group=group)
+        result = collectives_cc.get_process_group_ranks()
 
+        self.assertEqual(result, [0, 1])
+        mock_dist.get_process_group_ranks.assert_called_once_with(mock_dist.group.WORLD)
 
-@patch("hyper_parallel.collectives.cc.platform")
-class TestGetBackend(unittest.TestCase):
-    """Tests for :func:`get_backend`."""
+    def test_get_process_group_ranks_forwards_explicit_group(self, mock_dist: MagicMock) -> None:
+        """An explicit process group is passed directly to PyTorch."""
+        group = MagicMock(name="group")
+        mock_dist.get_process_group_ranks.return_value = [2, 3]
 
-    def test_returns_platform_backend_name(self, mock_platform: MagicMock) -> None:
-        """
-        Feature: get_backend return value
-        Description: platform reports backend string for default group
-        Expectation: API returns the same backend name
-        """
-        mock_platform.get_backend.return_value = "hccl"
-        backend = get_backend()
-        self.assertEqual(backend, "hccl")
-        mock_platform.get_backend.assert_called_once_with(group=None)
+        result = collectives_cc.get_process_group_ranks(group)
 
-    def test_forwards_explicit_group(self, mock_platform: MagicMock) -> None:
-        """
-        Feature: get_backend with explicit group
-        Description: pass a subgroup handle
-        Expectation: platform is queried with that group
-        """
-        group = MagicMock(name="sub_pg")
-        mock_platform.get_backend.return_value = "nccl"
-        backend = get_backend(group)
-        self.assertEqual(backend, "nccl")
-        mock_platform.get_backend.assert_called_once_with(group=group)
+        self.assertEqual(result, [2, 3])
+        mock_dist.get_process_group_ranks.assert_called_once_with(group)
 
+    def test_get_backend_forwards_group(self, mock_dist: MagicMock) -> None:
+        """Backend lookup delegates directly to PyTorch."""
+        group = MagicMock(name="group")
+        mock_dist.get_backend.return_value = "nccl"
 
-@patch("hyper_parallel.collectives.cc.platform")
-class TestSplitGroup(unittest.TestCase):
-    """Tests for :func:`split_group`."""
+        result = collectives_cc.get_backend(group)
 
-    def test_forwards_arguments_and_returns_subgroup(self, mock_platform: MagicMock) -> None:
-        """
-        Feature: split_group delegation
-        Description: split default parent group into rank lists with timeout and metadata
-        Expectation: platform.split_group receives all kwargs; return value is propagated
-        """
-        parent_pg = MagicMock(name="parent_pg")
-        split_ranks = [[0, 1], [2, 3]]
-        timeout = timedelta(seconds=60)
-        pg_options = MagicMock(name="pg_options")
-        expected_subgroup = MagicMock(name="sub_pg")
-        mock_platform.split_group.return_value = expected_subgroup
+        self.assertEqual(result, "nccl")
+        mock_dist.get_backend.assert_called_once_with(group)
 
-        result = split_group(
-            parent_pg=parent_pg,
-            split_ranks=split_ranks,
-            timeout=timeout,
-            pg_options=pg_options,
-            group_desc="tp",
+    def test_get_group_local_rank_forwards_group(self, mock_dist: MagicMock) -> None:
+        """Group-local rank lookup uses ``dist.get_rank(group)``."""
+        group = MagicMock(name="group")
+        mock_dist.get_rank.return_value = 1
+
+        result = collectives_cc.get_group_local_rank(group)
+
+        self.assertEqual(result, 1)
+        mock_dist.get_rank.assert_called_once_with(group)
+
+    def test_split_group_creates_and_selects_current_group(self, mock_dist: MagicMock) -> None:
+        """Group splitting creates every subgroup and returns the rank's subgroup."""
+        group0 = MagicMock(name="group0")
+        group1 = MagicMock(name="group1")
+        mock_dist.get_rank.return_value = 2
+        mock_dist.new_group.side_effect = [group0, group1]
+
+        result = collectives_cc.split_group(split_ranks=[[0, 1], [2, 3]])
+
+        self.assertIs(result, group1)
+        self.assertEqual(
+            mock_dist.new_group.call_args_list,
+            [call(ranks=[0, 1]), call(ranks=[2, 3])],
         )
 
-        self.assertIs(result, expected_subgroup)
-        mock_platform.split_group.assert_called_once_with(
-            parent_pg=parent_pg,
-            split_ranks=split_ranks,
-            timeout=timeout,
-            pg_options=pg_options,
-            group_desc="tp",
-        )
+    def test_split_group_reuses_cached_groups(self, mock_dist: MagicMock) -> None:
+        """Repeated rank lists reuse cached PyTorch process groups."""
+        group = MagicMock(name="group")
+        collectives_cc._EXISTING_COMM_GROUPS["(0, 1)"] = group
+        mock_dist.get_rank.return_value = 0
 
-    def test_forwards_defaults(self, mock_platform: MagicMock) -> None:
-        """
-        Feature: split_group default parameters
-        Description: call with no arguments
-        Expectation: platform receives None defaults for optional parameters
-        """
-        mock_platform.split_group.return_value = None
-        result = split_group()
-        self.assertIsNone(result)
-        mock_platform.split_group.assert_called_once_with(
-            parent_pg=None,
-            split_ranks=None,
-            timeout=None,
-            pg_options=None,
-            group_desc=None,
-        )
+        result = collectives_cc.split_group(split_ranks=[[1, 0]])
 
+        self.assertIs(result, group)
+        mock_dist.new_group.assert_not_called()
 
-@patch("hyper_parallel.collectives.cc.platform")
-class TestGetGroupLocalRank(unittest.TestCase):
-    """Tests for :func:`get_group_local_rank`."""
+    def test_split_group_rejects_empty_ranks(self, mock_dist: MagicMock) -> None:
+        """An empty split specification is invalid."""
+        del mock_dist
+        with self.assertRaises(ValueError):
+            collectives_cc.split_group(split_ranks=[])
 
-    def test_returns_platform_local_rank(self, mock_platform: MagicMock) -> None:
-        """
-        Feature: get_group_local_rank return value
-        Description: platform reports local rank within default group
-        Expectation: API returns the same integer
-        """
-        mock_platform.get_group_local_rank.return_value = 1
-        local_rank = get_group_local_rank()
-        self.assertEqual(local_rank, 1)
-        mock_platform.get_group_local_rank.assert_called_once_with(group=None)
+    def test_mark_created_groups_populates_cache(self, mock_dist: MagicMock) -> None:
+        """Existing PyTorch groups are cached by their sorted global ranks."""
+        group0 = MagicMock(name="group0")
+        group1 = MagicMock(name="group1")
+        mock_dist.get_process_group_ranks.side_effect = [[1, 0], [3, 2]]
 
-    def test_forwards_explicit_group(self, mock_platform: MagicMock) -> None:
-        """
-        Feature: get_group_local_rank with explicit group
-        Description: pass a subgroup handle
-        Expectation: platform is queried with that group
-        """
-        group = MagicMock(name="sub_pg")
-        mock_platform.get_group_local_rank.return_value = 0
-        local_rank = get_group_local_rank(group)
-        self.assertEqual(local_rank, 0)
-        mock_platform.get_group_local_rank.assert_called_once_with(group=group)
+        collectives_cc.mark_created_groups([group0, group1])
 
-
-@patch("hyper_parallel.collectives.cc.platform")
-class TestMarkCreatedGroups(unittest.TestCase):
-    """Tests for :func:`mark_created_groups`."""
-
-    def test_forwards_single_group(self, mock_platform: MagicMock) -> None:
-        """
-        Feature: mark_created_groups with one process group
-        Description: register a single subgroup in the platform cache
-        Expectation: platform.mark_created_groups is called with that group
-        """
-        group = MagicMock(name="pg")
-        mock_platform.mark_created_groups.return_value = None
-        result = mark_created_groups(group)
-        self.assertIsNone(result)
-        mock_platform.mark_created_groups.assert_called_once_with(process_group=group)
-
-    def test_forwards_group_list(self, mock_platform: MagicMock) -> None:
-        """
-        Feature: mark_created_groups with a list of process groups
-        Description: register multiple subgroups at once
-        Expectation: platform receives the same list object
-        """
-        groups = [MagicMock(name="pg0"), MagicMock(name="pg1")]
-        mark_created_groups(groups)
-        mock_platform.mark_created_groups.assert_called_once_with(process_group=groups)
+        self.assertIs(collectives_cc._EXISTING_COMM_GROUPS["(0, 1)"], group0)
+        self.assertIs(collectives_cc._EXISTING_COMM_GROUPS["(2, 3)"], group1)
 
 
 class TestCollectivesPublicExports(unittest.TestCase):
     """Sanity checks for package wiring and public re-exports."""
 
     def test_cc_module_exposes_all_collective_entry_points(self) -> None:
-        """
-        Feature: collectives.cc public API surface
-        Description: inspect module attributes
-        Expectation: all process-group helpers are defined on cc
-        """
+        """Every process-group helper remains publicly available."""
         expected = (
             "init_process_group",
             "destroy_process_group",
@@ -305,12 +196,8 @@ class TestCollectivesPublicExports(unittest.TestCase):
             self.assertTrue(hasattr(collectives_cc, name), msg=f"missing {name}")
 
     def test_hyper_parallel_reexports_collectives_api(self) -> None:
-        """
-        Feature: hyper_parallel top-level re-exports
-        Description: import collectives helpers from hyper_parallel package
-        Expectation: each name is callable and defined under collectives.cc
-        """
-        import hyper_parallel as hp
+        """Top-level exports continue to point at the collectives wrappers."""
+        import hyper_parallel as hp  # pylint: disable=import-outside-toplevel
 
         for name in (
             "init_process_group",
@@ -321,11 +208,7 @@ class TestCollectivesPublicExports(unittest.TestCase):
             "get_group_local_rank",
             "mark_created_groups",
         ):
-            exported = getattr(hp, name)
-            cc_fn = getattr(collectives_cc, name)
-            self.assertTrue(callable(exported))
-            self.assertEqual(exported.__name__, cc_fn.__name__)
-            self.assertIn("collectives.cc", exported.__module__)
+            self.assertIs(getattr(hp, name), getattr(collectives_cc, name))
 
 
 if __name__ == "__main__":

--- a/tests/ut/core/tensor_parallel/test_api.py
+++ b/tests/ut/core/tensor_parallel/test_api.py
@@ -58,7 +58,7 @@ class RecordingParallelStyle(ParallelStyle):
 
 
 class TestNamedChildren(unittest.TestCase):
-    """Tests for ``_named_children`` PyTorch / MindSpore dispatch."""
+    """Tests for PyTorch ``_named_children`` traversal."""
 
     def test_uses_named_children_when_available(self):
         """
@@ -69,27 +69,6 @@ class TestNamedChildren(unittest.TestCase):
         parent = nn.Sequential(nn.Linear(2, 2), nn.ReLU())
         expected = list(parent.named_children())
         self.assertEqual(list(_named_children(parent)), expected)
-
-    def test_uses_name_cells_when_named_children_missing(self):
-        """
-        Feature: _named_children on MindSpore-style cells
-        Description: module has ``name_cells`` but no ``named_children``
-        Expectation: returns ``name_cells().items()`` pairs
-        """
-
-        class FakeCell:
-            """Minimal MindSpore ``Cell`` stand-in for UT."""
-
-            def name_cells(self):
-                child = nn.Identity()
-                return {"block": child}
-
-        cell = FakeCell()
-        children = list(_named_children(cell))
-        self.assertEqual(len(children), 1)
-        self.assertEqual(children[0][0], "block")
-        self.assertIsInstance(children[0][1], nn.Identity)
-
 
 class TestParallelizeModule(unittest.TestCase):
     """Tests for ``parallelize_module`` dispatch and validation."""

--- a/tests/ut/core/tensor_parallel/test_colwise_parallel.py
+++ b/tests/ut/core/tensor_parallel/test_colwise_parallel.py
@@ -146,18 +146,13 @@ class TestColwiseParallelApply(unittest.TestCase):
         )
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_linear_calls_distribute_module(self, mock_style_platform, mock_mesh_platform):
+    def test_apply_linear_calls_distribute_module(self, mock_mesh_platform):
         """
         Feature: ColwiseParallel.apply on Linear module
         Description: apply ColwiseParallel to nn.Linear with mocked distribute_module
         Expectation: distribute_module is called with correct partition_fn, input_fn, output_fn
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.is_linear_module.return_value = True
-        mock_style_platform.is_embedding_module.return_value = False
-        mock_style_platform.Module = nn.Module
-
         style = ColwiseParallel()
         module = nn.Linear(8, 8)
 
@@ -171,20 +166,13 @@ class TestColwiseParallelApply(unittest.TestCase):
             self.assertIs(result, module)
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_linear_invokes_distribute_module_callbacks(
-        self, mock_style_platform, mock_mesh_platform
-    ):
+    def test_apply_linear_invokes_distribute_module_callbacks(self, mock_mesh_platform):
         """
         Feature: ColwiseParallel.apply registers callable hooks on distribute_module
         Description: capture partition_fn, input_fn, output_fn and invoke them for Linear
         Expectation: partition_fn runs _partition_linear_fn; I/O fns return without error
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.is_linear_module.return_value = True
-        mock_style_platform.is_embedding_module.return_value = False
-        mock_style_platform.Module = nn.Module
-
         style = ColwiseParallel()
         module = nn.Linear(4, 4)
 
@@ -205,18 +193,13 @@ class TestColwiseParallelApply(unittest.TestCase):
             self.assertEqual(out, "out")
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_embedding_calls_distribute_module(self, mock_style_platform, mock_mesh_platform):
+    def test_apply_embedding_calls_distribute_module(self, mock_mesh_platform):
         """
         Feature: ColwiseParallel.apply on Embedding module
         Description: apply ColwiseParallel to nn.Embedding with mocked distribute_module
         Expectation: distribute_module is called once
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.is_linear_module.return_value = False
-        mock_style_platform.is_embedding_module.return_value = True
-        mock_style_platform.Module = nn.Module
-
         style = ColwiseParallel()
         module = nn.Embedding(100, 64)
 
@@ -227,20 +210,13 @@ class TestColwiseParallelApply(unittest.TestCase):
             self.assertIs(result, module)
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_embedding_invokes_partition_fn(
-        self, mock_style_platform, mock_mesh_platform
-    ):
+    def test_apply_embedding_invokes_partition_fn(self, mock_mesh_platform):
         """
         Feature: ColwiseParallel.apply partition_fn for Embedding
         Description: invoke captured partition_fn after apply on Embedding module
         Expectation: _partition_embedding_fn is called once
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.is_linear_module.return_value = False
-        mock_style_platform.is_embedding_module.return_value = True
-        mock_style_platform.Module = nn.Module
-
         style = ColwiseParallel()
         module = nn.Embedding(8, 4)
 
@@ -253,18 +229,13 @@ class TestColwiseParallelApply(unittest.TestCase):
             mock_partition.assert_called_once_with(module, mesh)
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_unsupported_module_raises(self, mock_style_platform, mock_mesh_platform):
+    def test_apply_unsupported_module_raises(self, mock_mesh_platform):
         """
         Feature: ColwiseParallel.apply rejects unsupported module types
         Description: apply ColwiseParallel to nn.LayerNorm
         Expectation: raises NotImplementedError mentioning supported types
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.is_linear_module.return_value = False
-        mock_style_platform.is_embedding_module.return_value = False
-        mock_style_platform.Module = nn.Module
-
         style = ColwiseParallel()
         module = nn.LayerNorm(8)
 

--- a/tests/ut/core/tensor_parallel/test_mc2_style.py
+++ b/tests/ut/core/tensor_parallel/test_mc2_style.py
@@ -22,7 +22,6 @@ from torch import nn
 
 os.environ["HYPER_PARALLEL_PLATFORM"] = "torch"
 
-import hyper_parallel.platform.platform as plat_mod
 from hyper_parallel.core.dtensor.placement_types import Replicate, Shard
 from hyper_parallel.core.tensor_parallel.mc2 import (
     AllGatherMatmulFunction,
@@ -207,26 +206,12 @@ class TestMC2StyleApply(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             style.apply(nn.Embedding(10, 4), _FakeMesh())
 
-    def test_mc2_apply_works_when_platform_cache_is_mindspore(self):
-        """
-        Feature: MC2 apply does not depend on get_platform() singleton
-        Description: cache a MindSpore-like platform that rejects torch.nn.Linear
-        Expectation: MC2ColwiseParallel.apply still replaces nn.Linear
-        """
-        class _MindSporeLikePlatform:
-            @staticmethod
-            def is_linear_module(module):
-                return type(module).__name__ == "Dense"
-
+    def test_mc2_apply_uses_pytorch_linear_type(self):
+        """MC2 conversion recognizes ``torch.nn.Linear`` directly."""
         style = MC2ColwiseParallel(input_layouts=Shard(0), use_local_output=False)
         linear = nn.Linear(4, 8, bias=False)
-        previous = plat_mod.platform
-        plat_mod.platform = _MindSporeLikePlatform()
-        try:
-            with patch.object(ColwiseParallel, "apply", lambda self, module, device_mesh: module):
-                result = style.apply(linear, _FakeMesh())
-        finally:
-            plat_mod.platform = previous
+        with patch.object(ColwiseParallel, "apply", lambda self, module, device_mesh: module):
+            result = style.apply(linear, _FakeMesh())
 
         self.assertIsInstance(result, MC2Linear)
         self.assertEqual(result.mc2_mode, "all_gather")

--- a/tests/ut/core/tensor_parallel/test_no_parallel.py
+++ b/tests/ut/core/tensor_parallel/test_no_parallel.py
@@ -157,18 +157,13 @@ class TestNoParallelApply(unittest.TestCase):
         )
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_linear_calls_distribute_module(
-        self, mock_style_platform, mock_mesh_platform
-    ):
+    def test_apply_linear_calls_distribute_module(self, mock_mesh_platform):
         """
         Feature: NoParallel.apply on Linear module
         Description: mock distribute_module
         Expectation: distribute_module called with partition_fn=None; returns module from mock
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.Module = nn.Module
-
         style = NoParallel()
         module = nn.Linear(8, 16)
 
@@ -182,18 +177,13 @@ class TestNoParallelApply(unittest.TestCase):
             self.assertIs(result, module)
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_invokes_distribute_module_callbacks(
-        self, mock_style_platform, mock_mesh_platform
-    ):
+    def test_apply_invokes_distribute_module_callbacks(self, mock_mesh_platform):
         """
         Feature: NoParallel.apply registers input/output callbacks
         Description: invoke callbacks captured from mocked distribute_module
         Expectation: partition_fn is None; input_fn/output_fn delegate to static helpers
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.Module = nn.Module
-
         style = NoParallel()
         module = nn.Linear(8, 16)
 
@@ -214,18 +204,13 @@ class TestNoParallelApply(unittest.TestCase):
             self.assertEqual(out, "out")
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_layernorm_calls_distribute_module(
-        self, mock_style_platform, mock_mesh_platform
-    ):
+    def test_apply_layernorm_calls_distribute_module(self, mock_mesh_platform):
         """
         Feature: NoParallel.apply on LayerNorm module
         Description: mock distribute_module
         Expectation: distribute_module called once; returns module from mock
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.Module = nn.Module
-
         style = NoParallel()
         module = nn.LayerNorm(8)
 
@@ -406,18 +391,13 @@ class TestNoParallelIntegration(unittest.TestCase):
         )
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_parallelize_module_dict_plan_with_no_parallel(
-        self, mock_style_platform, mock_mesh_platform
-    ):
+    def test_parallelize_module_dict_plan_with_no_parallel(self, mock_mesh_platform):
         """
         Feature: parallelize_module with dict plan containing NoParallel
         Description: apply NoParallel via parallelize_module dict
         Expectation: distribute_module called on target module
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.Module = nn.Module
-
         class SimpleModel(nn.Module):
             def __init__(self):
                 super().__init__()

--- a/tests/ut/core/tensor_parallel/test_rowwise_parallel.py
+++ b/tests/ut/core/tensor_parallel/test_rowwise_parallel.py
@@ -156,18 +156,13 @@ class TestRowwiseParallelApply(unittest.TestCase):
         )
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_linear_calls_distribute_module(self, mock_style_platform, mock_mesh_platform):
+    def test_apply_linear_calls_distribute_module(self, mock_mesh_platform):
         """
         Feature: RowwiseParallel.apply on Linear module
         Description: apply RowwiseParallel to nn.Linear with mocked distribute_module
         Expectation: distribute_module is called; desired_input_layouts is (Shard(-1),)
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.is_linear_module.return_value = True
-        mock_style_platform.is_embedding_module.return_value = False
-        mock_style_platform.Module = nn.Module
-
         style = RowwiseParallel()
         module = nn.Linear(8, 8)
 
@@ -179,20 +174,13 @@ class TestRowwiseParallelApply(unittest.TestCase):
             self.assertEqual(style.desired_input_layouts, (Shard(-1),))
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_linear_invokes_distribute_module_callbacks(
-        self, mock_style_platform, mock_mesh_platform
-    ):
+    def test_apply_linear_invokes_distribute_module_callbacks(self, mock_mesh_platform):
         """
         Feature: RowwiseParallel.apply registers callable hooks on distribute_module
         Description: capture and invoke partition_fn, input_fn, output_fn for Linear
         Expectation: partition_fn calls _partition_linear_fn; I/O hooks delegate to static helpers
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.is_linear_module.return_value = True
-        mock_style_platform.is_embedding_module.return_value = False
-        mock_style_platform.Module = nn.Module
-
         style = RowwiseParallel()
         module = nn.Linear(4, 4)
 
@@ -213,18 +201,13 @@ class TestRowwiseParallelApply(unittest.TestCase):
             self.assertEqual(out, "out")
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_embedding_calls_distribute_module(self, mock_style_platform, mock_mesh_platform):
+    def test_apply_embedding_calls_distribute_module(self, mock_mesh_platform):
         """
         Feature: RowwiseParallel.apply on Embedding module
         Description: apply RowwiseParallel to nn.Embedding with mocked distribute_module
         Expectation: distribute_module is called; desired_input_layouts is (Replicate(),)
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.is_linear_module.return_value = False
-        mock_style_platform.is_embedding_module.return_value = True
-        mock_style_platform.Module = nn.Module
-
         style = RowwiseParallel()
         module = nn.Embedding(100, 64)
 
@@ -236,20 +219,13 @@ class TestRowwiseParallelApply(unittest.TestCase):
             self.assertEqual(style.desired_input_layouts, (Replicate(),))
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_embedding_invokes_partition_fn(
-        self, mock_style_platform, mock_mesh_platform
-    ):
+    def test_apply_embedding_invokes_partition_fn(self, mock_mesh_platform):
         """
         Feature: RowwiseParallel.apply partition_fn for Embedding
         Description: invoke captured partition_fn after apply on Embedding module
         Expectation: _partition_embedding_fn is called once
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.is_linear_module.return_value = False
-        mock_style_platform.is_embedding_module.return_value = True
-        mock_style_platform.Module = nn.Module
-
         style = RowwiseParallel()
         module = nn.Embedding(8, 4)
 
@@ -262,18 +238,13 @@ class TestRowwiseParallelApply(unittest.TestCase):
             mock_partition.assert_called_once_with(module, mesh)
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_unsupported_module_raises(self, mock_style_platform, mock_mesh_platform):
+    def test_apply_unsupported_module_raises(self, mock_mesh_platform):
         """
         Feature: RowwiseParallel.apply rejects unsupported module types
         Description: apply RowwiseParallel to nn.LayerNorm
         Expectation: raises NotImplementedError mentioning supported types
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.is_linear_module.return_value = False
-        mock_style_platform.is_embedding_module.return_value = False
-        mock_style_platform.Module = nn.Module
-
         style = RowwiseParallel()
         module = nn.LayerNorm(8)
 
@@ -529,14 +500,12 @@ class TestRowwiseParallelIO(unittest.TestCase):
         self.assertIsInstance(result, torch.Tensor)
         self.assertTrue(torch.allclose(result, expected))
 
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_prepare_output_fn_embedding_wraps_partial(self, mock_platform):
+    def test_prepare_output_fn_embedding_wraps_partial(self):
         """
         Feature: RowwiseParallel._prepare_output_fn Embedding partial path
         Description: plain tensor output from Embedding with embedding module passed in
         Expectation: DTensor.from_local is called with Partial(sum) before redistribute
         """
-        mock_platform.is_embedding_module.return_value = True
         mesh = MagicMock()
         module = nn.Embedding(10, 4)
         local_out = torch.randn(2, 4)
@@ -562,14 +531,12 @@ class TestRowwiseParallelIO(unittest.TestCase):
             mock_dt.redistribute.assert_called_once_with(mesh, (Replicate(),))
             self.assertIs(result, local_out)
 
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_prepare_output_fn_non_embedding_plain_tensor_raises(self, mock_platform):
+    def test_prepare_output_fn_non_embedding_plain_tensor_raises(self):
         """
         Feature: RowwiseParallel._prepare_output_fn rejects plain tensors for Linear
         Description: non-DTensor output without an Embedding module
         Expectation: TypeError mentioning DTensor / unsupported module
         """
-        mock_platform.is_embedding_module.return_value = False
         with self.assertRaises(TypeError) as ctx:
             RowwiseParallel._prepare_output_fn(
                 (Replicate(),),
@@ -611,18 +578,13 @@ class TestColRowComposition(unittest.TestCase):
         )
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_mlp_colwise_rowwise_composition(self, mock_style_platform, mock_mesh_platform):
+    def test_mlp_colwise_rowwise_composition(self, mock_mesh_platform):
         """
         Feature: ColwiseParallel + RowwiseParallel composition on MLP
         Description: parallelize_module with linear1=ColwiseParallel, linear2=RowwiseParallel
         Expectation: distribute_module called twice (once per submodule)
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.is_linear_module.return_value = True
-        mock_style_platform.is_embedding_module.return_value = False
-        mock_style_platform.Module = nn.Module
-
         class MLP(nn.Module):
             def __init__(self):
                 super().__init__()

--- a/tests/ut/core/tensor_parallel/test_sequence_parallel.py
+++ b/tests/ut/core/tensor_parallel/test_sequence_parallel.py
@@ -118,18 +118,13 @@ class TestSequenceParallelApply(unittest.TestCase):
         )
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_layernorm_calls_distribute_module(
-        self, mock_style_platform, mock_mesh_platform
-    ):
+    def test_apply_layernorm_calls_distribute_module(self, mock_mesh_platform):
         """
         Feature: SequenceParallel.apply on LayerNorm
         Description: mock distribute_module
         Expectation: distribute_module called once; returns module from mock
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.Module = nn.Module
-
         style = SequenceParallel()
         module = nn.LayerNorm(8)
 
@@ -140,18 +135,13 @@ class TestSequenceParallelApply(unittest.TestCase):
             self.assertIs(result, module)
 
     @patch("hyper_parallel.core.dtensor.device_mesh.platform")
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_apply_invokes_distribute_module_callbacks(
-        self, mock_style_platform, mock_mesh_platform
-    ):
+    def test_apply_invokes_distribute_module_callbacks(self, mock_mesh_platform):
         """
         Feature: SequenceParallel.apply registers partition/input/output callbacks
         Description: invoke callbacks captured from mocked distribute_module
         Expectation: partition_fn is no-op; input_fn/output_fn delegate to static helpers
         """
         mesh = self._make_1d_mesh(mock_mesh_platform)
-        mock_style_platform.Module = nn.Module
-
         style = SequenceParallel(sequence_dim=1)
         module = nn.LayerNorm(8)
 

--- a/tests/ut/core/tensor_parallel/test_style.py
+++ b/tests/ut/core/tensor_parallel/test_style.py
@@ -39,12 +39,29 @@ from hyper_parallel.core.dtensor.dtensor import DTensor
 from hyper_parallel.core.dtensor.placement_types import Replicate, Shard
 from hyper_parallel.core.tensor_parallel.api import parallelize_module
 from hyper_parallel.core.tensor_parallel.style import (
+    _cast_fp_tensor,
     ParallelStyle,
     PrepareModuleInput,
     PrepareModuleInputOutput,
     PrepareModuleOutput,
 )
 from hyper_parallel.platform.platform import EXISTING_COMM_GROUPS, PlatformType
+
+
+class TestTorchTensorHelpers(unittest.TestCase):
+    """Tests for direct PyTorch tensor helpers used by parallel styles."""
+
+    def test_cast_fp_tensor_casts_floating_tensor(self):
+        """A floating tensor is converted to the requested reduction dtype."""
+        tensor = torch.ones(2, dtype=torch.float16)
+        result = _cast_fp_tensor(torch.float32, tensor)
+        self.assertEqual(result.dtype, torch.float32)
+
+    def test_cast_fp_tensor_preserves_integer_tensor(self):
+        """Integer tensors are not converted by the floating-point helper."""
+        tensor = torch.ones(2, dtype=torch.int64)
+        result = _cast_fp_tensor(torch.float32, tensor)
+        self.assertIs(result, tensor)
 
 
 def _patch_platform_rank_for_dtensor_redistribute(world_size: int = 1):
@@ -563,14 +580,12 @@ class TestPrepareModuleInput(unittest.TestCase):
         mock_dt.redistribute.assert_called_once_with(mesh, (Shard(0),))
         self.assertTrue(torch.allclose(result, local))
 
-    @patch("hyper_parallel.core.tensor_parallel.style.platform")
-    def test_prepare_input_arg_raises_for_non_tensor(self, mock_platform):
+    def test_prepare_input_arg_raises_for_non_tensor(self):
         """
         Feature: PrepareModuleInput._prepare_input_arg type validation
         Description: non-tensor, non-DTensor positional value with a layout set
         Expectation: AssertionError
         """
-        mock_platform.is_tensor.return_value = False
         style = PrepareModuleInput(
             input_layouts=Replicate(),
             desired_input_layouts=Replicate(),


### PR DESCRIPTION
Paired: [GitHub #27](https://github.com/mindspore-ai/hyper-parallel/pull/27) ↔ [GitCode !1383](https://gitcode.com/mindspore/hyper-parallel/merge_requests/1383)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitee.com/mindspore/mindspore/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `mindspore-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**

/kind refactor

----

**What does this PR do / why do we need it**:

移除 `collectives` 和 `core/tensor_parallel` 对 Platform 抽象层的依赖，直接使用 PyTorch 和 `torch.distributed` 接口。

主要改动：

1. `collectives`
   - 使用 `torch.distributed` 实现进程组初始化、销毁、Backend 查询和 Rank 查询。
   - 使用 `torch.distributed.new_group` 创建子通信组。
   - 在 `collectives.cc` 内维护通信组缓存，不再依赖 Platform 通信组缓存。

2. `core/tensor_parallel`
   - 使用 `torch.nn.Module`、`torch.nn.Linear` 和 `torch.nn.Embedding` 替代 Platform 模块类型及判断接口。
   - 使用 PyTorch 接口处理 Tensor 类型判断和浮点类型转换。
   - MC2 autograd Function 直接继承 `torch.autograd.Function`。
   - Forward pre-hook 直接通过 PyTorch Module 注册。
   - CE 算子注册表使用 PyTorch canonical operator name。
   - 移除 Tensor Parallel 中的 MindSpore 分支。

3. UT
   - Collectives UT 改为 mock `torch.distributed`。
   - Tensor Parallel UT 移除相关 Platform mock，改为验证 PyTorch 行为。
   - 删除 Tensor Parallel 中的 MindSpore 专用测试分支。

修改完成后，`hyper_parallel/collectives` 和 `hyper_parallel/core/tensor_parallel` 中不再包含 `get_platform()`、`hyper_parallel.platform` 或 `platform.*` 调用。

本 PR 不涉及 DTensor，相关改造由其他任务处理。

----

**Which issue(s) this PR fixes**:

Fixes #377

----

**Test Plan and Test result：What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

```bash
pytest -q \
  tests/ut/collectives/test_cc.py \
  tests/ut/core/tensor_parallel/test_api.py \
  tests/ut/core/tensor_parallel/test_colwise_parallel.py \
  tests/ut/core/tensor_parallel/test_mc2_style.py \
  tests/ut/core/tensor_parallel/test_no_parallel.py \
  tests/ut/core/tensor_parallel/test_rowwise_parallel.py \
  tests/ut/core/tensor_parallel/test_sequence_parallel.py \
  tests/ut/core/tensor_parallel/test_style.py \
  --disable-warnings
```

测试结果：
```
163 passed, 1 warning
```
----

**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

- [x] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
- [x] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
- [x] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
- [x] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
- [x] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- - [ ] 是否导致无法前向兼容 -->
<!-- - [ ] 是否涉及依赖的三方库变更 -->

<!-- bot4-pr-sync-meta
schema_version: 1
source: gitcode
gitcode_repo: mindspore/hyper-parallel
gitcode_mr: 1383
github_repo: mindspore-ai/hyper-parallel
github_pr: 27
github_branch: sync/pr-1383
-->

<!-- atomgit-backport-meta -->
atomgit_repo: mindspore/hyper-parallel
atomgit_mr: 1383
source_branch: refactor_tp
source_url: https://gitcode.com/mindspore/hyper-parallel/merge_requests/1383
<!-- /atomgit-backport-meta -->
