### PR TITLE
fix: 修复 fast-tuner dryrun 启动及流水线参数传递

### DIFF
--- a/hyper_parallel/auto_parallel/fast-tuner/fast_tuner/parallel_tool.py
+++ b/hyper_parallel/auto_parallel/fast-tuner/fast_tuner/parallel_tool.py
@@ -104,6 +104,8 @@ def main():
                         help='Path to the TOML file')
     parser.add_argument(f"--{InputParam.PARAM_MAPPING['MINDFORMERS_DIR']}",
                         default='', help='Directory of mindformers')
+    parser.add_argument(f"--{InputParam.PARAM_MAPPING['REGISTER_PATH']}",
+                        default='research/jiutian', help='MindFormers registration path')
     parser.add_argument(f"--{InputParam.PARAM_MAPPING['MINDSPEED_PATH']}", default='',
                         help='Path to the MindSpeed file')
     parser.add_argument(f"--{InputParam.PARAM_MAPPING['TORCHTITAN_PATH']}", default='',

--- a/hyper_parallel/auto_parallel/fast-tuner/fast_tuner/pipeline_conductor/dryrun.py
+++ b/hyper_parallel/auto_parallel/fast-tuner/fast_tuner/pipeline_conductor/dryrun.py
@@ -25,6 +25,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 from multiprocessing import Pool
 
 from fast_tuner.utils.logger import logger
@@ -93,6 +94,9 @@ class DryRun:
         """
         with open(env_config_json, 'r', encoding='utf-8') as f:
             env_vars = json.load(f)
+        blocked = {'PYTHONPATH', 'LD_LIBRARY_PATH'} & env_vars.keys()
+        if blocked:
+            raise ValueError(f'Environment configuration contains blocked variables: {sorted(blocked)}')
         env_vars['RANK_SIZE'] = str(rank_size)
         os.environ.update(env_vars)
 
@@ -122,9 +126,12 @@ class DryRun:
         log_file = os.path.join(cwd, self.log_file_name, f'rank_{rank_id}.log')
         logger.info(f"start training for rank_{rank_id}, device_{device_id}, waiting a moment...")
         if self.config_file_type == 0:
+            script_path = os.path.abspath(self.ms_adapter_file)
+            if not os.path.isfile(script_path):
+                raise ValueError(f'MindSpore adapter script does not exist: {script_path}')
             os.environ['ASCEND_RT_VISIBLE_DEVICES'] = str(device_id)
             os.environ['RANK_ID'] = str(rank_id)
-            command = ['python', self.ms_adapter_file, '--register_path',
+            command = [sys.executable, script_path, '--register_path',
                        self.register_path, '--config', self.config_file]
             with open(log_file, 'w', encoding='utf-8') as log:
                 subprocess.run(command, stdout=log, stderr=subprocess.STDOUT, check=False)

--- a/hyper_parallel/auto_parallel/fast-tuner/fast_tuner/utils/dryrun_manage.py
+++ b/hyper_parallel/auto_parallel/fast-tuner/fast_tuner/utils/dryrun_manage.py
@@ -15,6 +15,7 @@
 """dryrun operation"""
 import os
 import subprocess
+import sys
 import re
 import json
 from multiprocessing import Pool
@@ -42,8 +43,13 @@ def create_target_dir(file, target_directory):
 def execute_command(para, config_file_path, target_dir, rank_id, tp):
     '''execute dryrun command'''
     if para.YAML_PATH:
-        command = ['python', os.path.join(para.MINDFORMERS_DIR, 'run_mindformer.py'), '--config', config_file_path,
-               '--register_path', para.REGISTER_PATH]
+        if not para.MINDFORMERS_DIR:
+            raise ValueError('mindformers_dir must be set explicitly for a YAML dryrun.')
+        script_path = os.path.abspath(os.path.join(para.MINDFORMERS_DIR, 'run_mindformer.py'))
+        if not os.path.isfile(script_path):
+            raise ValueError(f'MindFormers entry script does not exist: {script_path}')
+        command = [sys.executable, script_path, '--config', config_file_path,
+                   '--register_path', para.REGISTER_PATH]
     else:
         command = ['bash', config_file_path]
     try:

--- a/hyper_parallel/auto_parallel/fast-tuner/fast_tuner/utils/input_param.py
+++ b/hyper_parallel/auto_parallel/fast-tuner/fast_tuner/utils/input_param.py
@@ -25,6 +25,7 @@ class InputParam:
         "SHELL_PATH" : "shell_path",
         "TOML_PATH" : "toml_path",
         "MINDFORMERS_DIR" : "mindformers_dir",
+        "REGISTER_PATH": "register_path",
         "MINDSPEED_PATH" : "mindspeed_path",
         "TORCHTITAN_PATH": "torchtitan_path",
         "DRYRUN_DATA_DIR" : "dryrun_data_dir",

--- a/hyper_parallel/core/pipeline_parallel/mpipe/executor_base.py
+++ b/hyper_parallel/core/pipeline_parallel/mpipe/executor_base.py
@@ -113,7 +113,19 @@ class MPipeTransposeExecutorBase(ABC):
         """Receive a tensor's ``(shape, dtype)`` from ``src`` (exchanged every step)."""
         meta: list = [None, None]
         platform.recv_object_list(meta, src, self._mpipe_group)
-        return meta[0], meta[1]
+        shape, dtype = meta
+        if not isinstance(shape, (tuple, list)) or not shape or len(shape) > 8:
+            raise ValueError(f'Invalid tensor metadata shape from rank {src}: {shape!r}')
+        if any(not isinstance(dim, int) or dim < 0 for dim in shape):
+            raise ValueError(f'Invalid tensor metadata dimensions from rank {src}: {shape!r}')
+        numel = 1
+        for dim in shape:
+            numel *= dim
+            if numel > 2**31 - 1:
+                raise ValueError(f'Tensor metadata exceeds the supported size from rank {src}: {shape!r}')
+        if dtype is None:
+            raise ValueError(f'Missing tensor metadata dtype from rank {src}')
+        return tuple(shape), dtype
 
     def _output_arity(self):
         """Number of output tensors to communicate (cached after first use)."""


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What does this PR do / why do we need it**:

fast-tuner 的 YAML dryrun 使用未映射的 `REGISTER_PATH`，导致启动前报错；后续流水线又把 MindFormers 安装目录当作脚本文件，并丢失自定义注册路径。Python dryrun 重新搜索裸 `python`，还可能使用不同于当前调优进程的解释器。

本 PR 完成以下修改：

- 补齐 `register_path` 的 CLI/JSON 映射，并通过 `ParallelInput`、`pipeline_proc` 传到流水线 dryrun；默认值沿用 `research/jiutian`。
- YAML dryrun 拒绝遗漏的安装目录，检查 `run_mindformer.py`；流水线输入将安装目录转换成入口脚本，空值保留为空以便启动时明确拒绝，不退化为 CWD 同名脚本。
- 两种 Python dryrun 都使用 `sys.executable`。流水线执行前检查实际脚本为文件并绝对化，避免文件名被解释为解释器选项。
- 修复这条调用链中的 `ProfileInfo` 构造参数不匹配、未设置低内存环境变量时的默认值，以及 dryrun 模块的 `pp_util` 导入缺失。
- 在 README 和运行说明中明确脚本、注册模块、Shell 模板、环境 JSON 都属于可信作业配置。保留相对路径和合法自定义运行环境；这些检查不提供不可信代码执行沙箱。

**验证接入**：fast-tuner 是独立安装的子包，测试放在其 `tests/ut`，删除手工 `sys.modules` 包绑定，避免给 HP 主包 UT 增加未声明的 fast-tuner 依赖。

**检查器修正**：仓库规则要求保留版权年份区间，但 pylint 检查器原来只接受字面量 `Copyright 2026`。现在接受单年份和年份区间，仍检查版权主体、许可证片段及前 16 行位置，并增加正反例。合并重复的类型注解检查循环以满足复杂度门禁，测试覆盖参数种类。codespell 复用 CI 词表，并补充真实依赖名 `astroid`，不屏蔽缺失许可证诊断。

**Which issue(s) this PR fixes**:

Fixes #43353

关联跟踪：[mindspore/org-issues #43353](https://gitcode.com/mindspore/org-issues/issues/43353)。该 issue 汇总以下四项扫描发现；本 PR 修复其中确认的启动缺陷并补充信任边界说明，不代表四项安全定性全部成立或全部已修复。合并后不自动关闭 issue，需逐项评审及仲景平台闭环后交测试回归。

| 问题 | 本 PR 处理及验收范围 |
|---|---|
| ZJ-2026-3922 | 修复缺失 REGISTER_PATH、空安装目录隐式选择 CWD、流水线目录/注册参数传递及解释器选择。保留可信外部源码安装能力。 |
| ZJ-2026-3927 | 增加入口非空、文件存在性、绝对路径及当前解释器检查；配置执行训练脚本是接口能力，不声称这些检查构成任意代码执行沙箱。 |
| ZJ-2026-3921 | 保留合法环境设置，补充可信作业配置说明。没有证明低信任配置进入高权限服务的边界；不以黑名单删除加载变量。 |
| ZJ-2026-3925 | 不修改通信协议。资源上限缺失事实成立，具体越界/恶意 rank 安全影响仍需实际后端与可达条件补证；不得按本 PR 已修复关闭。 |

按组织《走单规范流程》在 #43353 汇总根因、方案、自验、DT review、引入原因和回归建议。流程文档不作为待修复缺陷关联。回归版本为本 PR 合入后包含该修复的 master 提交或对应 daily 包，实际合入 SHA/版本号待合入后补充。

**Test Plan and Test result：What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

从仓库根目录执行，独立 CPython 3.11 环境中 editable 安装本 checkout 的 fast-tuner：

```bash
python -m pip install -e ./hyper_parallel/auto_parallel/fast-tuner pytest pylint
python -m pytest hyper_parallel/auto_parallel/fast-tuner/tests/ut -q
python -m pytest scripts/tests/test_pylint_hyperparallel.py -q
```

两个测试入口分别运行：

- fast-tuner：13 个测试、13 个子测试通过。包括真实 CLI/JSON、profiling CSV、候选构造、pipeline_proc 到实际无害 Python 子进程的参数传递；验证重复调用的自定义/默认注册路径、安装目录、解释器、脚本检查、空值拒绝和日志解析。
- 检查器：3 个测试、14 个子测试通过。覆盖合法/缺失/错误/位置错误的版权头，以及位置参数、关键字参数、可变参数和返回类型检查。
- 整个 PR 变更范围的 autogit 检查通过（含 pylint、复杂度、拼写、代码风格、测试说明/标记、AGENTS 目录检查）；3 份 Markdown 单独执行 markdownlint，0 问题；`git diff --check` 通过。
- 无手工模块绑定、无测试 skip。pytest 有 marker 注册和 SWIG 弃用警告；测试定位器未识别子包 UT，产生非阻断 advisory。

**验证边界**：计算求解器及最终结果写出在调用链测试中替代，不执行真实模型训练。Shell 分支验证命令构造；未运行真实 Bash、NPU/MindSpore 训练、HP 全量 UT 或 NCCL/HCCL 畸形通信。测试分别使用各自的 pytest 根，不把混合测试根的框架导入当作独立子包验证。未声称 CI 或全模型流程已通过。

**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

- [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
- [x] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
- [x] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
- [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
- [x] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

设计与新增 register_path CLI 接口评审待 Maintainer 确认，未代替评审人勾选。测试覆盖本 PR 声明的启动/参数传递契约，硬件与完整模型验证边界见上文；本 PR 更新仓库内 fast-tuner 文档，不涉及独立官网 Doc 仓内容。


<!-- atomgit-backport-meta -->
atomgit_repo: mindspore/hyper-parallel
atomgit_mr: 1352
source_branch: codex/fix-fast-tuner-dryrun-launch
source_url: https://gitcode.com/mindspore/hyper-parallel/merge_requests/1352
<!-- /atomgit-backport-meta -->
