### PR TITLE
fix(fsdp): finalize reductions in the enclosing backward task

### DIFF
--- a/hyper_parallel/core/fully_shard/hsdp_scheduler.py
+++ b/hyper_parallel/core/fully_shard/hsdp_scheduler.py
@@ -31,12 +31,16 @@ class HSDPSchedulerContext:
     """HSDPSchedulerContext"""
 
     def __init__(self) -> None:
+        """Initialize state shared by schedulers in one FSDP module tree."""
         # Currently only record is_last_backward flag for scheduler context.
         self.is_last_backward: bool = True
         # flag to identify "root_module"
         self.root_module = None
         # all_hsdp_schedulers (for one module tree structure)
         self.all_hsdp_schedulers = []
+        # MindSpore nested backward tasks share the enclosing FSDP tree's finalization owner.
+        self.post_backward_final_callback_queued: bool = False
+        self.post_backward_schedulers: dict = {}
         # Flag to avoid repeatedly initializing parameter FQNs.
         self._param_fqn_initilized = False
 

--- a/hyper_parallel/platform/mindspore/fully_shard/scheduler.py
+++ b/hyper_parallel/platform/mindspore/fully_shard/scheduler.py
@@ -130,7 +130,16 @@ class MindSporeHSDPSchedulerV2(HSDPSchedulerV2):
     # pylint: disable=W0212
     def _backward_pre_hook(self, grad):
         """Execute backward pre hook."""
-        _pynative_executor.queue_backward_final_callback(self._root_backward_hook)
+        ctx = self.scheduler_ctx
+        ctx.post_backward_schedulers[self] = None
+        # The first entry owns finalization in the enclosing backward task. A reentrant
+        # checkpoint's inner FSDP units may register callbacks on a nested task; those
+        # callbacks must still finish local gradients without draining the outer queue.
+        callback = self._backward_hook
+        if not ctx.post_backward_final_callback_queued:
+            ctx.post_backward_final_callback_queued = True
+            callback = self._root_backward_hook
+        _pynative_executor.queue_backward_final_callback(callback)
         if self.scheduler_state == FSDPSchedulerState.PRE_BACKWARD:
             return grad
         HSDPSchedulerV2.root_bp_state = True
@@ -139,32 +148,29 @@ class MindSporeHSDPSchedulerV2(HSDPSchedulerV2):
 
     # pylint: disable=W0613
     def _root_backward_hook(self, force_reduce=False):
-        """Finalize the outermost backward: drain pending reductions and apply grads.
+        """Finalize participating units, then drain once in their enclosing backward.
 
-        The drain is unconditional. Every step below is self-limiting -- the fused
-        groups are ``None``-guarded and ``reduce_params`` is an empty-queue no-op
-        when there is no pending work -- so running them on every invocation never
-        double-applies and preserves the invariant that a parameter's ``.grad`` is
-        either ``None`` or a fully reduced value. This mirrors torch FSDP2, whose
-        wait in ``_root_post_backward_final_callback`` is likewise not gated on the
-        per-group post-backward training state.
+        Reentrant inner-task callbacks only call ``_backward_hook``. Non-reentrant
+        recomputation can instead defer a unit's local final callback until after this
+        one. Finish every participating unit first, including units whose inputs did
+        not require gradients and therefore have no ``PostBackwardFunction``.
 
-        Gating the drain on ``scheduler_state != BACKWARD`` is unsafe for any unit
-        that acts as a root while being fed a differentiable activation: its input's
-        ``PostBackwardFunction`` drives ``scheduler_state == BACKWARD``, so the gate
-        would skip the drain and leak the last module's reduce-scatter into the next
-        optimizer step. Pipeline accumulation keeps the queues empty here, launches
-        reduction after each stage's final backward, and drains the final tail through
-        :meth:`wait_for_pending_reductions`.
-
-        ``root_bp_state`` (top-level root backward in flight; gates forward prefetch during
-        activation recompute) is independent of the drain and is cleared only by the root
-        module's own hook, keyed on ``_is_root``.
+        Callback ownership is independent of ``_is_root`` and ``scheduler_state``:
+        an unwrapped model may expose several FSDP roots with differentiable inputs.
+        Such roots still need their terminal reduction even after local post-backward.
+        Pipeline callers retain the explicit ``wait_for_pending_reductions`` entry.
         """
-        self._backward_hook()
-        if self._is_root:
-            HSDPSchedulerV2.root_bp_state = False
-        self.wait_for_pending_reductions()
+        ctx = self.scheduler_ctx
+        schedulers = tuple(ctx.post_backward_schedulers) or (self,)
+        try:
+            for scheduler in schedulers:
+                scheduler._backward_hook()
+            if any(scheduler._is_root for scheduler in schedulers):
+                HSDPSchedulerV2.root_bp_state = False
+            self.wait_for_pending_reductions()
+        finally:
+            ctx.post_backward_schedulers.clear()
+            ctx.post_backward_final_callback_queued = False
 
     def wait_for_pending_reductions(self) -> None:
         """Drain every asynchronous gradient reduction queued by this backend."""

--- a/tests/mindspore/st/fully_shard/_test_fully_shard_checkpoint_finalize.py
+++ b/tests/mindspore/st/fully_shard/_test_fully_shard_checkpoint_finalize.py
@@ -1,0 +1,202 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""NPU regression for both checkpoint hook orders and nested HSDP finalization."""
+from contextlib import contextmanager
+import importlib
+from typing import Any
+from unittest.mock import patch
+
+import mindspore as ms
+from mindspore import Tensor, nn
+from mindspore.communication import get_rank, init
+import numpy as np
+import pytest
+
+from hyper_parallel import SkipDTensorDispatch, init_device_mesh
+from hyper_parallel.core.activation_checkpoint import checkpoint_wrapper
+from hyper_parallel.core.fully_shard.api import HSDPModule, fully_shard
+from hyper_parallel.core.fully_shard.utils import MixedPrecisionPolicy
+from hyper_parallel.platform.mindspore.autograd_compat import enable_mindspore_backward_compat
+from hyper_parallel.platform.mindspore.fully_shard.scheduler import MindSporeHSDPSchedulerV2
+from hyper_parallel.platform.mindspore.fully_shard.state import MindSporeHSDPStateV2
+
+
+class _Block(nn.Cell):
+    """The child projection models an expert FSDP unit inside a checkpoint."""
+
+    def __init__(self, generator: np.random.Generator) -> None:
+        """Initialize deterministic projection weights."""
+        super().__init__()
+        self.fc1 = nn.Dense(32, 32, has_bias=False,
+                            weight_init=Tensor(generator.normal(0, 0.1, (32, 32)).astype(np.float32)))
+        self.fc2 = nn.Dense(32, 32, has_bias=False,
+                            weight_init=Tensor(generator.normal(0, 0.1, (32, 32)).astype(np.float32)))
+        self.relu = nn.ReLU()
+
+    def construct(self, inputs: Tensor) -> Tensor:
+        """Preserve an input-gradient path across every checkpoint boundary."""
+        return inputs + self.fc2(self.relu(self.fc1(inputs)))
+
+
+class _Model(nn.Cell):
+    """Use a stem to give checkpointed layers differentiable inputs."""
+
+    def __init__(self) -> None:
+        """Initialize the stem and four nested FSDP blocks."""
+        super().__init__()
+        generator = np.random.default_rng(17)
+        self.stem = nn.Dense(32, 32, has_bias=False,
+                             weight_init=Tensor(generator.normal(0, 0.1, (32, 32)).astype(np.float32)))
+        self.layers = nn.CellList([_Block(generator) for _ in range(4)])
+
+    def construct(self, inputs: Tensor) -> Tensor:
+        """Return a scalar loss."""
+        value = self.stem(inputs)
+        for layer in self.layers:
+            value = layer(value)
+        return (value * value).mean()
+
+
+def _build_model(mesh, wrapper, wrap_root):
+    model = _Model()
+    if wrapper is not None:
+        for index in (0, 1):
+            model.layers[index] = wrapper(model.layers[index])
+    policy = MixedPrecisionPolicy(param_dtype=ms.float32, reduce_dtype=ms.float32,
+                                  output_dtype=ms.float32, apply_grad_on_fp32_main_grad=True)
+    options = {"mesh": mesh, "mp_policy": policy, "comm_fusion": False, "reshard_after_forward": True}
+    for layer in model.layers:
+        raw_layer = getattr(layer, "_wrapped_module", layer)
+        fully_shard(raw_layer.fc2, **options)
+        fully_shard(layer, **options)
+    if wrap_root:
+        fully_shard(model, **options)
+        roots = [model]
+    else:
+        fully_shard(model.stem, **options)
+        roots = [model.stem, *model.layers]
+    for root in roots:
+        root.set_reduce_op_type("sum")
+    return model, roots
+
+
+@contextmanager
+def _observe_backward(model, reentrant_api):
+    schedulers = {module.hsdp_scheduler for _, module in model.cells_and_names()
+                  if isinstance(module, HSDPModule)}
+    record = {"depth": 0, "completed": set(), "drains": []}
+    original_post = MindSporeHSDPSchedulerV2._hsdp_backward_hook
+    original_drain = MindSporeHSDPStateV2.delay_apply_reduce_grads.__func__
+
+    def post(scheduler: MindSporeHSDPSchedulerV2, *args: Any) -> None:
+        """Record local completion after the actual post-backward work."""
+        original_post(scheduler, *args)
+        record["completed"].add(scheduler)
+
+    def drain(cls: type) -> None:
+        """Record the backward depth and outstanding local finalizers."""
+        record["drains"].append((record["depth"], len(schedulers - record["completed"])))
+        original_drain(cls)
+
+    with patch.object(MindSporeHSDPSchedulerV2, "_hsdp_backward_hook", post), patch.object(
+            MindSporeHSDPStateV2, "delay_apply_reduce_grads", classmethod(drain)):
+        if reentrant_api is None:
+            yield record
+        else:
+            original_run = reentrant_api.run_backward
+
+            def nested_run(*args: Any, **kwargs: Any) -> Any:
+                """Track the real reentrant engine call without changing its result."""
+                record["depth"] += 1
+                try:
+                    return original_run(*args, **kwargs)
+                finally:
+                    record["depth"] -= 1
+
+            with patch.object(reentrant_api, "run_backward", nested_run):
+                yield record
+
+
+def _run_steps(model, roots, inputs, reentrant_api, wrap_root):
+    results = []
+    with _observe_backward(model, reentrant_api) as record:
+        for step in range(2):
+            for root in roots:
+                root.zero_grad()
+            for micro in range(2):
+                for root in roots:
+                    root.set_requires_all_reduce(micro == 1)
+                record["completed"].clear()
+                record["drains"].clear()
+                loss = model(inputs[step * 2 + micro]) / 2
+                loss.backward()
+                ms.runtime.synchronize()
+                assert record["drains"], "The enclosing backward must finalize reductions"
+                assert all(depth == 0 for depth, _ in record["drains"]), record["drains"]
+                if wrap_root:
+                    assert record["drains"] == [(0, 0)], record["drains"]
+                assert not MindSporeHSDPStateV2.pending_all_reduce_groups
+                for root in roots:
+                    ctx = root.hsdp_scheduler.scheduler_ctx
+                    assert not ctx.post_backward_final_callback_queued
+                    assert not ctx.post_backward_schedulers
+            gradients = {}
+            for name, parameter in model.parameters_and_names():
+                grad = getattr(parameter, "main_grad", None)
+                assert grad is not None, name
+                local = grad.to_local() if hasattr(grad, "to_local") else grad
+                normalized = name.replace("_ckpt_wrapped_module.", "").replace("_wrapped_module.", "")
+                gradients[normalized] = local.asnumpy().copy()
+            results.append((float(loss.asnumpy()), gradients))
+    return results
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _distributed_runtime():
+    ms.set_context(mode=ms.PYNATIVE_MODE)
+    enable_mindspore_backward_compat()
+    init()
+
+
+@pytest.mark.parametrize("use_reentrant", [False, True])
+@pytest.mark.parametrize("wrap_root", [True, False])
+def test_checkpoint_finalize_order_and_gradients(use_reentrant, wrap_root):
+    """
+    Feature: HSDP checkpoint finalization.
+    Description: Compare both checkpoint hook orders against an eager HSDP reference,
+        with a nested sharded child, optional outer root, and repeated accumulation.
+    Expectation: No nested-task drain, no lost terminal gradients, identical gradients.
+    """
+    reentrant_api = None
+    wrapper = checkpoint_wrapper
+    if use_reentrant:
+        # Reentrant checkpointing is an optional backend on older HyperParallel branches.
+        reentrant_api = importlib.import_module(
+            "hyper_parallel.platform.mindspore.activation_checkpoint.reentrant_checkpoint"
+        )
+        wrapper = reentrant_api.reentrant_checkpoint_wrapper
+    mesh = init_device_mesh("npu", (2, 2), mesh_dim_names=("replicate", "shard"))
+    generator = np.random.default_rng(101 + get_rank())
+    inputs = [Tensor(generator.normal(size=(4, 32)).astype(np.float32)) for _ in range(4)]
+    with SkipDTensorDispatch():
+        reference, reference_roots = _build_model(mesh, None, wrap_root)
+        expected = _run_steps(reference, reference_roots, inputs, None, wrap_root)
+        model, roots = _build_model(mesh, wrapper, wrap_root)
+        actual = _run_steps(model, roots, inputs, reentrant_api, wrap_root)
+    for (expected_loss, expected_grads), (actual_loss, actual_grads) in zip(expected, actual):
+        assert actual_loss == pytest.approx(expected_loss, rel=1e-5, abs=1e-6)
+        assert actual_grads.keys() == expected_grads.keys()
+        for name, expected_grad in expected_grads.items():
+            np.testing.assert_allclose(actual_grads[name], expected_grad, rtol=1e-5, atol=1e-6, err_msg=name)

--- a/tests/mindspore/st/fully_shard/test_fully_shard_checkpoint_finalize.py
+++ b/tests/mindspore/st/fully_shard/test_fully_shard_checkpoint_finalize.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Launch the four-rank checkpoint/HSDP finalization regression matrix."""
+from pathlib import Path
+
+from tests.common.mark_utils import arg_mark
+from tests.mindspore.st.utils import msrun_case
+
+
+@arg_mark(plat_marks=["platform_ascend910b"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+def test_checkpoint_finalize_order_and_gradients(monkeypatch):
+    """Both checkpoint modes and wrapped/unwrapped roots preserve finalization and gradients."""
+    monkeypatch.chdir(Path(__file__).parent)
+    msrun_case(3, "_test_fully_shard_checkpoint_finalize.py", "test_checkpoint_finalize_order_and_gradients",
+               18538, worker_num=4, local_worker_num=4)

--- a/tests/ut/platform/mindspore/fully_shard/test_mixed_precision.py
+++ b/tests/ut/platform/mindspore/fully_shard/test_mixed_precision.py
@@ -46,7 +46,7 @@ ensure_mindspore_platform_for_fully_shard()
 import mindspore as ms
 
 from hyper_parallel.core.dtensor.dtensor import DTensor
-from hyper_parallel.core.fully_shard.hsdp_scheduler import HSDPSchedulerV2
+from hyper_parallel.core.fully_shard.hsdp_scheduler import HSDPSchedulerContext, HSDPSchedulerV2
 from hyper_parallel.core.fully_shard.hsdp_state import HSDPState
 from hyper_parallel.core.fully_shard.hsdp_utils import FSDPSchedulerState, ShardedState
 from hyper_parallel.core.fully_shard.utils import MixedPrecisionPolicy
@@ -1208,6 +1208,7 @@ class TestSchedulerBackwardCompatFlow(unittest.TestCase):
         scheduler.cell = MagicMock()
         scheduler._hsdp_backward_pre_hook = MagicMock()
         scheduler._root_backward_hook = MagicMock()
+        scheduler.scheduler_ctx = HSDPSchedulerContext()
         grad = MagicMock()
 
         result = scheduler._backward_pre_hook(grad)
@@ -1229,6 +1230,7 @@ class TestSchedulerBackwardCompatFlow(unittest.TestCase):
         scheduler.cell = MagicMock()
         scheduler._hsdp_backward_pre_hook = MagicMock()
         scheduler._root_backward_hook = MagicMock()
+        scheduler.scheduler_ctx = HSDPSchedulerContext()
         grad = MagicMock()
 
         result = scheduler._backward_pre_hook(grad)
@@ -1296,6 +1298,8 @@ class TestSchedulerBackwardCompatFlow(unittest.TestCase):
         scheduler.scheduler_state = FSDPSchedulerState.PRE_BACKWARD
         scheduler._backward_hook = MagicMock()
         scheduler.hsdp_state = MagicMock()
+        scheduler.scheduler_ctx = HSDPSchedulerContext()
+        scheduler._is_root = True
 
         HSDPSchedulerV2.root_bp_state = True
 
@@ -1305,23 +1309,25 @@ class TestSchedulerBackwardCompatFlow(unittest.TestCase):
         scheduler.hsdp_state.reduce_params.assert_called_once_with()
         self.assertFalse(HSDPSchedulerV2.root_bp_state)
 
-    def test_root_backward_hook_keeps_root_state_for_non_root_callback(self):
+    def test_root_backward_hook_keeps_root_state_for_non_root_owner(self):
         """
         Feature: recompute forward guard
-        Description: Non-root final callbacks should not clear the shared recompute state
-        Expectation: root_bp_state remains set until the outermost callback runs
+        Description: A non-root finalization owner must drain without resetting another root's state
+        Expectation: terminal reduction runs even when local post-backward is already complete
         """
         scheduler = object.__new__(MindSporeHSDPSchedulerV2)
         scheduler.scheduler_state = FSDPSchedulerState.BACKWARD
         scheduler._backward_hook = MagicMock()
         scheduler.hsdp_state = MagicMock()
+        scheduler.scheduler_ctx = HSDPSchedulerContext()
+        scheduler._is_root = False
 
         HSDPSchedulerV2.root_bp_state = True
 
         scheduler._root_backward_hook()
 
         scheduler._backward_hook.assert_called_once_with()
-        scheduler.hsdp_state.reduce_params.assert_not_called()
+        scheduler.hsdp_state.reduce_params.assert_called_once_with()
         self.assertTrue(HSDPSchedulerV2.root_bp_state)
 
 

--- a/tests/ut/platform/mindspore/fully_shard/test_scheduler.py
+++ b/tests/ut/platform/mindspore/fully_shard/test_scheduler.py
@@ -35,7 +35,7 @@ ensure_mindspore_platform_for_fully_shard()
 
 import mindspore as ms
 
-from hyper_parallel.core.fully_shard.hsdp_scheduler import HSDPSchedulerV2
+from hyper_parallel.core.fully_shard.hsdp_scheduler import HSDPSchedulerContext, HSDPSchedulerV2
 from hyper_parallel.core.fully_shard.hsdp_utils import FSDPSchedulerState
 from hyper_parallel.platform.mindspore.fully_shard import scheduler as scheduler_mod
 from hyper_parallel.platform.mindspore.fully_shard.scheduler import MindSporeHSDPSchedulerV2
@@ -58,6 +58,8 @@ def _make_scheduler():
     scheduler.scheduler_state = FSDPSchedulerState.PRE_FORWARD
     scheduler.cell = "cell"
     scheduler._fsdp_group_post_pending = None
+    scheduler._is_root = False
+    scheduler.scheduler_ctx = HSDPSchedulerContext()
     return scheduler
 
 
@@ -265,6 +267,98 @@ class TestMindSporeScheduler(MindSporeFullyShardUnitTest):
         scheduler._hsdp_backward_hook.reset_mock()
         MindSporeHSDPSchedulerV2._backward_hook(scheduler)
         scheduler._hsdp_backward_hook.assert_not_called()
+
+    def test_nested_callback_only_finishes_its_local_unit(self):
+        """An inner backward callback must not wait outer pending reductions."""
+        outer = _make_scheduler()
+        inner = _make_scheduler()
+        inner.scheduler_ctx = outer.scheduler_ctx
+        outer._is_root = True
+        callbacks = []
+        for scheduler in (outer, inner):
+            scheduler.scheduler_state = FSDPSchedulerState.PRE_BACKWARD
+            scheduler._backward_hook = MagicMock()
+            scheduler.wait_for_pending_reductions = MagicMock()
+
+        with patch.object(scheduler_mod._pynative_executor, "queue_backward_final_callback",
+                          side_effect=callbacks.append):
+            outer._backward_pre_hook("grad")
+            inner._backward_pre_hook("grad")
+        HSDPSchedulerV2.root_bp_state = True
+        callbacks[1]()  # Reentrant child finishes before the enclosing backward task.
+        inner._backward_hook.assert_called_once_with()
+        inner.wait_for_pending_reductions.assert_not_called()
+        outer.wait_for_pending_reductions.assert_not_called()
+        self.assertTrue(outer.scheduler_ctx.post_backward_final_callback_queued)
+        self.assertTrue(HSDPSchedulerV2.root_bp_state)
+
+        callbacks[0]()
+        outer.wait_for_pending_reductions.assert_called_once_with()
+        self.assertFalse(outer.scheduler_ctx.post_backward_final_callback_queued)
+        self.assertFalse(outer.scheduler_ctx.post_backward_schedulers)
+        self.assertFalse(HSDPSchedulerV2.root_bp_state)
+
+    def test_outer_callback_finalizes_units_before_late_local_callbacks(self):
+        """Non-reentrant/fallback hooks may run after the enclosing callback."""
+        owner = _make_scheduler()
+        child = _make_scheduler()
+        child.scheduler_ctx = owner.scheduler_ctx
+        callbacks = []
+        order = []
+
+        def finish(scheduler: MindSporeHSDPSchedulerV2, label: str) -> None:
+            """Model the local post-backward state transition."""
+            scheduler.scheduler_state = FSDPSchedulerState.BACKWARD
+            order.append(label)
+
+        for scheduler, label in ((owner, "owner"), (child, "child")):
+            scheduler.scheduler_state = FSDPSchedulerState.PRE_BACKWARD
+            scheduler._hsdp_backward_hook = MagicMock(
+                side_effect=lambda *args, unit=scheduler, name=label: finish(unit, name)
+            )
+        owner.wait_for_pending_reductions = MagicMock(side_effect=lambda: order.append("drain"))
+        with patch.object(scheduler_mod._pynative_executor, "queue_backward_final_callback",
+                          side_effect=callbacks.append):
+            owner._backward_pre_hook("grad")
+            child._backward_pre_hook("grad")
+            child._backward_pre_hook("second output grad")
+
+        callbacks[0]()  # Neither local post-backward fallback has run yet.
+        self.assertEqual(order, ["owner", "child", "drain"])
+        for callback in callbacks[1:]:
+            callback()
+        self.assertEqual(order, ["owner", "child", "drain"])
+        owner.wait_for_pending_reductions.assert_called_once_with()
+
+    def test_non_root_owner_finalizes_after_local_backward_and_rearms(self):
+        """Callback ownership must not depend on root flags or BACKWARD state."""
+        scheduler = _make_scheduler()
+        scheduler.scheduler_state = FSDPSchedulerState.PRE_BACKWARD
+        scheduler.wait_for_pending_reductions = MagicMock()
+        callbacks = []
+        with patch.object(scheduler_mod._pynative_executor, "queue_backward_final_callback",
+                          side_effect=callbacks.append):
+            for _ in range(2):
+                scheduler.scheduler_state = FSDPSchedulerState.PRE_BACKWARD
+                scheduler._backward_pre_hook("grad")
+                scheduler.scheduler_state = FSDPSchedulerState.BACKWARD
+                callbacks[-1]()
+                self.assertFalse(scheduler.scheduler_ctx.post_backward_final_callback_queued)
+                self.assertFalse(scheduler.scheduler_ctx.post_backward_schedulers)
+        self.assertEqual(scheduler.wait_for_pending_reductions.call_count, 2)
+        self.assertEqual(callbacks, [scheduler._root_backward_hook, scheduler._root_backward_hook])
+
+    def test_final_callback_clears_registration_after_failure(self):
+        """A failed terminal wait must not retain scheduler references or its queued flag."""
+        scheduler = _make_scheduler()
+        scheduler.scheduler_state = FSDPSchedulerState.BACKWARD
+        scheduler.scheduler_ctx.post_backward_schedulers[scheduler] = None
+        scheduler.scheduler_ctx.post_backward_final_callback_queued = True
+        scheduler.wait_for_pending_reductions = MagicMock(side_effect=RuntimeError("communication failed"))
+        with self.assertRaisesRegex(RuntimeError, "communication failed"):
+            scheduler._root_backward_hook()
+        self.assertFalse(scheduler.scheduler_ctx.post_backward_final_callback_queued)
+        self.assertFalse(scheduler.scheduler_ctx.post_backward_schedulers)
 
     def test_terminal_wait_drains_rs_before_waiting_all_reduces(self):
         """The terminal action should launch the tail AR, then wait all ARs."""


### PR DESCRIPTION
Paired: [GitHub #53](https://github.com/mindspore-ai/hyper-parallel/pull/53) ↔ [GitCode !1560](https://gitcode.com/mindspore/hyper-parallel/merge_requests/1560)

**What type of PR is this?**

/kind bug

**What does this PR do / why do we need it**:

修复 MindSpore PyNative 下重入 checkpoint 内部嵌套 FSDP 时，内层 backward 的 final callback 提前等待外层梯度通信、打断计算通信重叠的问题。兼容 `use_reentrant=True` 和 `False` 两种不同的 hook 执行顺序。

### 问题与触发条件

触发结构是：外层 Transformer FSDP 包含重入 checkpoint，而 checkpoint 内部的 routed experts 又是独立的 FSDP 单元。

原实现中，每个 FSDP 模块的 `_backward_pre_hook` 都注册 `_root_backward_hook`。重入 checkpoint 会执行内层 `run_backward()`，专家模块在这个内层任务中注册的 final callback 会在内层 backward 结束时执行。

但是 `_root_backward_hook` 无条件调用 `wait_for_pending_reductions()`；`_is_root` 只控制 `root_bp_state` 复位。`pending_all_reduce_groups` 又是共享队列，所以内层专家的 callback 会同时等待此前外层模块已发起、尚未完成的 AllReduce。

```text
前面各层 backward：持续发起异步梯度 AllReduce
  → checkpoint 内层 backward
    → 专家 FSDP final callback
      → 等待整个共享归约队列
  → 等待完成后，外层 backward 才能继续
```

在一个 MoE 训练 profiling 中，首个重计算层附近出现约 394 ms 连续无计算区间，计算流上是连续 EVENT_WAIT，同时副本维梯度 AllReduce 仍在执行。小模型真实 NPU 复现进一步确认了上述机制：首个内层 callback 一次等待 5 个归约组，其中 4 个属于此前的外层模块。仅有重入 checkpoint、没有内部独立 FSDP 的对照不触发该问题。

### 修复

- 在同一 FSDP 模块树共享的 scheduler context 中记录本轮参与 backward 的 scheduler，并指定一个整轮收尾回调。
- 首次进入 backward 时注册整体 `_root_backward_hook`；后续模块仍注册局部 `_backward_hook`，保留内层任务结束时必要的局部 post-backward，但不允许它清空外层通信队列。
- 整体回调先补齐所有参与模块的局部 post-backward，再执行最终梯度归约等待；最后清空本轮回调登记。
- 仅修改 MindSpore scheduler 的执行行为；公共 context 新增元数据，Torch scheduler 行为不变。没有新增外部配置或第三方依赖。

### 两种重计算模式的 hook 顺序

| 场景 | 修复后的处理 |
|---|---|
| `use_reentrant=True` | 内层专家 callback 只执行局部 post-backward；整轮通信等待仍属于外层 backward。 |
| `use_reentrant=False` | 部分局部 final callback 可能晚于整体 callback；整体收尾先补齐全部参与模块，避免漏发最后一组梯度归约。 |
| 外层模型未包 FSDP | 各 FSDP 子树由首次反向入口承担收尾，不依赖物理 `_is_root` 标志或模块当前是否已处于 `BACKWARD` 状态。 |
| 输入不需要梯度 | 即使没有输入侧 `PostBackwardFunction`，仍保留局部 final callback 和整体补齐路径。 |
| 重复反向、梯度累积 | 每轮结束清空回调登记；不把上轮 owner 状态带入下一轮。 |

没有删除通信 handle 的必要等待，也没有恢复旧的 `scheduler_state != BACKWARD` 条件；后者曾导致某些根模块漏掉终端梯度归约。

**Which issue(s) this PR fixes**:

暂无关联 issue。

**Test Plan and Test result：What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

- MindSpore 2.10.0，PyNative 模式，真实 4 张 Ascend NPU，HSDP mesh 为 replicate2 × shard2。
- 本 PR 变更范围 UT 门禁：62 passed，8 skipped（已有跳过/条件跳过）。新增 UT 覆盖内层 callback 不执行全局 drain、局部 callback 晚到时的补齐、非 root owner、重复反向登记与收尾异常时的登记清理。
- 新增 4 NPU ST 覆盖 `use_reentrant={False, True}` × `wrap_root={True, False}`，每个 rank 的 4 种组合全部通过。
- 每种组合跑两轮，每轮累积两个 micro-batch；前一个只做分片归约，最后一个开启副本 AllReduce。逐参数梯度和 loss 与无重计算的同拓扑模型对照一致（rtol=1e-5，atol=1e-6）。
- 检查真实内层 backward 不执行整轮 drain，全部终端梯度存在，无残留 pending group 或回调登记；外层根被 FSDP 包裹时，整体 drain 前全部参与模块已完成局部 post-backward。
- ST 使用仓库 `msrun_case` 启动，并可从仓库根目录直接运行；测试中的深度记录只用于断言，不修改被测调度行为。
- PR 创建门禁已通过变更范围内的 UT/ST，ST 启动测试为 1 passed、内部四种组合在每个 rank 均通过。`git diff --check` 和 Python 编译检查通过。
- 项目 pylint 与原始基线对比：35 条历史告警降为 34 条，无新增告警；完整旧文件尚非零告警。
- 尚未重跑 16384-die 全模型测速；本 PR 不宣称已测得上述 394 ms 的实际消除量或全模型吞吐收益。

**Self-checklist**:

- [ ] **设计**：等待 Maintainer 评审。
- [x] **测试**：新增 UT/ST 已随 PR 提交，两种重计算模式及有无外层 FSDP 根均已验证。
- [x] **验证**：已说明触发条件、真实 NPU 复现、梯度对照和性能验证边界。
- [x] **接口**：无对外 API/配置变更。
- [x] **文档**：已更新实现注释，无官网文档变更。

<!-- atomgit-backport-meta -->
atomgit_repo: mindspore/hyper-parallel
atomgit_mr: 1340
source_branch: fix/fsdp-checkpoint-finalization
source_url: https://gitcode.com/mindspore/hyper-parallel/merge_requests/1340
<!-- /atomgit-backport-meta -->
