### PR TITLE
feat: FSDP/HSDP 支持配置梯度规约通信间隔

### DIFF
--- a/hyper_parallel/core/fully_shard/api.py
+++ b/hyper_parallel/core/fully_shard/api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ============================================================================
 """hybrid shard data parallel interface"""
+import warnings
 from collections import namedtuple
 from typing import Any, List, Mapping, cast, Optional, Union
 
@@ -318,6 +319,55 @@ class HSDPModule:
     def set_is_last_backward(self, is_last_backward: bool):
         """set is_last_backward flag"""
         self.hsdp_scheduler.scheduler_ctx.is_last_backward = is_last_backward
+
+    def set_reduce_comm_interval(self, interval: int = 1) -> None:
+        """Configure how many subsequent HSDP units may overlap reduce-scatter.
+
+        The configuration belongs to the root module's scheduler context and
+        therefore applies to the entire HSDP module tree. Only non-fused HSDP
+        units count toward the interval. An interval of one preserves the
+        default behavior: a unit's reduce-scatter is waited after the next unit
+        finishes backward computation. Larger values retain more communication
+        inputs, outputs, and gradients on the device until that many subsequent
+        units have completed backward.
+
+        Configure the root module before its first forward. This method only
+        updates configuration and does not wait in-flight work. The root
+        backward hook drains intervals larger than the module-tree depth before
+        reduced gradients are applied.
+
+        Args:
+            interval: Number of subsequent HSDP units between reduce-scatter
+                waits. Must be a positive integer.
+
+        Raises:
+            NotImplementedError: If the active platform is not PyTorch.
+            ValueError: If ``interval`` is not a positive integer or the module
+                has not been initialized by ``fully_shard``, or if the root
+                module has already started its first forward.
+
+        Note:
+            Intervals greater than one do not support communication fusion. If
+            ``comm_fusion=True``, a warning is emitted and the interval remains
+            forced to one so fused communication keeps its single-work lifecycle.
+        """
+        if platform.platform_type != PlatformType.PYTORCH:
+            raise NotImplementedError("set_reduce_comm_interval is only supported on PyTorch")
+        if isinstance(interval, bool) or not isinstance(interval, int) or interval < 1:
+            raise ValueError(f"interval must be a positive int, but got {interval!r}.")
+        if self.hsdp_scheduler is None:
+            raise ValueError("call fully_shard before setting reduce communication interval")
+        if self.hsdp_scheduler.scheduler_ctx.lazy_init_done:
+            raise ValueError("set reduce communication interval before the root module's first forward")
+        if self.hsdp_scheduler.comm_fusion_policy.enable_comm_fusion and interval > 1:
+            warnings.warn(
+                "reduce communication intervals greater than one are not supported when "
+                "comm_fusion=True; using interval=1.",
+                UserWarning,
+                stacklevel=2,
+            )
+            interval = 1
+        self.hsdp_scheduler.scheduler_ctx.per_param_comm_ctx.reduce_interval = interval
 
     def reset_iter_state(self, recursive: bool = True) -> None:
         """Reset fully_shard iteration bookkeeping without clearing optimizer gradients.

--- a/hyper_parallel/core/fully_shard/hsdp_scheduler.py
+++ b/hyper_parallel/core/fully_shard/hsdp_scheduler.py
@@ -14,6 +14,7 @@
 # ============================================================================
 """HSDP scheduler"""
 import functools
+from collections import deque
 from typing import Any, List, Mapping, Optional, Tuple, Union
 
 from hyper_parallel.platform import get_platform
@@ -41,6 +42,24 @@ class ParamGroupCommCtx:
         self.comm_handle = None
 
 
+class PerParamCommCtx:
+    """Track non-fused gradient communication for one HSDP module tree.
+
+    The two ``pre_*`` deques advance in lockstep. Each entry contains the
+    parameters or groups launched by one non-fused HSDP unit, including an
+    empty list when that unit has no gradient to reduce. A larger interval
+    retains reduce-scatter buffers and source gradients for more units, so the
+    root backward hook must drain every remaining entry before applying grads.
+    """
+
+    def __init__(self) -> None:
+        """Initialize one empty per-parameter communication pipeline."""
+        self.reduce_interval: int = 1
+        self.pre_reduce_scatter_params = deque()
+        self.pre_all_reduce_groups = deque()
+        self.all_reduce_work_groups = []
+
+
 class HSDPSchedulerContext:
     """Share scheduler and backward-pipeline state within one HSDP module tree."""
 
@@ -57,12 +76,8 @@ class HSDPSchedulerContext:
         self.all_hsdp_schedulers = []
         # Parameter FQNs are initialized once after all schedulers share this context.
         self._param_fqn_initialized = False
-        # Backward pipeline queues shared only by schedulers in this module tree.
-        self.pre_reduce_scatter_params = []
-        self.pre_all_reduce_params = []
-        self.pre_direct_all_reduce_grads = []
-        self.pre_all_reduce_groups = []
-        self.pending_all_reduce_groups = []
+        # Backward pipelines are shared only by schedulers in this module tree.
+        self.per_param_comm_ctx = PerParamCommCtx()
         self.param_group_comm_ctx = ParamGroupCommCtx()
 
 
@@ -171,11 +186,9 @@ class HSDPSchedulerV2:
     def reset_iter_state(self) -> None:
         """Reset scheduler bookkeeping after a completed iteration."""
         self.scheduler_ctx.root_bp_state = False
-        self.scheduler_ctx.pre_reduce_scatter_params.clear()
-        self.scheduler_ctx.pre_all_reduce_params.clear()
-        self.scheduler_ctx.pre_direct_all_reduce_grads.clear()
-        self.scheduler_ctx.pre_all_reduce_groups.clear()
-        self.scheduler_ctx.pending_all_reduce_groups.clear()
+        self.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.clear()
+        self.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.clear()
+        self.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups.clear()
         self.scheduler_ctx.param_group_comm_ctx.pre_param_group = None
         self.scheduler_ctx.param_group_comm_ctx.all_reduce_param_group = None
         self.scheduler_ctx.param_group_comm_ctx.comm_handle = None

--- a/hyper_parallel/platform/mindspore/fully_shard/scheduler.py
+++ b/hyper_parallel/platform/mindspore/fully_shard/scheduler.py
@@ -161,9 +161,14 @@ class MindSporeHSDPSchedulerV2(HSDPSchedulerV2):
 
     def _finalize_per_param_reductions(self) -> None:
         """Drain the module-tree-local comm_fusion=False communication queues."""
-        last_all_reduce_groups = self.hsdp_state._wait_prev_reduce_scatter()
-        self.hsdp_state._wait_prev_reduce_scatter_without_all_reduce()
-        self.hsdp_state._issue_prev_fused_all_reduce(last_all_reduce_groups)
+        while self.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params:
+            reduce_scatter_params = (
+                self.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.popleft()
+            )
+            all_reduce_groups = self.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.popleft()
+            self.hsdp_state._wait_prev_reduce_scatter(all_reduce_groups)
+            self.hsdp_state._wait_prev_reduce_scatter_without_all_reduce(reduce_scatter_params)
+            self.hsdp_state._issue_prev_fused_all_reduce(all_reduce_groups)
         self.hsdp_state.wait_and_split_all_reduce_work_groups()
 
     def launch_tp_replicate_reduce_and_apply(self) -> None:

--- a/hyper_parallel/platform/mindspore/fully_shard/state.py
+++ b/hyper_parallel/platform/mindspore/fully_shard/state.py
@@ -261,13 +261,22 @@ class MindSporeHSDPStateV2(HSDPState):
             self.post_backward_for_comm_fusion()
             return
 
-        previous_groups = self._wait_prev_reduce_scatter()
-        self._wait_prev_reduce_scatter_without_all_reduce()
+        expired_reduce_scatter_params = []
+        expired_all_reduce_groups = []
+        if self.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params:
+            expired_reduce_scatter_params = (
+                self.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.popleft()
+            )
+            expired_all_reduce_groups = (
+                self.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.popleft()
+            )
+            self._wait_prev_reduce_scatter(expired_all_reduce_groups)
+            self._wait_prev_reduce_scatter_without_all_reduce(expired_reduce_scatter_params)
         self._issue_reduce_scatter_for_current_module()
-        self._issue_prev_fused_all_reduce(previous_groups)
+        self._issue_prev_fused_all_reduce(expired_all_reduce_groups)
 
     def _issue_reduce_scatter_for_current_module(self) -> None:
-        """Issue per-parameter reduce-scatter and fuse compatible HSDP all-reduces."""
+        """Issue this unit's reduce-scatter and append one queue slot."""
         params_to_reduce = []
         for hsdp_param in self.hsdp_params:
             skip_param = (
@@ -280,8 +289,6 @@ class MindSporeHSDPStateV2(HSDPState):
             )
             if not skip_param:
                 params_to_reduce.append(hsdp_param)
-        if not params_to_reduce:
-            return
 
         groups_by_comm = defaultdict(list)
         for hsdp_param in params_to_reduce:
@@ -292,6 +299,7 @@ class MindSporeHSDPStateV2(HSDPState):
             else:
                 groups_by_comm[None].append(hsdp_param)
 
+        direct_reduce_scatter_params = []
         for hsdp_param in groups_by_comm.get(None, ()):
             logger.debug(
                 "post_backward module=%s launch=reduce_scatter param=%s all_reduce=False",
@@ -299,8 +307,9 @@ class MindSporeHSDPStateV2(HSDPState):
                 hsdp_param,
             )
             hsdp_param.reduce_scatter_grad(reduce_op=self.reduce_op_type)
-            self.scheduler_ctx.pre_reduce_scatter_params.append(hsdp_param)
+            direct_reduce_scatter_params.append(hsdp_param)
 
+        all_reduce_groups = []
         for group_key, hsdp_params in groups_by_comm.items():
             if group_key is None:
                 continue
@@ -320,45 +329,56 @@ class MindSporeHSDPStateV2(HSDPState):
                     reduce_op=self.reduce_op_type,
                     output_buffer=group.get_param_buffer_view(index),
                 )
-            self.scheduler_ctx.pre_all_reduce_groups.append(group)
+            all_reduce_groups.append(group)
 
-    def _wait_prev_reduce_scatter(self) -> List[AllReduceParamGroup]:
-        """Wait previous fused reduce-scatter groups before all-reduce."""
-        if not self.scheduler_ctx.pre_all_reduce_groups:
-            return []
-        previous_groups = list(self.scheduler_ctx.pre_all_reduce_groups)
-        self.scheduler_ctx.pre_all_reduce_groups.clear()
-        for previous_group in previous_groups:
+        self.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.append(
+            direct_reduce_scatter_params
+        )
+        self.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.append(all_reduce_groups)
+
+    def _wait_prev_reduce_scatter(self, all_reduce_groups: List[AllReduceParamGroup]) -> None:
+        """Wait a previous unit's reduce-scatter groups before all-reduce."""
+        for all_reduce_group in all_reduce_groups:
             logger.debug(
                 "post_backward module=%s wait=fused_reduce_scatter group_params=%s",
                 self,
-                previous_group.hsdp_params,
+                all_reduce_group.hsdp_params,
             )
-            for hsdp_param in previous_group.hsdp_params:
+            for hsdp_param in all_reduce_group.hsdp_params:
                 hsdp_param.reduce_scatter_output()
                 hsdp_param.clear_reduce_scatter_output()
                 if hsdp_param.unsharded_accumulated_grad_data is not None:
                     hsdp_param.unsharded_accumulated_grad = None
                 elif hsdp_param.unsharded_param.grad is not None:
                     hsdp_param.unsharded_param.grad = None
-        return previous_groups
 
-    def _issue_prev_fused_all_reduce(self, previous_groups: List[AllReduceParamGroup]) -> None:
-        """Launch the previous module's fused all-reduce asynchronously."""
-        for previous_group in previous_groups:
-            previous_group.accumulate_reduce_partial_outputs()
+    def _issue_prev_fused_all_reduce(
+        self,
+        all_reduce_groups: List[AllReduceParamGroup],
+    ) -> None:
+        """Launch a previous unit's fused all-reduce after its RS wait."""
+        for all_reduce_group in all_reduce_groups:
+            all_reduce_group.accumulate_reduce_partial_outputs()
             logger.debug(
                 "post_backward module=%s launch=fused_all_reduce group_params=%s",
                 self,
-                previous_group.hsdp_params,
+                all_reduce_group.hsdp_params,
             )
-            previous_group.issue_async_allreduce()
-            self.scheduler_ctx.pending_all_reduce_groups.append(previous_group)
+            all_reduce_group.issue_async_allreduce()
+            self.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups.append(all_reduce_group)
 
-    def _wait_prev_reduce_scatter_without_all_reduce(self) -> None:
-        """Wait reduce-scatter outputs that do not enter a DP all-reduce."""
-        while self.scheduler_ctx.pre_reduce_scatter_params:
-            hsdp_param = self.scheduler_ctx.pre_reduce_scatter_params.pop(0)
+    def _wait_prev_reduce_scatter_without_all_reduce(
+        self,
+        hsdp_params: List[MindSporeHSDPParamV2],
+    ) -> None:
+        """Wait a previous unit's RS outputs that skip DP all-reduce.
+
+        The public gradient-accumulation API configures
+        ``requires_all_reduce`` recursively for the whole module tree. The root
+        hook relies on that invariant when it drains child slots through the
+        root state.
+        """
+        for hsdp_param in hsdp_params:
             logger.debug(
                 "post_backward module=%s wait=reduce_scatter param=%s",
                 self,
@@ -382,21 +402,20 @@ class MindSporeHSDPStateV2(HSDPState):
 
     def wait_and_split_all_reduce_work_groups(self) -> None:
         """Wait fused all-reduce work and expose each parameter result."""
-        for group in self.scheduler_ctx.pending_all_reduce_groups:
+        for group in self.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups:
             logger.debug(
                 "post_backward module=%s wait=fused_all_reduce group_params=%s",
                 self,
                 group.hsdp_params,
             )
             group.wait_and_split_grads()
-        self.scheduler_ctx.pending_all_reduce_groups.clear()
+        self.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups.clear()
 
     def reset_iter_state(self) -> None:
         """Clear communication bookkeeping without clearing optimizer gradients."""
-        self.scheduler_ctx.pre_reduce_scatter_params.clear()
-        self.scheduler_ctx.pre_all_reduce_params.clear()
-        self.scheduler_ctx.pre_all_reduce_groups.clear()
-        self.scheduler_ctx.pending_all_reduce_groups.clear()
+        self.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.clear()
+        self.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.clear()
+        self.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups.clear()
         if self.param_group is not None:
             self.param_group.reset_iter_state()
         for hsdp_param in self.hsdp_params:

--- a/hyper_parallel/platform/torch/fully_shard/scheduler.py
+++ b/hyper_parallel/platform/torch/fully_shard/scheduler.py
@@ -194,11 +194,17 @@ class TorchHSDPSchedulerV2(HSDPSchedulerV2):
             comm_ctx.all_reduce_param_group = None
 
     def _finalize_per_param_reductions(self) -> None:
-        """Drain the module-tree-local comm_fusion=False RS/AR queues."""
-        # A fused root may own non-fused children, so always drain the tree queues.
-        last_all_reduce_groups = self.hsdp_state._wait_prev_reduce_scatter()
-        self.hsdp_state._wait_prev_reduce_scatter_without_all_reduce()
-        self.hsdp_state._issue_prev_fused_all_reduce(last_all_reduce_groups)
+        """Drain every residual non-fused RS unit before applying gradients."""
+        while self.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params:
+            reduce_scatter_params = (
+                self.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.popleft()
+            )
+            all_reduce_groups = self.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.popleft()
+            self.hsdp_state._wait_prev_reduce_scatter(all_reduce_groups)
+            self.hsdp_state._wait_prev_reduce_scatter_without_all_reduce(
+                reduce_scatter_params
+            )
+            self.hsdp_state._issue_prev_fused_all_reduce(all_reduce_groups)
         self.hsdp_state.wait_and_split_all_reduce_work_groups()
 
     def launch_tp_replicate_reduce_and_apply(self) -> None:

--- a/hyper_parallel/platform/torch/fully_shard/state.py
+++ b/hyper_parallel/platform/torch/fully_shard/state.py
@@ -289,27 +289,39 @@ class TorchHSDPStateV2(HSDPState):
             # Reshard before gradient communication to reduce backward memory peak.
             self.shard()
         if not self.comm_fusion_policy.enable_comm_fusion:
-            # Step 1: wait previous reduce-scatter (for params needing all-reduce)
-            prev_group = self._wait_prev_reduce_scatter()
+            expired_reduce_scatter_params = []
+            expired_all_reduce_groups = []
+            if (
+                len(self.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params)
+                >= self.scheduler_ctx.per_param_comm_ctx.reduce_interval
+            ):
+                expired_reduce_scatter_params = (
+                    self.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.popleft()
+                )
+                expired_all_reduce_groups = (
+                    self.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.popleft()
+                )
+                self._wait_prev_reduce_scatter(expired_all_reduce_groups)
+                self._wait_prev_reduce_scatter_without_all_reduce(
+                    expired_reduce_scatter_params
+                )
 
-            # Step 2: wait previous reduce-scatter outputs that skip replicate all-reduce
-            self._wait_prev_reduce_scatter_without_all_reduce()
-
-            # Step 3: issue current reduce_scatter
             self._issue_reduce_scatter_for_current_module()
-
-            # Step 4: issue previous fused all-reduce asynchronously
-            self._issue_prev_fused_all_reduce(prev_group)
+            self._issue_prev_fused_all_reduce(expired_all_reduce_groups)
         else:
             self.post_backward_for_comm_fusion()
 
-    def _issue_reduce_scatter_for_current_module(self):
+    def _issue_reduce_scatter_for_current_module(self) -> None:
         """Issue reduce_scatter for current module's parameters with fused all-reduce support.
 
         This method groups parameters by their replicate_process_group and:
         1. For params without all_reduce needs: issue reduce_scatter directly
         2. For params with all_reduce needs: allocate fused buffer and issue reduce_scatter
            into aligned views, enabling zero-copy fused all_reduce later.
+
+        One entry is appended to each per-parameter communication deque even
+        when this unit has no active gradient. This preserves interval distance
+        in HSDP units without storing duplicate communication handles.
         """
         # Collect parameters that need gradient reduction
         params_to_reduce = []
@@ -326,8 +338,8 @@ class TorchHSDPStateV2(HSDPState):
                 continue
             params_to_reduce.append(hsdp_param)
 
-        if not params_to_reduce:
-            return
+        params_without_all_reduce = []
+        all_reduce_groups = []
 
         # Group by replicate process group and reduction dtype so every fused
         # all-reduce buffer has one communication group and one element type.
@@ -351,7 +363,7 @@ class TorchHSDPStateV2(HSDPState):
                 hsdp_param.reduce_scatter_grad(
                     reduce_op=self.reduce_op_type,
                 )
-                self.scheduler_ctx.pre_reduce_scatter_params.append(hsdp_param)
+                params_without_all_reduce.append(hsdp_param)
 
         # Handle params that need all_reduce (HSDP with multiple replicas)
         for group_key, hsdp_params in groups_by_comm.items():
@@ -381,104 +393,120 @@ class TorchHSDPStateV2(HSDPState):
                     output_buffer=buffer_view,
                 )
 
-            # Save the group so the next module hook can wait RS and launch AR.
-            self.scheduler_ctx.pre_all_reduce_groups.append(group)
+            all_reduce_groups.append(group)
 
-    def _wait_prev_reduce_scatter(self) -> List[AllReduceParamGroup]:
-        """Step 1: wait prev reduce_scatter.
+        self.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.append(
+            params_without_all_reduce
+        )
+        self.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.append(all_reduce_groups)
+
+    def _wait_prev_reduce_scatter(
+        self,
+        all_reduce_groups: List[AllReduceParamGroup],
+    ) -> None:
+        """Wait a previous unit's reduce-scatter work that feeds all-reduce.
 
         This enables overlapping:
-        - Layer N-1's reduce_scatter wait with Layer N's backward compute
+        - Layer N's reduce_scatter wait with later layers' backward compute.
 
-        Returns:
-            List of previous AllReduceParamGroups (one per communication group).
+        Args:
+            all_reduce_groups: Groups whose reduce-scatter outputs are ready to
+                consume after their handles are waited.
         """
-        if self.scheduler_ctx.pre_all_reduce_groups:
-            prev_groups = list(self.scheduler_ctx.pre_all_reduce_groups)
-            self.scheduler_ctx.pre_all_reduce_groups.clear()
-            for prev_group in prev_groups:
-                logger.debug(
-                    "post_backward module=%s wait=fused_reduce_scatter group_params=%s",
-                    self,
-                    prev_group.hsdp_params,
-                )
-                for hsdp_param in prev_group.hsdp_params:
-                    hsdp_param.reduce_scatter_output()
-                    hsdp_param.clear_reduce_scatter_output()
-                    if hsdp_param.unsharded_accumulated_grad_data is not None:
-                        hsdp_param.unsharded_accumulated_grad = None
-                    elif hsdp_param.unsharded_param.grad is not None:
-                        hsdp_param.unsharded_param.grad = None
-            return prev_groups
-        return []
+        for all_reduce_group in all_reduce_groups:
+            logger.debug(
+                "post_backward module=%s wait=fused_reduce_scatter group_params=%s",
+                self,
+                all_reduce_group.hsdp_params,
+            )
+            for hsdp_param in all_reduce_group.hsdp_params:
+                hsdp_param.reduce_scatter_output()
+                hsdp_param.clear_reduce_scatter_output()
+                if hsdp_param.unsharded_accumulated_grad_data is not None:
+                    hsdp_param.unsharded_accumulated_grad = None
+                elif hsdp_param.unsharded_param.grad is not None:
+                    hsdp_param.unsharded_param.grad = None
 
-    def _issue_prev_fused_all_reduce(self, prev_groups: List[AllReduceParamGroup]) -> None:
-        """Step 4: issue the previous module's fused all-reduce asynchronously.
+    def _issue_prev_fused_all_reduce(
+        self,
+        all_reduce_groups: List[AllReduceParamGroup],
+    ) -> None:
+        """Issue a previous unit's fused all-reduce after its source RS wait.
 
-        The all-reduce work is collected in ``pending_all_reduce_groups``
+        The all-reduce work is collected in ``all_reduce_work_groups``
         and is waited in the root backward hook.
 
         Args:
-            prev_groups: Previous parameter groups whose all-reduce should be issued.
+            all_reduce_groups: Parameter groups whose all-reduce should be issued.
         """
-        for prev_group in prev_groups:
-            prev_group.accumulate_reduce_partial_outputs()
+        for all_reduce_group in all_reduce_groups:
+            all_reduce_group.accumulate_reduce_partial_outputs()
             logger.debug(
                 "post_backward module=%s launch=fused_all_reduce group_params=%s",
                 self,
-                prev_group.hsdp_params,
+                all_reduce_group.hsdp_params,
             )
-            prev_group.issue_async_allreduce()
-            self.scheduler_ctx.pending_all_reduce_groups.append(prev_group)
+            all_reduce_group.issue_async_allreduce()
+            self.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups.append(all_reduce_group)
 
-    def _wait_prev_reduce_scatter_without_all_reduce(self) -> None:
-        """Wait previous RS outputs that do not enter a replicate all-reduce.
+    def _wait_prev_reduce_scatter_without_all_reduce(
+        self,
+        hsdp_params: List[TorchHSDPParamV2],
+    ) -> None:
+        """Wait a previous unit's RS outputs that skip replicate all-reduce.
 
         When the current micro-step disables all-reduce, outputs accumulate in
         ``reduce_partial_output`` without being cast or applied to the parameter.
         On the final synchronized micro-step, the partial result is merged into
         the current RS output and retained for root-hook finalization.
+
+        Args:
+            hsdp_params: Parameters whose reduce-scatter work should be waited.
+
+        Note:
+            The public gradient-accumulation API configures
+            ``requires_all_reduce`` recursively for the whole module tree. The
+            root hook relies on that invariant when it drains child slots
+            through the root state.
         """
-        while self.scheduler_ctx.pre_reduce_scatter_params:
-            pre_hsdp_param = self.scheduler_ctx.pre_reduce_scatter_params.pop(0)
+        for hsdp_param in hsdp_params:
             logger.debug(
                 "post_backward module=%s wait=reduce_scatter param=%s",
                 self,
-                pre_hsdp_param,
+                hsdp_param,
             )
-            reduced_grad = pre_hsdp_param.reduce_scatter_output()
+            reduced_grad = hsdp_param.reduce_scatter_output()
             if not self.requires_all_reduce:
-                if pre_hsdp_param.reduce_partial_output is None:
-                    pre_hsdp_param.reduce_partial_output = reduced_grad
+                if hsdp_param.reduce_partial_output is None:
+                    hsdp_param.reduce_partial_output = reduced_grad
                 else:
-                    pre_hsdp_param.reduce_partial_output.add_(reduced_grad)
-                pre_hsdp_param.clear_reduce_scatter_output()
-            elif pre_hsdp_param.reduce_partial_output is not None:
-                reduced_grad.add_(pre_hsdp_param.reduce_partial_output)
-                pre_hsdp_param.reduce_partial_output = None
+                    hsdp_param.reduce_partial_output.add_(reduced_grad)
+                hsdp_param.clear_reduce_scatter_output()
+            elif hsdp_param.reduce_partial_output is not None:
+                reduced_grad.add_(hsdp_param.reduce_partial_output)
+                hsdp_param.reduce_partial_output = None
 
-            if pre_hsdp_param.unsharded_accumulated_grad_data is not None:
-                pre_hsdp_param.unsharded_accumulated_grad = None
-            elif pre_hsdp_param.unsharded_param.grad is not None:
-                pre_hsdp_param.unsharded_param.grad = None
+            if hsdp_param.unsharded_accumulated_grad_data is not None:
+                hsdp_param.unsharded_accumulated_grad = None
+            elif hsdp_param.unsharded_param.grad is not None:
+                hsdp_param.unsharded_param.grad = None
 
     def wait_and_split_all_reduce_work_groups(self) -> None:
         """Wait fused all-reduce work and expose each parameter result."""
-        for group in self.scheduler_ctx.pending_all_reduce_groups:
+        for group in self.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups:
             logger.debug(
                 "post_backward module=%s wait=fused_all_reduce group_params=%s",
                 self,
                 group.hsdp_params,
             )
             group.wait_and_split_grads()
-        self.scheduler_ctx.pending_all_reduce_groups.clear()
+        self.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups.clear()
 
     def reset_iter_state(self) -> None:
         """Clear Torch communication bookkeeping without clearing optimizer gradients."""
-        self.scheduler_ctx.pre_reduce_scatter_params.clear()
-        self.scheduler_ctx.pre_all_reduce_params.clear()
-        self.scheduler_ctx.pre_all_reduce_groups.clear()
-        self.scheduler_ctx.pending_all_reduce_groups.clear()
+        self.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.clear()
+        self.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.clear()
+        self.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups.clear()
         if self.param_group is not None:
             self.param_group.reset_iter_state()
         for hsdp_param in self.hsdp_params:

--- a/tests/ut/platform/mindspore/fully_shard/test_fully_shard_list_api.py
+++ b/tests/ut/platform/mindspore/fully_shard/test_fully_shard_list_api.py
@@ -275,6 +275,14 @@ class TestHSDPModuleInterfaceMindSpore(unittest.TestCase):
         handle.wait()
         handle.wait()
 
+    @patch("hyper_parallel.core.fully_shard.api.platform.platform_type", PlatformType.MINDSPORE)
+    def test_reduce_comm_interval_is_not_supported(self):
+        """MindSpore should reject the Torch-only reduce communication interval API."""
+        module = self.FakeHSDPModule()
+
+        with self.assertRaisesRegex(NotImplementedError, "only supported on PyTorch"):
+            module.set_reduce_comm_interval()
+
     @patch("hyper_parallel.core.fully_shard.api.platform.get_cells_and_names")
     def test_reshard_and_reduce_op_delegate_to_state(self, mock_cells):
         """State operations should be routed through the current scheduler."""

--- a/tests/ut/platform/mindspore/fully_shard/test_scheduler.py
+++ b/tests/ut/platform/mindspore/fully_shard/test_scheduler.py
@@ -20,7 +20,7 @@ import os
 import unittest
 from contextlib import nullcontext
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -187,7 +187,7 @@ class TestMindSporeScheduler(MindSporeFullyShardUnitTest):
         self.assertTrue(scheduler.scheduler_ctx.root_bp_state)
 
     def test_root_backward_and_backward_hook_drain_comm_context(self):
-        """Root backward should finish staged fused groups and state reductions once."""
+        """A mixed root should drain every residual per-parameter unit before applying gradients."""
         scheduler = _make_scheduler()
         scheduler.scheduler_state = FSDPSchedulerState.FORWARD
         scheduler._is_root = True
@@ -197,7 +197,28 @@ class TestMindSporeScheduler(MindSporeFullyShardUnitTest):
         pre_group = SimpleNamespace(wait_reduce_scatter_and_issue_all_reduce=MagicMock())
         comm_ctx = SimpleNamespace(all_reduce_param_group=all_reduce_group, pre_param_group=pre_group)
         scheduler.scheduler_ctx.param_group_comm_ctx = comm_ctx
-        scheduler.hsdp_state._wait_prev_reduce_scatter.return_value = []
+        per_param_comm_ctx = scheduler.scheduler_ctx.per_param_comm_ctx
+        reduce_scatter_param_batches = [["param-0"], []]
+        all_reduce_group_batches = [["group-0"], ["group-1"]]
+        per_param_comm_ctx.pre_reduce_scatter_params.extend(reduce_scatter_param_batches)
+        per_param_comm_ctx.pre_all_reduce_groups.extend(all_reduce_group_batches)
+        communication_order = MagicMock()
+        communication_order.attach_mock(
+            scheduler.hsdp_state._wait_prev_reduce_scatter,
+            "wait_prev_reduce_scatter",
+        )
+        communication_order.attach_mock(
+            scheduler.hsdp_state._wait_prev_reduce_scatter_without_all_reduce,
+            "wait_prev_reduce_scatter_without_all_reduce",
+        )
+        communication_order.attach_mock(
+            scheduler.hsdp_state._issue_prev_fused_all_reduce,
+            "issue_prev_fused_all_reduce",
+        )
+        communication_order.attach_mock(
+            scheduler.hsdp_state.wait_and_split_all_reduce_work_groups,
+            "wait_and_split_all_reduce_work_groups",
+        )
         scheduler.hsdp_state.hsdp_params = []
 
         MindSporeHSDPSchedulerV2._root_backward_hook(scheduler)
@@ -205,9 +226,24 @@ class TestMindSporeScheduler(MindSporeFullyShardUnitTest):
         scheduler._hsdp_backward_hook.assert_called_once_with(scheduler.cell, None, None)
         all_reduce_group.wait_all_reduce_and_save_grad.assert_called_once_with()
         pre_group.wait_reduce_scatter_and_issue_all_reduce.assert_called_once_with()
-        scheduler.hsdp_state._wait_prev_reduce_scatter.assert_called_once_with()
-        scheduler.hsdp_state._wait_prev_reduce_scatter_without_all_reduce.assert_called_once_with()
-        scheduler.hsdp_state.wait_and_split_all_reduce_work_groups.assert_called_once_with()
+        self.assertEqual(
+            communication_order.mock_calls,
+            [
+                call.wait_prev_reduce_scatter(all_reduce_group_batches[0]),
+                call.wait_prev_reduce_scatter_without_all_reduce(
+                    reduce_scatter_param_batches[0]
+                ),
+                call.issue_prev_fused_all_reduce(all_reduce_group_batches[0]),
+                call.wait_prev_reduce_scatter(all_reduce_group_batches[1]),
+                call.wait_prev_reduce_scatter_without_all_reduce(
+                    reduce_scatter_param_batches[1]
+                ),
+                call.issue_prev_fused_all_reduce(all_reduce_group_batches[1]),
+                call.wait_and_split_all_reduce_work_groups(),
+            ],
+        )
+        self.assertEqual(list(per_param_comm_ctx.pre_reduce_scatter_params), [])
+        self.assertEqual(list(per_param_comm_ctx.pre_all_reduce_groups), [])
         self.assertFalse(scheduler.scheduler_ctx.root_bp_state)
 
         scheduler.scheduler_state = FSDPSchedulerState.BACKWARD
@@ -298,21 +334,19 @@ class TestCoreScheduler(unittest.TestCase):
         other_scheduler = self._make_core_scheduler()
         current_ctx = scheduler.scheduler_ctx
         other_ctx = other_scheduler.scheduler_ctx
+        current_per_param_comm_ctx = current_ctx.per_param_comm_ctx
+        other_per_param_comm_ctx = other_ctx.per_param_comm_ctx
         current_ctx.root_bp_state = True
         other_ctx.root_bp_state = True
-        current_ctx.pre_reduce_scatter_params.append("current-rs")
-        current_ctx.pre_all_reduce_params.append("current-ar")
-        current_ctx.pre_direct_all_reduce_grads.append("current-direct-ar")
-        current_ctx.pre_all_reduce_groups.append("current-pre-group")
-        current_ctx.pending_all_reduce_groups.append("current-pending-group")
+        current_per_param_comm_ctx.pre_reduce_scatter_params.append(["current-rs"])
+        current_per_param_comm_ctx.pre_all_reduce_groups.append(["current-pre-group"])
+        current_per_param_comm_ctx.all_reduce_work_groups.append("current-ar-work")
         current_ctx.param_group_comm_ctx.pre_param_group = "current-pre-param-group"
         current_ctx.param_group_comm_ctx.all_reduce_param_group = "current-ar-param-group"
         current_ctx.param_group_comm_ctx.comm_handle = "current-rs-handle"
-        other_ctx.pre_reduce_scatter_params.append("other-rs")
-        other_ctx.pre_all_reduce_params.append("other-ar")
-        other_ctx.pre_direct_all_reduce_grads.append("other-direct-ar")
-        other_ctx.pre_all_reduce_groups.append("other-pre-group")
-        other_ctx.pending_all_reduce_groups.append("other-pending-group")
+        other_per_param_comm_ctx.pre_reduce_scatter_params.append(["other-rs"])
+        other_per_param_comm_ctx.pre_all_reduce_groups.append(["other-pre-group"])
+        other_per_param_comm_ctx.all_reduce_work_groups.append("other-ar-work")
         other_ctx.param_group_comm_ctx.pre_param_group = "other-pre-param-group"
         other_ctx.param_group_comm_ctx.all_reduce_param_group = "other-ar-param-group"
         other_ctx.param_group_comm_ctx.comm_handle = "other-rs-handle"
@@ -320,20 +354,16 @@ class TestCoreScheduler(unittest.TestCase):
         scheduler.reset_iter_state()
 
         self.assertFalse(current_ctx.root_bp_state)
-        self.assertEqual(current_ctx.pre_reduce_scatter_params, [])
-        self.assertEqual(current_ctx.pre_all_reduce_params, [])
-        self.assertEqual(current_ctx.pre_direct_all_reduce_grads, [])
-        self.assertEqual(current_ctx.pre_all_reduce_groups, [])
-        self.assertEqual(current_ctx.pending_all_reduce_groups, [])
+        self.assertEqual(list(current_per_param_comm_ctx.pre_reduce_scatter_params), [])
+        self.assertEqual(list(current_per_param_comm_ctx.pre_all_reduce_groups), [])
+        self.assertEqual(current_per_param_comm_ctx.all_reduce_work_groups, [])
         self.assertIsNone(current_ctx.param_group_comm_ctx.pre_param_group)
         self.assertIsNone(current_ctx.param_group_comm_ctx.all_reduce_param_group)
         self.assertIsNone(current_ctx.param_group_comm_ctx.comm_handle)
         self.assertTrue(other_ctx.root_bp_state)
-        self.assertEqual(other_ctx.pre_reduce_scatter_params, ["other-rs"])
-        self.assertEqual(other_ctx.pre_all_reduce_params, ["other-ar"])
-        self.assertEqual(other_ctx.pre_direct_all_reduce_grads, ["other-direct-ar"])
-        self.assertEqual(other_ctx.pre_all_reduce_groups, ["other-pre-group"])
-        self.assertEqual(other_ctx.pending_all_reduce_groups, ["other-pending-group"])
+        self.assertEqual(list(other_per_param_comm_ctx.pre_reduce_scatter_params), [["other-rs"]])
+        self.assertEqual(list(other_per_param_comm_ctx.pre_all_reduce_groups), [["other-pre-group"]])
+        self.assertEqual(other_per_param_comm_ctx.all_reduce_work_groups, ["other-ar-work"])
         self.assertEqual(other_ctx.param_group_comm_ctx.pre_param_group, "other-pre-param-group")
         self.assertEqual(other_ctx.param_group_comm_ctx.all_reduce_param_group, "other-ar-param-group")
         self.assertEqual(other_ctx.param_group_comm_ctx.comm_handle, "other-rs-handle")

--- a/tests/ut/platform/mindspore/fully_shard/test_state.py
+++ b/tests/ut/platform/mindspore/fully_shard/test_state.py
@@ -234,7 +234,8 @@ class TestBackwardCommunication(MindSporeFullyShardUnitTest):
         state._issue_reduce_scatter_for_current_module()
 
         fsdp_param.reduce_scatter_grad.assert_called_once_with(reduce_op="avg")
-        self.assertEqual(state.scheduler_ctx.pre_reduce_scatter_params, [fsdp_param])
+        per_param_comm_ctx = state.scheduler_ctx.per_param_comm_ctx
+        self.assertEqual(list(per_param_comm_ctx.pre_reduce_scatter_params), [[fsdp_param]])
         mock_group_cls.assert_called_once_with(
             replicate_group="dp",
             hsdp_params=[hsdp_param],
@@ -245,7 +246,17 @@ class TestBackwardCommunication(MindSporeFullyShardUnitTest):
             reduce_op="avg",
             output_buffer=all_reduce_group.get_param_buffer_view.return_value,
         )
-        self.assertEqual(state.scheduler_ctx.pre_all_reduce_groups, [all_reduce_group])
+        self.assertEqual(list(per_param_comm_ctx.pre_all_reduce_groups), [[all_reduce_group]])
+
+    def test_issue_reduce_scatter_records_empty_unit(self):
+        """A unit without gradients should still occupy one communication slot."""
+        state = _new_state()
+
+        state._issue_reduce_scatter_for_current_module()
+
+        per_param_comm_ctx = state.scheduler_ctx.per_param_comm_ctx
+        self.assertEqual(list(per_param_comm_ctx.pre_reduce_scatter_params), [[]])
+        self.assertEqual(list(per_param_comm_ctx.pre_all_reduce_groups), [[]])
 
     def test_wait_fsdp_reduce_scatter_retains_final_output_for_root(self):
         """Final synchronized RS output should remain in the parameter context."""
@@ -254,9 +265,8 @@ class TestBackwardCommunication(MindSporeFullyShardUnitTest):
         param.reduce_scatter_output.return_value = reduced_grad
         param.reduce_scatter_comm_ctx.reduce_scatter_output = reduced_grad
         state = _new_state([param])
-        state.scheduler_ctx.pre_reduce_scatter_params.append(param)
 
-        state._wait_prev_reduce_scatter_without_all_reduce()
+        state._wait_prev_reduce_scatter_without_all_reduce([param])
 
         self.assertIs(param.reduce_scatter_comm_ctx.reduce_scatter_output, reduced_grad)
         self.assertIsNone(param.unsharded_param.grad)
@@ -268,24 +278,71 @@ class TestBackwardCommunication(MindSporeFullyShardUnitTest):
         param.reduce_scatter_output.return_value = reduced_grad
         state = _new_state([param])
         state.requires_all_reduce = False
-        state.scheduler_ctx.pre_reduce_scatter_params.append(param)
 
-        state._wait_prev_reduce_scatter_without_all_reduce()
+        state._wait_prev_reduce_scatter_without_all_reduce([param])
 
         self.assertIs(param.reduce_partial_output, reduced_grad)
         param.clear_reduce_scatter_output.assert_called_once_with()
 
     def test_fused_all_reduce_group_is_waited_and_split(self):
-        """Tree-local pending groups should expose outputs before root applies grads."""
+        """Tree-local all-reduce work should expose outputs before root applies grads."""
         group = MagicMock(spec=AllReduceParamGroup)
         group.hsdp_params = []
         state = _new_state()
-        state.scheduler_ctx.pending_all_reduce_groups.append(group)
+        per_param_comm_ctx = state.scheduler_ctx.per_param_comm_ctx
+        per_param_comm_ctx.all_reduce_work_groups.append(group)
 
         state.wait_and_split_all_reduce_work_groups()
 
         group.wait_and_split_grads.assert_called_once_with()
-        self.assertEqual(state.scheduler_ctx.pending_all_reduce_groups, [])
+        self.assertEqual(per_param_comm_ctx.all_reduce_work_groups, [])
+
+    def test_issue_prev_fused_all_reduce_records_work_for_root(self):
+        """A completed grouped reduce-scatter should launch and retain its all-reduce work."""
+        group = MagicMock(spec=AllReduceParamGroup)
+        group.hsdp_params = []
+        state = _new_state()
+
+        state._issue_prev_fused_all_reduce([group])
+
+        group.accumulate_reduce_partial_outputs.assert_called_once_with()
+        group.issue_async_allreduce.assert_called_once_with()
+        self.assertEqual(state.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups, [group])
+
+    def test_post_backward_expires_one_unit_before_launching_current_reduce_scatter(self):
+        """MindSpore should retain its one-unit per-parameter pipeline ordering."""
+        state = _new_state()
+        state.shard = MagicMock()
+        expired_param = MagicMock()
+        expired_group = MagicMock()
+        per_param_comm_ctx = state.scheduler_ctx.per_param_comm_ctx
+        per_param_comm_ctx.pre_reduce_scatter_params.append([expired_param])
+        per_param_comm_ctx.pre_all_reduce_groups.append([expired_group])
+        events = []
+        state._wait_prev_reduce_scatter = MagicMock(
+            side_effect=lambda groups: events.append(("wait_group", groups))
+        )
+        state._wait_prev_reduce_scatter_without_all_reduce = MagicMock(
+            side_effect=lambda params: events.append(("wait_param", params))
+        )
+        state._issue_reduce_scatter_for_current_module = MagicMock(
+            side_effect=lambda: events.append(("issue_rs", None))
+        )
+        state._issue_prev_fused_all_reduce = MagicMock(
+            side_effect=lambda groups: events.append(("issue_ar", groups))
+        )
+
+        state.post_backward()
+
+        self.assertEqual(
+            events,
+            [
+                ("wait_group", [expired_group]),
+                ("wait_param", [expired_param]),
+                ("issue_rs", None),
+                ("issue_ar", [expired_group]),
+            ],
+        )
 
     def test_comm_fusion_drains_previous_stages_and_launches_current(self):
         """Fused communication should pipeline AR wait, RS wait, then current RS."""
@@ -342,13 +399,16 @@ class TestStateConfiguration(MindSporeFullyShardUnitTest):
         param = _fake_param()
         param.sharded_param.grad = "optimizer-grad"
         state = _new_state([param])
-        state.scheduler_ctx.pre_reduce_scatter_params.append(param)
-        state.scheduler_ctx.pending_all_reduce_groups.append(MagicMock())
+        per_param_comm_ctx = state.scheduler_ctx.per_param_comm_ctx
+        per_param_comm_ctx.pre_reduce_scatter_params.append([param])
+        per_param_comm_ctx.pre_all_reduce_groups.append([])
+        per_param_comm_ctx.all_reduce_work_groups.append(MagicMock())
 
         state.reset_iter_state()
 
-        self.assertEqual(state.scheduler_ctx.pre_reduce_scatter_params, [])
-        self.assertEqual(state.scheduler_ctx.pending_all_reduce_groups, [])
+        self.assertEqual(list(per_param_comm_ctx.pre_reduce_scatter_params), [])
+        self.assertEqual(list(per_param_comm_ctx.pre_all_reduce_groups), [])
+        self.assertEqual(per_param_comm_ctx.all_reduce_work_groups, [])
         self.assertEqual(param.sharded_param.grad, "optimizer-grad")
         self.assertIsNone(param.reduce_scatter_comm_ctx.reduce_scatter_output)
         self.assertIsNone(param.all_reduce_comm_ctx.all_reduce_output)

--- a/tests/ut/platform/torch/fully_shard/test_core_hsdp_param.py
+++ b/tests/ut/platform/torch/fully_shard/test_core_hsdp_param.py
@@ -529,6 +529,7 @@ class TestCoreScheduler(unittest.TestCase):
         root_module.hsdp_scheduler = scheduler
         scheduler.cell = root_module
         scheduler.modules = [root_module]
+        scheduler.scheduler_ctx.per_param_comm_ctx.reduce_interval = 4
         child_ctx = HSDPSchedulerContext()
         child_state = SimpleNamespace(
             scheduler_ctx=child_ctx,
@@ -559,6 +560,7 @@ class TestCoreScheduler(unittest.TestCase):
         self.assertIs(child_scheduler.scheduler_ctx, scheduler.scheduler_ctx)
         self.assertIs(child_state.scheduler_ctx, scheduler.scheduler_ctx)
         self.assertIs(child_state.param_group.comm_ctx, scheduler.scheduler_ctx.param_group_comm_ctx)
+        self.assertEqual(child_scheduler.scheduler_ctx.per_param_comm_ctx.reduce_interval, 4)
         self.assertEqual(scheduler.scheduler_ctx.all_hsdp_schedulers, [scheduler, child_scheduler])
         self.assertEqual(scheduler.hsdp_state.module_name, "")
         self.assertEqual(child_state.module_name, "layer")

--- a/tests/ut/platform/torch/fully_shard/test_fully_shard_list_api.py
+++ b/tests/ut/platform/torch/fully_shard/test_fully_shard_list_api.py
@@ -329,6 +329,89 @@ class TestCoreApiHelpersTorch(unittest.TestCase):
         hsdp_sync_stream()
         mock_platform.wait_grad_handle.assert_called_once_with()
 
+
+class TestHSDPModuleReduceCommInterval(unittest.TestCase):
+    """Unit tests for the Torch-only reduce communication interval API."""
+
+    @staticmethod
+    def _module(comm_fusion: bool = False) -> HSDPModule:
+        """Create an initialized HSDPModule stub with a per-parameter context."""
+        module = HSDPModule()
+        module.hsdp_scheduler = SimpleNamespace(
+            comm_fusion_policy=SimpleNamespace(enable_comm_fusion=comm_fusion),
+            scheduler_ctx=SimpleNamespace(
+                lazy_init_done=False,
+                per_param_comm_ctx=SimpleNamespace(reduce_interval=1),
+            ),
+        )
+        return module
+
+    @patch("hyper_parallel.core.fully_shard.api.platform.platform_type", PlatformType.PYTORCH)
+    def test_default_and_explicit_intervals_update_shared_context(self):
+        """Default and explicit positive intervals should update the scheduler context."""
+        module = self._module()
+
+        module.set_reduce_comm_interval()
+        self.assertEqual(module.hsdp_scheduler.scheduler_ctx.per_param_comm_ctx.reduce_interval, 1)
+
+        module.set_reduce_comm_interval(4)
+        self.assertEqual(module.hsdp_scheduler.scheduler_ctx.per_param_comm_ctx.reduce_interval, 4)
+
+    @patch("hyper_parallel.core.fully_shard.api.warnings.warn")
+    @patch("hyper_parallel.core.fully_shard.api.platform.platform_type", PlatformType.PYTORCH)
+    def test_supported_configurations_do_not_warn(self, mock_warn):
+        """Non-fused intervals and the fused default should not emit a warning."""
+        module = self._module(comm_fusion=False)
+        module.set_reduce_comm_interval(3)
+
+        fused_module = self._module(comm_fusion=True)
+        fused_module.set_reduce_comm_interval(1)
+
+        mock_warn.assert_not_called()
+        self.assertEqual(module.hsdp_scheduler.scheduler_ctx.per_param_comm_ctx.reduce_interval, 3)
+        self.assertEqual(fused_module.hsdp_scheduler.scheduler_ctx.per_param_comm_ctx.reduce_interval, 1)
+
+    @patch("hyper_parallel.core.fully_shard.api.platform.platform_type", PlatformType.PYTORCH)
+    def test_comm_fusion_warns_and_forces_interval_one(self):
+        """Comm fusion should warn and retain its single-work communication lifecycle."""
+        module = self._module(comm_fusion=True)
+        module.hsdp_scheduler.scheduler_ctx.per_param_comm_ctx.reduce_interval = 5
+
+        with self.assertWarnsRegex(UserWarning, "comm_fusion=True"):
+            module.set_reduce_comm_interval(2)
+
+        self.assertEqual(module.hsdp_scheduler.scheduler_ctx.per_param_comm_ctx.reduce_interval, 1)
+
+    @patch("hyper_parallel.core.fully_shard.api.platform.platform_type", PlatformType.PYTORCH)
+    def test_invalid_intervals_do_not_change_configuration(self):
+        """Boolean, non-integer, and non-positive intervals should be rejected."""
+        module = self._module()
+        invalid_intervals = (True, False, 0, -1, 1.0, "2", None)
+
+        for interval in invalid_intervals:
+            with self.subTest(interval=interval), self.assertRaisesRegex(ValueError, "positive int"):
+                module.set_reduce_comm_interval(interval)
+
+        self.assertEqual(module.hsdp_scheduler.scheduler_ctx.per_param_comm_ctx.reduce_interval, 1)
+
+    @patch("hyper_parallel.core.fully_shard.api.platform.platform_type", PlatformType.PYTORCH)
+    def test_uninitialized_module_is_rejected(self):
+        """The interval API should require initialization through fully_shard."""
+        module = HSDPModule()
+
+        with self.assertRaisesRegex(ValueError, "fully_shard"):
+            module.set_reduce_comm_interval(2)
+
+    @patch("hyper_parallel.core.fully_shard.api.platform.platform_type", PlatformType.PYTORCH)
+    def test_configuration_after_first_forward_is_rejected(self):
+        """The interval must be configured before the shared tree is initialized."""
+        module = self._module()
+        module.hsdp_scheduler.scheduler_ctx.lazy_init_done = True
+
+        with self.assertRaisesRegex(ValueError, "before the root module's first forward"):
+            module.set_reduce_comm_interval(2)
+
+
 class TestFullyShardListAPI(unittest.TestCase):
     """Unit tests for fully_shard list support (mocked to avoid NPU/dist)."""
 
@@ -354,7 +437,10 @@ class TestFullyShardListAPI(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "cover every parameter"):
             _validate_managed_params_source_shard_infos(managed, {first: metadata})
         with self.assertRaisesRegex(ValueError, "not managed"):
-            _validate_managed_params_source_shard_infos(managed, {first: metadata, second: metadata, external: metadata})
+            _validate_managed_params_source_shard_infos(
+                managed,
+                {first: metadata, second: metadata, external: metadata},
+            )
         with self.assertRaisesRegex(ValueError, "SourceShardMetaInfo"):
             _validate_managed_params_source_shard_infos(managed, {first: metadata, second: object()})
         origin_metadata = SourceShardMetaInfo(self._create_mock_mesh(), (Replicate(),), origin_is_dtensor=True)

--- a/tests/ut/platform/torch/fully_shard/test_state.py
+++ b/tests/ut/platform/torch/fully_shard/test_state.py
@@ -20,6 +20,7 @@ dtype no-op vs cast, and invalid input handling. All tests run on CPU.
 import os
 import unittest
 from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 # Force torch platform before any hyper_parallel imports
@@ -29,9 +30,9 @@ os.environ["HYPER_PARALLEL_PLATFORM"] = "torch"
 import torch
 
 from hyper_parallel.core.fully_shard.hsdp_state import HSDPState
-from hyper_parallel.core.fully_shard.hsdp_scheduler import HSDPSchedulerContext, HSDPSchedulerV2
+from hyper_parallel.core.fully_shard.hsdp_scheduler import HSDPSchedulerContext
 from hyper_parallel.core.fully_shard.hsdp_utils import GroupInfo
-from hyper_parallel.core.fully_shard.utils import CPUOffloadPolicy, DDPMeshInfo, HSDPMeshInfo
+from hyper_parallel.core.fully_shard.utils import CPUOffloadPolicy, DDPMeshInfo, FSDPMeshInfo, HSDPMeshInfo
 from hyper_parallel.core.fully_shard.api import HSDPModule, _extend_module_with_hsdp_interface
 from hyper_parallel.platform.torch.fully_shard import state as state_mod
 from hyper_parallel.platform.torch.fully_shard.param_group import AllReduceParamGroup
@@ -42,10 +43,11 @@ from hyper_parallel.platform.torch.fully_shard.state import TorchHSDPStateV2, _t
 class _FakeGroup:
     """Small process group double with only size() implemented."""
 
-    def __init__(self, size=2):
+    def __init__(self, size: int = 2) -> None:
+        """Initialize the fake process group size."""
         self._size = size
 
-    def size(self):
+    def size(self) -> int:
         """Return fake process group size."""
         return self._size
 
@@ -56,15 +58,16 @@ class _FakeHSDPParam:
     def __init__(
         self,
         *,
-        requires_grad=True,
-        is_sharded=True,
-        shard_size=2,
-        dp_size=2,
-        grad=None,
-        unsharded_grad=None,
-        accumulated_grad=None,
-        device=None,
-    ):
+        requires_grad: bool = True,
+        is_sharded: bool = True,
+        shard_size: int = 2,
+        dp_size: int = 2,
+        grad: Optional[torch.Tensor] = None,
+        unsharded_grad: Optional[torch.Tensor] = None,
+        accumulated_grad: Optional[torch.Tensor] = None,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        """Initialize the parameter and communication-context test doubles."""
         self.is_sharded = is_sharded
         self.shard_size = shard_size
         self.shard_world_size = shard_size
@@ -124,7 +127,7 @@ class _FakeHSDPParam:
         )
         self._grad = None
 
-    def reduce_comm_dtype(self, grad=None) -> torch.dtype:
+    def reduce_comm_dtype(self, grad: Optional[torch.Tensor] = None) -> torch.dtype:
         """Return the effective reduction dtype for this parameter double."""
         if self.reduce_dtype is not None:
             return self.reduce_dtype
@@ -143,7 +146,8 @@ class _FakeHSDPParam:
         self.all_reduce_comm_ctx.all_reduce_output = None
 
     @property
-    def unsharded_param(self):
+    def unsharded_param(self) -> SimpleNamespace:
+        """Return the fake unsharded parameter object."""
         return self._unsharded_param
 
 
@@ -186,7 +190,7 @@ def _new_root_scheduler(state):
 class TestToDtypeIfNeeded(unittest.TestCase):
     """Unit tests for _to_dtype_if_needed (tensor dtype cast or no-op)."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Set up test fixtures before each test method."""
         os.environ["HYPER_PARALLEL_PLATFORM"] = "torch"
         self.device = torch.device("cpu")
@@ -407,8 +411,7 @@ class TestTorchHSDPStateV2(unittest.TestCase):
         state.requires_all_reduce = False
 
         for _ in range(2):
-            state.scheduler_ctx.pre_reduce_scatter_params.append(param)
-            state._wait_prev_reduce_scatter_without_all_reduce()
+            state._wait_prev_reduce_scatter_without_all_reduce([param])
 
         torch.testing.assert_close(
             param.reduce_partial_output,
@@ -429,8 +432,7 @@ class TestTorchHSDPStateV2(unittest.TestCase):
                 param.reduce_scatter_comm_ctx.reduce_scatter_output = current_output
                 state = _new_state([param])
 
-                state.scheduler_ctx.pre_reduce_scatter_params.append(param)
-                state._wait_prev_reduce_scatter_without_all_reduce()
+                state._wait_prev_reduce_scatter_without_all_reduce([param])
 
                 self.assertIsNone(param.reduce_partial_output)
                 torch.testing.assert_close(current_output, torch.tensor([4.0, 6.0]))
@@ -476,15 +478,15 @@ class TestTorchHSDPStateV2(unittest.TestCase):
         param.reduce_scatter_output.return_value = current_output
         param.reduce_scatter_comm_ctx.reduce_scatter_output = current_output
 
-        def apply_reduced_grad(grad):
+        def apply_reduced_grad(grad: torch.Tensor) -> bool:
+            """Accumulate one finalized gradient into the optimizer gradient."""
             param.sharded_param.grad.add_(grad)
             return False
 
         param.apply_reduced_grad.side_effect = apply_reduced_grad
         state = _new_state([param])
 
-        state.scheduler_ctx.pre_reduce_scatter_params.append(param)
-        state._wait_prev_reduce_scatter_without_all_reduce()
+        state._wait_prev_reduce_scatter_without_all_reduce([param])
         scheduler = _new_root_scheduler(state)
         for _ in range(2):
             scheduler._finalize_comm_fusion_reductions()
@@ -494,17 +496,30 @@ class TestTorchHSDPStateV2(unittest.TestCase):
         param.apply_reduced_grad.assert_called_once_with(current_output)
 
     def test_post_backward_no_reduce_accumulates_and_reshards(self):
-        """Post-backward without reduction should accumulate grads and reshard."""
+        """A no-sync unit should not advance or consume the communication interval."""
         param = _FakeHSDPParam()
         state = _new_state([param])
         state.reduce_grads = False
         state.shard = MagicMock()
+        comm_ctx = state.scheduler_ctx.per_param_comm_ctx
+        comm_ctx.pre_reduce_scatter_params.append(["in-flight-param"])
+        comm_ctx.pre_all_reduce_groups.append(["in-flight-group"])
+        state._wait_prev_reduce_scatter = MagicMock()
+        state._wait_prev_reduce_scatter_without_all_reduce = MagicMock()
+        state._issue_reduce_scatter_for_current_module = MagicMock()
+        state._issue_prev_fused_all_reduce = MagicMock()
 
         TorchHSDPStateV2.post_backward(state)
 
         param.accumulate_unsharded_grad_if_needed.assert_called_once()
         param.to_accumulated_grad_if_needed.assert_called_once()
         state.shard.assert_called_once()
+        self.assertEqual(list(comm_ctx.pre_reduce_scatter_params), [["in-flight-param"]])
+        self.assertEqual(list(comm_ctx.pre_all_reduce_groups), [["in-flight-group"]])
+        state._wait_prev_reduce_scatter.assert_not_called()
+        state._wait_prev_reduce_scatter_without_all_reduce.assert_not_called()
+        state._issue_reduce_scatter_for_current_module.assert_not_called()
+        state._issue_prev_fused_all_reduce.assert_not_called()
 
     def test_post_backward_groups_sharded_and_replicated_params_by_process_group(self):
         """Post-backward should route sharded and replicated params through the unified pipeline."""
@@ -517,8 +532,455 @@ class TestTorchHSDPStateV2(unittest.TestCase):
 
         sharded.reduce_scatter_grad.assert_called_once()
         replicated.reduce_scatter_grad.assert_called_once()
-        self.assertEqual(len(state.scheduler_ctx.pre_all_reduce_groups), 2)
+        self.assertEqual(len(state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups), 1)
+        self.assertEqual(len(state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups[0]), 2)
         state.shard.assert_called_once()
+
+    def test_post_backward_waits_only_the_unit_expired_by_reduce_interval(self):
+        """The oldest unit should wait after the configured number of later units."""
+        for reduce_interval in (1, 2):
+            with self.subTest(reduce_interval=reduce_interval):
+                state = _new_state()
+                state.shard = MagicMock()
+                state.scheduler_ctx.per_param_comm_ctx.reduce_interval = reduce_interval
+                state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.append(
+                    ["layer-7-param"]
+                )
+                state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.append(
+                    ["layer-7-group"]
+                )
+                for _ in range(reduce_interval - 1):
+                    state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.append([])
+                    state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.append([])
+
+                communication_events = []
+                state._wait_prev_reduce_scatter = MagicMock(
+                    side_effect=lambda groups: communication_events.append(("wait_grouped_rs", groups))
+                )
+                state._wait_prev_reduce_scatter_without_all_reduce = MagicMock(
+                    side_effect=lambda params: communication_events.append(("wait_direct_rs", params))
+                )
+
+                def issue_current_reduce_scatter() -> None:
+                    """Record the current unit without launching real communication."""
+                    communication_events.append(("issue_current_rs", []))
+                    state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.append([])
+                    state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.append([])
+
+                state._issue_reduce_scatter_for_current_module = MagicMock(
+                    side_effect=issue_current_reduce_scatter
+                )
+                state._issue_prev_fused_all_reduce = MagicMock(
+                    side_effect=lambda groups: communication_events.append(("issue_expired_ar", groups))
+                )
+
+                state.post_backward()
+
+                self.assertEqual(
+                    communication_events,
+                    [
+                        ("wait_grouped_rs", ["layer-7-group"]),
+                        ("wait_direct_rs", ["layer-7-param"]),
+                        ("issue_current_rs", []),
+                        ("issue_expired_ar", ["layer-7-group"]),
+                    ],
+                )
+                self.assertEqual(
+                    len(state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params),
+                    reduce_interval,
+                )
+                self.assertEqual(
+                    len(state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups),
+                    reduce_interval,
+                )
+
+    def test_direct_fsdp_reduce_scatter_waits_after_two_later_units(self):
+        """A direct FSDP reduce-scatter should wait on the second later unit."""
+        reduced_grad = torch.tensor([1.0, 2.0])
+        reduce_scatter_work = MagicMock()
+        communication_events = []
+        fsdp_param = _FakeHSDPParam(
+            dp_size=1,
+            unsharded_grad=torch.tensor([3.0, 4.0]),
+        )
+        fsdp_param.mesh_info = object.__new__(FSDPMeshInfo)
+
+        def issue_reduce_scatter(**unused_options: object) -> None:
+            """Record the direct FSDP reduce-scatter launch."""
+            communication_events.append("issue_rs")
+            fsdp_param.reduce_scatter_comm_ctx.reduce_scatter_handle = reduce_scatter_work
+            fsdp_param.reduce_scatter_comm_ctx.reduce_scatter_output = reduced_grad
+
+        def wait_reduce_scatter() -> torch.Tensor:
+            """Wait the direct FSDP work and return its reduced shard."""
+            communication_events.append("wait_rs")
+            reduce_scatter_work.wait()
+            fsdp_param.reduce_scatter_comm_ctx.reduce_scatter_handle = None
+            return reduced_grad
+
+        fsdp_param.reduce_scatter_grad.side_effect = issue_reduce_scatter
+        fsdp_param.reduce_scatter_output.side_effect = wait_reduce_scatter
+        scheduler_ctx = HSDPSchedulerContext()
+        scheduler_ctx.per_param_comm_ctx.reduce_interval = 2
+        launch_state = _new_state([fsdp_param])
+        first_later_state = _new_state()
+        second_later_state = _new_state()
+        for state in (launch_state, first_later_state, second_later_state):
+            state.scheduler_ctx = scheduler_ctx
+            state.reshard_after_backward = False
+
+        launch_state.post_backward()
+        first_later_state.post_backward()
+
+        self.assertEqual(communication_events, ["issue_rs"])
+        reduce_scatter_work.wait.assert_not_called()
+        self.assertEqual(
+            list(scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params),
+            [[fsdp_param], []],
+        )
+
+        second_later_state.post_backward()
+
+        self.assertEqual(communication_events, ["issue_rs", "wait_rs"])
+        reduce_scatter_work.wait.assert_called_once_with()
+        self.assertEqual(
+            list(scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params),
+            [[], []],
+        )
+        self.assertEqual(
+            list(scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups),
+            [[], []],
+        )
+
+    def test_hsdp_all_reduce_group_runs_reduce_scatter_to_all_reduce_lifecycle(self):
+        """An HSDP group should wait RS before issuing and waiting its AR work."""
+        communication_events = []
+        reduce_scatter_work = MagicMock()
+        all_reduce_work = MagicMock()
+        all_reduce_work.wait.side_effect = lambda: communication_events.append("wait_ar")
+        hsdp_param = _FakeHSDPParam(dp_size=2)
+        all_reduce_group = AllReduceParamGroup(
+            replicate_group=hsdp_param.mesh_info.replicate_process_group,
+            hsdp_params=[hsdp_param],
+            reduce_op=torch.distributed.ReduceOp.AVG,
+        )
+        all_reduce_group.allocate_fused_buffer(torch.device("cpu"))
+        reduce_scatter_output = all_reduce_group.get_param_buffer_view(0)
+        reduce_scatter_output.copy_(torch.tensor([6.0, 10.0]))
+        hsdp_param.reduce_scatter_comm_ctx.reduce_scatter_handle = reduce_scatter_work
+        hsdp_param.reduce_scatter_comm_ctx.reduce_scatter_output = reduce_scatter_output
+
+        def wait_reduce_scatter() -> torch.Tensor:
+            """Wait the grouped reduce-scatter work."""
+            communication_events.append("wait_rs")
+            reduce_scatter_work.wait()
+            hsdp_param.reduce_scatter_comm_ctx.reduce_scatter_handle = None
+            return reduce_scatter_output
+
+        def issue_all_reduce(
+            fused_buffer: torch.Tensor,
+            **communication_options: object,
+        ) -> MagicMock:
+            """Record the fused all-reduce launch and return its work handle."""
+            self.assertIs(fused_buffer, all_reduce_group.fused_buffer)
+            self.assertEqual(communication_options["op"], torch.distributed.ReduceOp.SUM)
+            self.assertIs(
+                communication_options["group"],
+                hsdp_param.mesh_info.replicate_process_group,
+            )
+            self.assertTrue(communication_options["async_op"])
+            communication_events.append("issue_ar")
+            return all_reduce_work
+
+        hsdp_param.reduce_scatter_output.side_effect = wait_reduce_scatter
+        state = _new_state([hsdp_param])
+
+        with patch.object(torch.distributed, "all_reduce", side_effect=issue_all_reduce):
+            state._wait_prev_reduce_scatter([all_reduce_group])
+            state._issue_prev_fused_all_reduce([all_reduce_group])
+            self.assertEqual(
+                state.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups,
+                [all_reduce_group],
+            )
+            state.wait_and_split_all_reduce_work_groups()
+
+        self.assertEqual(communication_events, ["wait_rs", "issue_ar", "wait_ar"])
+        reduce_scatter_work.wait.assert_called_once_with()
+        all_reduce_work.wait.assert_called_once_with()
+        self.assertEqual(state.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups, [])
+        self.assertIsNone(hsdp_param.reduce_scatter_comm_ctx.reduce_scatter_output)
+        self.assertIsNone(all_reduce_group.fused_buffer)
+        torch.testing.assert_close(
+            hsdp_param.all_reduce_comm_ctx.all_reduce_output,
+            torch.tensor([3.0, 5.0]),
+        )
+
+    def test_issue_reduce_scatter_records_empty_hsdp_unit(self):
+        """A no-gradient unit should occupy one interval slot without a work wrapper."""
+        state = _new_state()
+
+        state._issue_reduce_scatter_for_current_module()
+
+        self.assertEqual(
+            list(state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params),
+            [[]],
+        )
+        self.assertEqual(
+            list(state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups),
+            [[]],
+        )
+
+    def test_root_finalization_drains_large_interval_in_dependency_order(self):
+        """Root finalization should launch every dependent AR regardless of interval."""
+        state = _new_state()
+        state.scheduler_ctx.per_param_comm_ctx.reduce_interval = 1024
+        state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.extend(
+            [["layer-7-param"], [], ["layer-5-param"]]
+        )
+        state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.extend(
+            [["layer-7-group"], [], ["layer-5-group"]]
+        )
+        communication_events = []
+        state._wait_prev_reduce_scatter = MagicMock(
+            side_effect=lambda groups: communication_events.append(("wait_grouped_rs", groups))
+        )
+        state._wait_prev_reduce_scatter_without_all_reduce = MagicMock(
+            side_effect=lambda params: communication_events.append(("wait_direct_rs", params))
+        )
+        state._issue_prev_fused_all_reduce = MagicMock(
+            side_effect=lambda groups: communication_events.append(("issue_ar", groups))
+        )
+        state.wait_and_split_all_reduce_work_groups = MagicMock(
+            side_effect=lambda: communication_events.append(("wait_all_ar", []))
+        )
+        scheduler = _new_root_scheduler(state)
+
+        scheduler._finalize_per_param_reductions()
+
+        self.assertEqual(
+            communication_events,
+            [
+                ("wait_grouped_rs", ["layer-7-group"]),
+                ("wait_direct_rs", ["layer-7-param"]),
+                ("issue_ar", ["layer-7-group"]),
+                ("wait_grouped_rs", []),
+                ("wait_direct_rs", []),
+                ("issue_ar", []),
+                ("wait_grouped_rs", ["layer-5-group"]),
+                ("wait_direct_rs", ["layer-5-param"]),
+                ("issue_ar", ["layer-5-group"]),
+                ("wait_all_ar", []),
+            ],
+        )
+        self.assertEqual(
+            list(state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params),
+            [],
+        )
+        self.assertEqual(
+            list(state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups),
+            [],
+        )
+
+    def test_root_backward_drains_child_reduce_scatter_for_large_interval(self):
+        """The root hook should launch, drain, and apply child work for a huge interval."""
+        source_grad = torch.tensor([3.0, 4.0])
+        reduced_grad = torch.tensor([1.0, 2.0])
+        reduce_scatter_work = MagicMock()
+        communication_events = []
+        fsdp_param = _FakeHSDPParam(dp_size=1, unsharded_grad=source_grad)
+        fsdp_param.mesh_info = object.__new__(FSDPMeshInfo)
+
+        def issue_reduce_scatter(**unused_options: object) -> None:
+            """Launch the child reduce-scatter into its parameter context."""
+            communication_events.append("issue_rs")
+            fsdp_param._grad = source_grad
+            fsdp_param.reduce_scatter_comm_ctx.reduce_scatter_handle = reduce_scatter_work
+            fsdp_param.reduce_scatter_comm_ctx.reduce_scatter_output = reduced_grad
+
+        def wait_reduce_scatter() -> torch.Tensor:
+            """Wait the child reduce-scatter before the root applies its output."""
+            communication_events.append("wait_rs")
+            reduce_scatter_work.wait()
+            fsdp_param.reduce_scatter_comm_ctx.reduce_scatter_handle = None
+            fsdp_param._grad = None
+            return reduced_grad
+
+        def launch_tp_reduce(grad: torch.Tensor, reduce_op: object) -> None:
+            """Record the final source-replicate reduction stage."""
+            torch.testing.assert_close(grad, reduced_grad)
+            self.assertEqual(reduce_op, torch.distributed.ReduceOp.AVG)
+            communication_events.append("tp_reduce")
+
+        def apply_reduced_grad(grad: torch.Tensor) -> bool:
+            """Record application after all communication is complete."""
+            self.assertIsNone(fsdp_param.reduce_scatter_comm_ctx.reduce_scatter_handle)
+            torch.testing.assert_close(grad, reduced_grad)
+            communication_events.append("apply")
+            return False
+
+        fsdp_param.reduce_scatter_grad.side_effect = issue_reduce_scatter
+        fsdp_param.reduce_scatter_output.side_effect = wait_reduce_scatter
+        fsdp_param.all_reduce_source_replicate_grad_inplace.side_effect = launch_tp_reduce
+        fsdp_param.apply_reduced_grad.side_effect = apply_reduced_grad
+        root_state = _new_state()
+        root_state.module_name = "root"
+        scheduler = _new_root_scheduler(root_state)
+        scheduler._is_root = True
+        scheduler._backward_hook = MagicMock()
+        scheduler.scheduler_ctx.per_param_comm_ctx.reduce_interval = 1024
+        child_state = _new_state([fsdp_param])
+        child_state.scheduler_ctx = scheduler.scheduler_ctx
+        child_state.reshard_after_backward = False
+
+        def run_child_backward_hook() -> None:
+            """Run the child post-backward path from the root fallback."""
+            communication_events.append("child_hook")
+            child_state.post_backward()
+
+        child_backward_hook = MagicMock(side_effect=run_child_backward_hook)
+        child_scheduler = SimpleNamespace(
+            hsdp_state=child_state,
+            _backward_hook=child_backward_hook,
+        )
+        scheduler.scheduler_ctx.all_hsdp_schedulers.append(child_scheduler)
+
+        scheduler._root_backward_hook()
+
+        self.assertEqual(
+            communication_events,
+            ["child_hook", "issue_rs", "wait_rs", "tp_reduce", "apply"],
+        )
+        scheduler._backward_hook.assert_called_once_with()
+        child_backward_hook.assert_called_once_with()
+        reduce_scatter_work.wait.assert_called_once_with()
+        fsdp_param.apply_reduced_grad.assert_called_once_with(reduced_grad)
+        self.assertEqual(
+            list(scheduler.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params),
+            [],
+        )
+        self.assertEqual(
+            list(scheduler.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups),
+            [],
+        )
+        self.assertIsNone(fsdp_param._grad)
+
+    def test_root_backward_drains_child_grouped_reduction_for_large_interval(self):
+        """The root hook should complete the grouped HSDP RS-to-AR dependency chain."""
+        source_grad = torch.tensor([7.0, 11.0])
+        reduce_scatter_output = torch.tensor([6.0, 10.0])
+        expected_grad = torch.tensor([3.0, 5.0])
+        reduce_scatter_work = MagicMock()
+        all_reduce_work = MagicMock()
+        communication_events = []
+        all_reduce_work.wait.side_effect = lambda: communication_events.append("wait_ar")
+        hsdp_param = _FakeHSDPParam(dp_size=2, unsharded_grad=source_grad)
+
+        def issue_reduce_scatter(
+            *,
+            reduce_op: object,
+            output_buffer: torch.Tensor,
+        ) -> None:
+            """Launch grouped RS into the fused buffer owned by its AR group."""
+            self.assertEqual(reduce_op, torch.distributed.ReduceOp.AVG)
+            communication_events.append("issue_rs")
+            output_buffer.copy_(reduce_scatter_output)
+            hsdp_param._grad = source_grad
+            hsdp_param.reduce_scatter_comm_ctx.reduce_scatter_handle = reduce_scatter_work
+            hsdp_param.reduce_scatter_comm_ctx.reduce_scatter_output = output_buffer
+
+        def wait_reduce_scatter() -> torch.Tensor:
+            """Wait grouped RS before its dependent AR is issued."""
+            communication_events.append("wait_rs")
+            reduce_scatter_work.wait()
+            hsdp_param.reduce_scatter_comm_ctx.reduce_scatter_handle = None
+            hsdp_param._grad = None
+            return hsdp_param.reduce_scatter_comm_ctx.reduce_scatter_output
+
+        def issue_all_reduce(
+            fused_buffer: torch.Tensor,
+            **communication_options: object,
+        ) -> MagicMock:
+            """Launch the dependent fused AR and return its work handle."""
+            torch.testing.assert_close(fused_buffer[:2], reduce_scatter_output)
+            self.assertEqual(communication_options["op"], torch.distributed.ReduceOp.SUM)
+            self.assertIs(
+                communication_options["group"],
+                hsdp_param.mesh_info.replicate_process_group,
+            )
+            self.assertTrue(communication_options["async_op"])
+            communication_events.append("issue_ar")
+            return all_reduce_work
+
+        def launch_tp_reduce(grad: torch.Tensor, reduce_op: object) -> None:
+            """Record the final source-replicate reduction after HSDP AR."""
+            torch.testing.assert_close(grad, expected_grad)
+            self.assertEqual(reduce_op, torch.distributed.ReduceOp.AVG)
+            communication_events.append("tp_reduce")
+
+        def apply_reduced_grad(grad: torch.Tensor) -> bool:
+            """Record applying the fully reduced HSDP gradient."""
+            self.assertIsNone(hsdp_param.reduce_scatter_comm_ctx.reduce_scatter_handle)
+            all_reduce_work.wait.assert_called_once_with()
+            torch.testing.assert_close(grad, expected_grad)
+            communication_events.append("apply")
+            return False
+
+        hsdp_param.reduce_scatter_grad.side_effect = issue_reduce_scatter
+        hsdp_param.reduce_scatter_output.side_effect = wait_reduce_scatter
+        hsdp_param.all_reduce_source_replicate_grad_inplace.side_effect = launch_tp_reduce
+        hsdp_param.apply_reduced_grad.side_effect = apply_reduced_grad
+        root_state = _new_state()
+        root_state.module_name = "root"
+        scheduler = _new_root_scheduler(root_state)
+        scheduler._is_root = True
+        scheduler._backward_hook = MagicMock()
+        scheduler.scheduler_ctx.per_param_comm_ctx.reduce_interval = 1024
+        child_state = _new_state([hsdp_param])
+        child_state.scheduler_ctx = scheduler.scheduler_ctx
+        child_state.reshard_after_backward = False
+
+        def run_child_backward_hook() -> None:
+            """Run grouped HSDP communication from the root fallback hook."""
+            communication_events.append("child_hook")
+            child_state.post_backward()
+
+        child_backward_hook = MagicMock(side_effect=run_child_backward_hook)
+        child_scheduler = SimpleNamespace(
+            hsdp_state=child_state,
+            _backward_hook=child_backward_hook,
+        )
+        scheduler.scheduler_ctx.all_hsdp_schedulers.append(child_scheduler)
+
+        with patch.object(torch.distributed, "all_reduce", side_effect=issue_all_reduce):
+            scheduler._root_backward_hook()
+
+        self.assertEqual(
+            communication_events,
+            [
+                "child_hook",
+                "issue_rs",
+                "wait_rs",
+                "issue_ar",
+                "wait_ar",
+                "tp_reduce",
+                "apply",
+            ],
+        )
+        scheduler._backward_hook.assert_called_once_with()
+        child_backward_hook.assert_called_once_with()
+        reduce_scatter_work.wait.assert_called_once_with()
+        all_reduce_work.wait.assert_called_once_with()
+        torch.testing.assert_close(hsdp_param.apply_reduced_grad.call_args.args[0], expected_grad)
+        self.assertEqual(
+            list(scheduler.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params),
+            [],
+        )
+        self.assertEqual(
+            list(scheduler.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups),
+            [],
+        )
+        self.assertEqual(scheduler.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups, [])
+        self.assertIsNone(hsdp_param._grad)
 
     def test_post_backward_for_comm_fusion_drains_context_and_launches_param_group(self):
         """Comm-fusion post-backward should drain prior groups before launching this group."""
@@ -569,9 +1031,6 @@ class TestTorchHSDPStateV2(unittest.TestCase):
         param = _FakeHSDPParam(grad=existing_grad)
         param.reduce_scatter_comm_ctx.reduce_scatter_output = reduced_grad
         state = _new_state([param], comm_fusion=False)
-        state._wait_prev_reduce_scatter = MagicMock(return_value=[])
-        state._wait_prev_reduce_scatter_without_all_reduce = MagicMock()
-        state._issue_prev_fused_all_reduce = MagicMock()
         scheduler = _new_root_scheduler(state)
 
         with patch.object(state, "wait_and_split_all_reduce_work_groups"):
@@ -586,17 +1045,19 @@ class TestTorchHSDPStateV2(unittest.TestCase):
         torch.testing.assert_close(param.sharded_param.grad, existing_grad)
 
     def test_mixed_comm_fusion_root_waits_non_fused_reduce_scatter_before_apply(self):
-        """A fused root must drain a non-fused child's RS before applying its output."""
+        """A fused root must drain a non-fused FSDP child's RS before applying it."""
         reduced_grad = torch.tensor([1.0, 2.0])
         source_grad = torch.tensor([3.0, 4.0])
         handle = MagicMock()
         events = []
-        param = _FakeHSDPParam()
+        param = _FakeHSDPParam(dp_size=1)
+        param.mesh_info = object.__new__(FSDPMeshInfo)
         param._grad = source_grad
         param.reduce_scatter_comm_ctx.reduce_scatter_output = reduced_grad
         param.reduce_scatter_comm_ctx.reduce_scatter_handle = handle
 
-        def wait_reduce_scatter():
+        def wait_reduce_scatter() -> torch.Tensor:
+            """Wait the non-fused child's direct reduce-scatter work."""
             self.assertIs(param._grad, source_grad)
             events.append("wait_rs")
             handle.wait()
@@ -604,14 +1065,16 @@ class TestTorchHSDPStateV2(unittest.TestCase):
             param._grad = None
             return reduced_grad
 
-        def launch_tp_reduce(grad, reduce_op):
-            self.assertIs(grad, reduced_grad)
+        def launch_tp_reduce(grad: torch.Tensor, reduce_op: object) -> None:
+            """Record final source-replicate reduction after child RS."""
+            torch.testing.assert_close(grad, reduced_grad)
             self.assertEqual(reduce_op, torch.distributed.ReduceOp.AVG)
             events.append("tp_reduce")
 
-        def apply_reduced_grad(grad):
+        def apply_reduced_grad(grad: torch.Tensor) -> bool:
+            """Record applying the non-fused child's reduced gradient."""
             self.assertIsNone(param.reduce_scatter_comm_ctx.reduce_scatter_handle)
-            self.assertIs(grad, reduced_grad)
+            torch.testing.assert_close(grad, reduced_grad)
             events.append("apply")
             return False
 
@@ -626,9 +1089,11 @@ class TestTorchHSDPStateV2(unittest.TestCase):
         scheduler._is_root = True
         scheduler._backward_hook = MagicMock()
 
-        def launch_child_reduce_scatter():
+        def launch_child_reduce_scatter() -> None:
+            """Queue the non-fused child work from the root fallback hook."""
             events.append("launch_rs")
-            fused_root_state.scheduler_ctx.pre_reduce_scatter_params.append(param)
+            fused_root_state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.append([param])
+            fused_root_state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.append([])
 
         child_backward_hook = MagicMock(side_effect=launch_child_reduce_scatter)
         child_scheduler = SimpleNamespace(
@@ -642,6 +1107,14 @@ class TestTorchHSDPStateV2(unittest.TestCase):
         child_backward_hook.assert_called_once_with()
         handle.wait.assert_called_once_with()
         self.assertIsNone(param._grad)
+        self.assertEqual(
+            list(fused_root_state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params),
+            [],
+        )
+        self.assertEqual(
+            list(fused_root_state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups),
+            [],
+        )
 
     def test_state_reset_releases_iteration_state_and_preserves_optimizer_grads(self):
         """State reset should release communication storage but preserve optimizer gradients."""
@@ -667,18 +1140,18 @@ class TestTorchHSDPStateV2(unittest.TestCase):
 
         pre_group = SimpleNamespace()
         work_group = SimpleNamespace()
-        state.scheduler_ctx.pre_reduce_scatter_params.append(param)
-        state.scheduler_ctx.pre_all_reduce_params.append(param)
-        state.scheduler_ctx.pre_all_reduce_groups.append(pre_group)
-        state.scheduler_ctx.pending_all_reduce_groups.append(work_group)
+        state.scheduler_ctx.per_param_comm_ctx.reduce_interval = 3
+        state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.append([param])
+        state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.append([pre_group])
+        state.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups.append(work_group)
 
         state.reset_iter_state()
 
         state.param_group.reset_iter_state.assert_called_once_with()
-        self.assertEqual(state.scheduler_ctx.pre_reduce_scatter_params, [])
-        self.assertEqual(state.scheduler_ctx.pre_all_reduce_params, [])
-        self.assertEqual(state.scheduler_ctx.pre_all_reduce_groups, [])
-        self.assertEqual(state.scheduler_ctx.pending_all_reduce_groups, [])
+        self.assertEqual(list(state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params), [])
+        self.assertEqual(list(state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups), [])
+        self.assertEqual(state.scheduler_ctx.per_param_comm_ctx.all_reduce_work_groups, [])
+        self.assertEqual(state.scheduler_ctx.per_param_comm_ctx.reduce_interval, 3)
         self.assertIsNone(param.allgather_comm_ctx.allgather_output)
         self.assertIsNone(param.allgather_comm_ctx.allgather_handle)
         self.assertIsNone(param.reduce_scatter_comm_ctx.reduce_scatter_output)
@@ -705,17 +1178,20 @@ class TestTorchHSDPStateV2(unittest.TestCase):
         other_state = _new_state([other_param])
         other_state.param_group = MagicMock()
 
-        current_state.scheduler_ctx.pre_reduce_scatter_params.append(current_param)
-        current_state.scheduler_ctx.pre_all_reduce_params.append(current_param)
-        other_state.scheduler_ctx.pre_reduce_scatter_params.append(other_param)
-        other_state.scheduler_ctx.pre_all_reduce_params.append(other_param)
+        current_state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.append([current_param])
+        current_state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.append([])
+        other_state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params.append([other_param])
+        other_state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups.append([])
 
         current_state.reset_iter_state()
 
-        self.assertEqual(current_state.scheduler_ctx.pre_reduce_scatter_params, [])
-        self.assertEqual(current_state.scheduler_ctx.pre_all_reduce_params, [])
-        self.assertEqual(other_state.scheduler_ctx.pre_reduce_scatter_params, [other_param])
-        self.assertEqual(other_state.scheduler_ctx.pre_all_reduce_params, [other_param])
+        self.assertEqual(list(current_state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params), [])
+        self.assertEqual(list(current_state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups), [])
+        self.assertEqual(
+            list(other_state.scheduler_ctx.per_param_comm_ctx.pre_reduce_scatter_params),
+            [[other_param]],
+        )
+        self.assertEqual(list(other_state.scheduler_ctx.per_param_comm_ctx.pre_all_reduce_groups), [[]])
         self.assertIsNone(current_param.reduce_scatter_comm_ctx.reduce_scatter_output)
         self.assertIs(other_param.reduce_scatter_comm_ctx.reduce_scatter_output, other_reduce_scatter_output)
         self.assertIs(other_param.all_reduce_comm_ctx.all_reduce_output, other_all_reduce_output)


### PR DESCRIPTION
/kind feature

----

**What does this PR do / why do we need it**:

FSDP/HSDP 当前固定在后续一个通信单元进入反向阶段时等待上一轮
reduce-scatter，通信耗时较长时无法继续扩大计算与通信的重叠窗口。

- 新增 `HSDPModule.set_reduce_comm_interval(interval: int = 1)` 接口。
- PyTorch 支持在 root module 首次 forward 前配置通信间隔。
- 配置通过共享 scheduler context 作用于整个 HSDP module tree。
- 新增 `PerParamCommCtx`，统一管理 non-fusion 通信队列及 interval。
- 基于现有参数和 all-reduce group 队列实现 FIFO 滑动窗口。
- 不新增重复保存通信 handle/work 的队列。
- 空梯度单元仍占用 FIFO 槽位，保证 interval 距离语义精确。
- interval=1 保持原有等待时序。
- interval=N 时，reduce-scatter 延迟到后续第 N 个单元进行等待。
- HSDP all-reduce 在关联 reduce-scatter 完成后下发，并同步延迟。
- root backward 无视 interval，完整排空剩余通信和应用梯度。
- 超大 interval 不会遗漏通信或导致梯度精度错误。
- iteration reset 清理运行期队列，同时保留用户配置。
- communication fusion 场景下 interval>1 告警并降级为 1。
- MindSpore 保持 interval=1，并对配置接口抛出 `NotImplementedError`。
- 删除无生产使用方的旧通信字段及相应测试样板。
- 本次修改涉及 12 个文件，新增 1004 行，删除 221 行。

----

**Which issue(s) this PR fixes**:

Fixes #

----

**Test Plan and Test result：What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

- PyTorch fully-shard UT：250 passed，覆盖 50 个 subtests。
- MindSpore fully-shard UT：119 passed，4 skipped，覆盖 13 个 subtests。
- 覆盖接口默认值、合法值、非法类型及 fusion 降级行为。
- 覆盖 interval=1/2 的 FIFO 顺序和空梯度单元计数。
- 覆盖 FSDP reduce-scatter 及 HSDP reduce-scatter→all-reduce 时序。
- 覆盖 interval=1024 时 root backward 的完整通信排空。
- 覆盖 iteration reset、共享上下文和 mixed fusion root 场景。
- 8 卡 NPU、相同绑核及 seq=16 条件下，interval=1 为 84.52 ms，
  interval=2 为 78.41 ms，快测观测提升 7.23%。
- Profiling 与无 profiler 性能计时分别采集，结果未加入仓库。

----

**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

- [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
- [x] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
- [x] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
- [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
- [x] **文档**：本 PR 不涉及官网文档修改

<!-- atomgit-backport-meta -->
atomgit_repo: mindspore/hyper-parallel
atomgit_mr: 1316
source_branch: fsdp_support_grad_reduction_intervel
source_url: https://gitcode.com/mindspore/hyper-parallel/merge_requests/1316
<!-- /atomgit-backport-meta -->
