### PR TITLE
feat: support reentrant checkpoint exclusions

### DIFF
--- a/hyper_parallel/platform/mindspore/activation_checkpoint/reentrant_checkpoint.py
+++ b/hyper_parallel/platform/mindspore/activation_checkpoint/reentrant_checkpoint.py
@@ -1,0 +1,828 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Experimental reentrant activation checkpoint with excluded regions.
+
+This module is intentionally independent from the public activation checkpoint
+entry points.  It provides a hook-free prototype in which the outer checkpoint
+uses a custom backward and every excluded region retains a small, ordinary
+PyNative autograd graph.  During checkpoint replay, a custom autograd bridge
+returns the cached excluded output and routes its backward through the retained
+local graph.
+
+The implementation currently supports PyNative execution with Tensor leaves in
+nested input and output containers. Selective checkpoint policies and activation
+swapping are intentionally not supported yet.
+"""
+import contextlib
+import contextvars
+from collections import defaultdict
+from dataclasses import dataclass
+from functools import lru_cache
+import threading
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple
+import weakref
+
+from mindspore import Tensor
+from mindspore._c_expression import run_backward
+from mindspore._c_expression.amp import get_curr_amp_strategy
+from mindspore.common._grad_function import _Function
+from mindspore.common.api import _no_grad, _pynative_executor
+from mindspore.common.generator import get_rng_state, set_rng_state
+from mindspore.train.amp import AmpDecorator
+
+from hyper_parallel.core.activation_checkpoint.recompute_state import create_recompute_contexts
+from hyper_parallel.platform.mindspore.activation_checkpoint.activation_swap import ActivationWrapper
+
+
+_DEFAULT_REPLAY_KEY = object()
+
+
+@lru_cache(maxsize=1)
+def _get_tensor_type() -> type:
+    """Return the MindSpore Tensor type."""
+    return Tensor
+
+
+def _is_tensor(value: Any) -> bool:
+    """Return whether *value* is a MindSpore Tensor."""
+    return isinstance(value, _get_tensor_type())
+
+
+def _tensor_leaves(value: Any) -> List[Any]:
+    """Collect Tensor leaves from supported Python containers."""
+    if _is_tensor(value):
+        return [value]
+    leaves = []
+    if isinstance(value, (tuple, list)):
+        for item in value:
+            leaves.extend(_tensor_leaves(item))
+    elif isinstance(value, dict):
+        for item in value.values():
+            leaves.extend(_tensor_leaves(item))
+    return leaves
+
+
+def _map_tensors(function: Callable[[Any], Any], value: Any) -> Any:
+    """Apply *function* to Tensor leaves while preserving container types."""
+    if _is_tensor(value):
+        return function(value)
+    if isinstance(value, list):
+        return [_map_tensors(function, item) for item in value]
+    if isinstance(value, tuple):
+        items = [_map_tensors(function, item) for item in value]
+        if hasattr(value, "_fields"):
+            return type(value)(*items)
+        return tuple(items)
+    if isinstance(value, dict):
+        return type(value)((key, _map_tensors(function, item)) for key, item in value.items())
+    return value
+
+
+def _detach_tree(value: Any) -> Any:
+    """Detach every Tensor leaf in *value*."""
+    return _map_tensors(lambda tensor: tensor.detach(), value)
+
+
+def _validate_output(output: Any) -> None:
+    """Validate the output structure supported by the custom bridge."""
+    if _tensor_leaves(output):
+        return
+    raise ValueError(
+        "reentrant checkpoint requires at least one Tensor output leaf"
+    )
+
+
+def _normalize_sensitivities(output: Any, sensitivity: Any) -> List[Any]:
+    """Flatten sensitivities in the same order as output Tensor leaves."""
+    output_tensors = _tensor_leaves(output)
+    sensitivity_tensors = _tensor_leaves(sensitivity)
+    if len(output_tensors) != len(sensitivity_tensors):
+        raise RuntimeError(
+            "The number of reentrant checkpoint output sensitivities does not match its Tensor outputs: "
+            f"expected {len(output_tensors)}, but got {len(sensitivity_tensors)}"
+        )
+    return sensitivity_tensors
+
+
+def _mark_requires_grad(tensors: Sequence[Any]) -> None:
+    """Mark local VJP roots as requiring gradients."""
+    for tensor in tensors:
+        requires_grad = getattr(tensor, "requires_grad_", None)
+        if callable(requires_grad):
+            requires_grad()
+        else:
+            tensor._requires_grad = True  # pylint: disable=protected-access
+
+
+class _VjpTape:
+    """Retain one ordinary PyNative graph and expose a repeatable VJP."""
+
+    def __init__(self, output: Any, inputs: Sequence[Any], parameters: Sequence[Any]) -> None:
+        """Initialize a tape from a recorded output and its gradient targets."""
+        _validate_output(output)
+        self.output = output
+        self.inputs = tuple(inputs)
+        self.parameters = tuple(parameters)
+        self._released = False
+
+    @classmethod
+    def record(
+        cls,
+        function: Callable[..., Any],
+        args: Tuple[Any, ...],
+        kwargs: Dict[str, Any],
+        parameters: Sequence[Any],
+    ) -> "_VjpTape":
+        """Execute *function* with PyNative grad recording enabled.
+
+        Args:
+            function: Callable to record.
+            args: Positional arguments passed to the callable.
+            kwargs: Keyword arguments passed to the callable.
+            parameters: Parameters included as gradient targets.
+        """
+        input_tensors = _tensor_leaves((args, kwargs))
+        _mark_requires_grad(input_tensors)
+        previous_enable_grad = _pynative_executor.enable_grad()
+        previous_grad_flag = _pynative_executor.grad_flag()
+        _pynative_executor.set_enable_grad(True)
+        _pynative_executor.set_grad_flag(True)
+        try:
+            output = function(*args, **kwargs)
+        finally:
+            _pynative_executor.set_grad_flag(previous_grad_flag)
+            _pynative_executor.set_enable_grad(previous_enable_grad)
+        return cls(output, input_tensors, parameters)
+
+    def vjp(
+        self,
+        sensitivity: Any,
+        keep_graph: bool,
+        accumulate_parameters: bool = False,
+    ) -> Tuple[Tuple[Any, ...], Tuple[Any, ...]]:
+        """Calculate gradients for recorded inputs and parameters.
+
+        Args:
+            sensitivity: Output gradients supplied by the caller.
+            keep_graph: Whether to retain the local graph for another traversal.
+            accumulate_parameters: Accumulate parameter gradients through nested hooks.
+        """
+        if self._released:
+            raise RuntimeError("The retained reentrant checkpoint graph has already been released")
+        output_tensors = tuple(_tensor_leaves(self.output))
+        sensitivity_tensors = tuple(_normalize_sensitivities(self.output, sensitivity))
+        targets = self.inputs + self.parameters
+        if accumulate_parameters:
+            gradients = run_backward(
+                output_tensors,
+                sensitivity_tensors,
+                keep_graph,
+                False,
+                (),
+                allow_unreachable=True,
+                accumulate_grad=True,
+            )
+            if gradients is None:
+                gradients = tuple(getattr(tensor, "grad", None) for tensor in self.inputs)
+                for tensor in self.inputs:
+                    tensor.grad = None
+            if not keep_graph:
+                self.release()
+            return tuple(gradients), (None,) * len(self.parameters)
+        gradients = run_backward(
+            output_tensors,
+            sensitivity_tensors,
+            keep_graph,
+            False,
+            targets,
+            allow_unreachable=True,
+            accumulate_grad=False,
+        )
+        input_count = len(self.inputs)
+        input_grads = tuple(gradients[:input_count])
+        parameter_grads = tuple(gradients[input_count:])
+        if not keep_graph:
+            self.release()
+        return input_grads, parameter_grads
+
+    def release(self) -> None:
+        """Release all Python references keeping the PyNative graph alive."""
+        self.output = None
+        self.inputs = ()
+        self.parameters = ()
+        self._released = True
+
+
+@dataclass(frozen=True)
+class _SessionState:
+    """Describe the active recompute session on the current thread."""
+
+    session_id: Any
+    retain_graph: bool
+
+
+_CURRENT_HANDLE_COLLECTOR: contextvars.ContextVar[Optional[List[Any]]] = contextvars.ContextVar(
+    "hyper_parallel_reentrant_handle_collector",
+    default=None,
+)
+_CURRENT_SESSION: contextvars.ContextVar[Optional[_SessionState]] = contextvars.ContextVar(
+    "hyper_parallel_reentrant_session",
+    default=None,
+)
+_IN_REENTRANT_TOP_LEVEL_BACKWARD: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "hyper_parallel_in_reentrant_top_level_backward",
+    default=False,
+)
+
+_SESSION_LOCK = threading.RLock()
+_SESSION_CALLS: Dict[Any, weakref.WeakSet] = defaultdict(weakref.WeakSet)
+
+
+@contextlib.contextmanager
+def reentrant_recompute_handle_collector_ctx() -> Iterator[List[Any]]:
+    """Collect reentrant checkpoint handles created by forward execution."""
+    handles = []
+    token = _CURRENT_HANDLE_COLLECTOR.set(handles)
+    try:
+        yield handles
+    finally:
+        _CURRENT_HANDLE_COLLECTOR.reset(token)
+
+
+@contextlib.contextmanager
+def reentrant_recompute_session_ctx(
+    session_id: Any,
+    retain_on_unpack: bool = False,
+) -> Iterator[None]:
+    """Bind replay selection and graph retention to the current thread.
+
+    Args:
+        session_id: Stable identifier shared by pre-fired replay and backward.
+        retain_on_unpack: Retain both outer replay and excluded local graphs for
+            a later consumer such as the weight-gradient phase.
+    """
+    state = _SessionState(session_id=session_id, retain_graph=retain_on_unpack)
+    token = _CURRENT_SESSION.set(state)
+    try:
+        yield
+    finally:
+        _CURRENT_SESSION.reset(token)
+
+
+def clear_reentrant_recompute_session(session_id: Any) -> None:
+    """Release all checkpoint graphs retained by *session_id*.
+
+    Args:
+        session_id: Identifier of the replay session to clear.
+    """
+    with _SESSION_LOCK:
+        calls = list(_SESSION_CALLS.pop(session_id, ()))
+    for call in calls:
+        call.clear_recompute_session(session_id)
+
+
+def is_in_reentrant_top_level_backward() -> bool:
+    """Return whether execution is inside a top-level reentrant backward."""
+    return _IN_REENTRANT_TOP_LEVEL_BACKWARD.get()
+
+
+@contextlib.contextmanager
+def reentrant_recompute_backward_compat_ctx() -> Iterator[None]:
+    """Preserve shared-parameter accumulation order for a top-level backward."""
+    token = _IN_REENTRANT_TOP_LEVEL_BACKWARD.set(True)
+    try:
+        yield
+    finally:
+        _IN_REENTRANT_TOP_LEVEL_BACKWARD.reset(token)
+
+
+class _CheckpointInvocation:
+    """Own excluded-region graphs belonging to one checkpoint call."""
+
+    def __init__(self) -> None:
+        """Initialize an empty ordered call registry."""
+        self.exclude_entries: Dict[int, List[_ExcludeEntry]] = defaultdict(list)
+
+    def add_entry(self, wrapper_id: int, entry: "_ExcludeEntry") -> None:
+        """Append one original-forward excluded call.
+
+        Args:
+            wrapper_id: Identity of the exclusion wrapper.
+            entry: Retained graph for one invocation.
+        """
+        self.exclude_entries[wrapper_id].append(entry)
+
+    def get_entry(self, wrapper_id: int, index: int) -> "_ExcludeEntry":
+        """Return the excluded call matching replay order.
+
+        Args:
+            wrapper_id: Identity of the exclusion wrapper.
+            index: Invocation index within the wrapper.
+        """
+        entries = self.exclude_entries.get(wrapper_id)
+        if entries is None or index >= len(entries):
+            raise RuntimeError("Checkpoint replay executed an unmatched checkpoint exclusion wrapper call")
+        return entries[index]
+
+    def clear(self) -> None:
+        """Release all retained excluded-region graphs."""
+        for entries in self.exclude_entries.values():
+            for entry in entries:
+                entry.release()
+        self.exclude_entries.clear()
+
+
+class _ExecutionState:
+    """Expose one checkpoint invocation and phase to nested wrappers."""
+
+    def __init__(self, invocation: _CheckpointInvocation, recomputing: bool) -> None:
+        """Initialize forward or replay state."""
+        self.invocation = invocation
+        self.recomputing = recomputing
+        self._positions: Dict[int, int] = defaultdict(int)
+
+    def next_entry(self, wrapper_id: int) -> "_ExcludeEntry":
+        """Consume the next original call entry for *wrapper_id*.
+
+        Args:
+            wrapper_id: Identity of the exclusion wrapper.
+        """
+        index = self._positions[wrapper_id]
+        entry = self.invocation.get_entry(wrapper_id, index)
+        self._positions[wrapper_id] += 1
+        return entry
+
+
+_CURRENT_EXECUTION_STATE: contextvars.ContextVar[Optional[_ExecutionState]] = contextvars.ContextVar(
+    "hyper_parallel_reentrant_execution_state",
+    default=None,
+)
+
+
+@contextlib.contextmanager
+def _execution_state_ctx(state: _ExecutionState) -> Iterator[None]:
+    """Install a checkpoint execution phase in the current dynamic scope."""
+    token = _CURRENT_EXECUTION_STATE.set(state)
+    try:
+        yield
+    finally:
+        _CURRENT_EXECUTION_STATE.reset(token)
+
+
+@contextlib.contextmanager
+def _stack_contexts(contexts: Sequence[Any]) -> Iterator[None]:
+    """Enter a sequence of contexts in order and exit them in reverse."""
+    with contextlib.ExitStack() as stack:
+        for context in contexts:
+            stack.enter_context(context)
+        yield
+
+
+def _create_phase_contexts(
+    context_fn: Optional[Callable[[], Tuple[Any, Any]]],
+) -> Tuple[Tuple[Any, ...], Tuple[Any, ...]]:
+    """Create framework and optional user contexts for both phases."""
+    pairs = [create_recompute_contexts()]
+    if context_fn is not None:
+        user_pair = context_fn()
+        if not isinstance(user_pair, tuple) or len(user_pair) != 2:
+            raise ValueError("context_fn must return a (forward_context, recompute_context) tuple")
+        pairs.append(user_pair)
+    return tuple(pair[0] for pair in pairs), tuple(pair[1] for pair in pairs)
+
+
+class _ExcludeEntry:
+    """Retain one excluded forward output and its local VJP graph."""
+
+    def __init__(
+        self,
+        output: Any,
+        tape: _VjpTape,
+        parameter_count: int,
+        rng_state_after: Optional[Any],
+    ) -> None:
+        """Initialize one excluded call entry."""
+        self.output = output
+        self.tape = tape
+        self.input_count = len(tape.inputs)
+        self.parameter_count = parameter_count
+        self.rng_state_after = rng_state_after
+
+    def vjp(self, sensitivity: Any, keep_graph: bool) -> Tuple[Tuple[Any, ...], Tuple[Any, ...]]:
+        """Run the retained excluded-region backward graph.
+
+        Args:
+            sensitivity: Output gradients supplied by the bridge.
+            keep_graph: Whether to retain the graph for another traversal.
+        """
+        return self.tape.vjp(sensitivity, keep_graph)
+
+    def restore_rng_state(self) -> None:
+        """Advance replay RNG to the state after the skipped region."""
+        if self.rng_state_after is None:
+            return
+        set_rng_state(self.rng_state_after)
+
+    def release(self) -> None:
+        """Release output and local VJP graph references."""
+        self.output = None
+        self.tape.release()
+
+
+@lru_cache(maxsize=1)
+def _get_exclude_replay_function() -> type:
+    """Create the private MindSpore custom autograd bridge lazily."""
+    class _ExcludeReplayFunction(_Function):
+        """Return a cached output and connect it to replay inputs in backward."""
+
+        @staticmethod
+        def forward(ctx: Any, entry: _ExcludeEntry, input_count: int, *tensors: Any) -> Any:
+            """Return the cached output without executing the excluded module.
+
+            Args:
+                ctx: Autograd context for the bridge call.
+                entry: Retained excluded-region graph.
+                input_count: Number of activation inputs.
+                tensors: Activation and parameter tensors attached to the bridge.
+            """
+            del tensors
+            ctx.entry = entry
+            ctx.input_count = input_count
+            return _detach_tree(entry.output)
+
+        @staticmethod
+        def backward(ctx: Any, *grad_outputs: Any) -> Tuple[Any, ...]:
+            """Route the bridge VJP through the original excluded graph.
+
+            Args:
+                ctx: Autograd context created in forward.
+                grad_outputs: Gradients of the cached outputs.
+            """
+            session = _CURRENT_SESSION.get()
+            keep_graph = session is not None and session.retain_graph
+            sensitivity = grad_outputs[0] if len(grad_outputs) == 1 else grad_outputs
+            input_grads, parameter_grads = ctx.entry.vjp(sensitivity, keep_graph)
+            if len(input_grads) != ctx.input_count:
+                raise RuntimeError(
+                    "Checkpoint exclusion input count changed between original forward and replay"
+                )
+            return (None, None, *input_grads, *parameter_grads)
+
+    return _ExcludeReplayFunction
+
+
+def _apply_exclude_replay(
+    entry: _ExcludeEntry,
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+    parameters: Sequence[Any],
+) -> Any:
+    """Apply an autograd bridge from current replay tensors to cached output."""
+    entry.restore_rng_state()
+    input_tensors = tuple(_tensor_leaves((args, kwargs)))
+    if len(input_tensors) != entry.input_count:
+        raise RuntimeError(
+            "Checkpoint exclusion Tensor input count changed between original forward and replay: "
+            f"expected {entry.input_count}, but got {len(input_tensors)}"
+        )
+    if len(parameters) != entry.parameter_count:
+        raise RuntimeError(
+            "Checkpoint exclusion parameter count changed between original forward and replay: "
+            f"expected {entry.parameter_count}, but got {len(parameters)}"
+        )
+    differentiable_tensors = input_tensors + tuple(parameters)
+    if not differentiable_tensors:
+        return _detach_tree(entry.output)
+    replay_function = _get_exclude_replay_function()
+    return replay_function.apply(entry, len(input_tensors), *differentiable_tensors)
+
+
+class ReentrantCheckpointExcludeWrapper(ActivationWrapper):
+    """Execute a region once and reuse its output during reentrant replay."""
+
+    def __init__(self, module: Callable[..., Any], save_rng_state: bool = True) -> None:
+        """Initialize a reentrant checkpoint exclusion wrapper."""
+        if not callable(module):
+            raise ValueError("module must be a MindSpore Cell or callable")
+        super().__init__(module, track_overlaps=False)
+        self.save_rng_state = save_rng_state
+
+    def construct(self, *args: Any, **kwargs: Any) -> Any:
+        """Record a local VJP in forward and insert a bridge during replay."""
+        state = _CURRENT_EXECUTION_STATE.get()
+        if state is None:
+            return self._wrapped_module(*args, **kwargs)
+        parameters = tuple(self._wrapped_module.trainable_params())
+        if state.recomputing:
+            entry = state.next_entry(id(self))
+            return _apply_exclude_replay(entry, args, kwargs, parameters)
+
+        detached_args = _detach_tree(args)
+        detached_kwargs = _detach_tree(kwargs)
+        tape = _VjpTape.record(self._wrapped_module, detached_args, detached_kwargs, parameters)
+        rng_state_after = None
+        if self.save_rng_state:
+            rng_state_after = get_rng_state()
+        entry = _ExcludeEntry(tape.output, tape, len(parameters), rng_state_after)
+        state.invocation.add_entry(id(self), entry)
+        return tape.output
+
+
+class _ReentrantCheckpointCall:
+    """Own the state and retained graphs for one checkpoint invocation."""
+
+    def __init__(
+        self,
+        module: Callable[..., Any],
+        context_fn: Optional[Callable[[], Tuple[Any, Any]]],
+        save_rng_state: bool,
+    ) -> None:
+        """Initialize one checkpoint invocation."""
+        self._wrapped_module = module
+        self.context_fn = context_fn
+        self.save_rng_state = save_rng_state
+        self._invocation = _CheckpointInvocation()
+        self._original_args: Optional[Tuple[Any, ...]] = None
+        self._original_kwargs: Optional[Dict[str, Any]] = None
+        self._rng_state = None
+        self._amp_strategy = None
+        self._forward_contexts: Tuple[Any, ...] = ()
+        self._recompute_contexts: Tuple[Any, ...] = ()
+        self._replay_tapes: Dict[Any, _VjpTape] = {}
+        self._lock = threading.RLock()
+
+    @staticmethod
+    def _validate_inputs(args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> None:
+        """Validate that the checkpoint invocation has a Tensor input leaf."""
+        if not _tensor_leaves((args, kwargs)):
+            raise ValueError("reentrant checkpoint requires at least one Tensor input")
+
+    def run_forward(self, args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> Any:
+        """Execute the original checkpoint forward without recording its graph.
+
+        Args:
+            args: Positional checkpoint arguments.
+            kwargs: Keyword checkpoint arguments.
+        """
+        self._validate_inputs(args, kwargs)
+        self._original_args = args
+        self._original_kwargs = dict(kwargs)
+        self._forward_contexts, self._recompute_contexts = _create_phase_contexts(self.context_fn)
+        if self.save_rng_state:
+            self._rng_state = get_rng_state()
+        self._amp_strategy = get_curr_amp_strategy()
+        execution_state = _ExecutionState(self._invocation, recomputing=False)
+        with _stack_contexts(self._forward_contexts), _execution_state_ctx(execution_state), _no_grad():
+            output = self._wrapped_module(*args, **kwargs)
+        _validate_output(output)
+        collector = _CURRENT_HANDLE_COLLECTOR.get()
+        if collector is not None:
+            collector.append(self)
+        return output
+
+    @contextlib.contextmanager
+    def _replay_environment(self) -> Iterator[None]:
+        """Restore RNG, AMP, user contexts, and recompute state for replay."""
+        previous_rng_state = get_rng_state() if self.save_rng_state else None
+        if self.save_rng_state:
+            set_rng_state(self._rng_state)
+        _pynative_executor.set_is_run_recompute(True)
+        execution_state = _ExecutionState(self._invocation, recomputing=True)
+        try:
+            with _stack_contexts(self._recompute_contexts), _execution_state_ctx(execution_state):
+                if self._amp_strategy is None:
+                    yield
+                else:
+                    with AmpDecorator(
+                        self._amp_strategy.get_amp_level(),
+                        self._amp_strategy.get_amp_dtype(),
+                        self._amp_strategy.get_white_list(),
+                        self._amp_strategy.get_black_list(),
+                    ):
+                        yield
+        finally:
+            _pynative_executor.set_is_run_recompute(False)
+            if previous_rng_state is not None:
+                set_rng_state(previous_rng_state)
+
+    def _record_replay(self) -> _VjpTape:
+        """Replay the checkpoint function once and retain its PyNative graph."""
+        if self._original_args is None or self._original_kwargs is None:
+            raise RuntimeError("Cannot replay a reentrant checkpoint before its original forward")
+        replay_args = _detach_tree(self._original_args)
+        replay_kwargs = _detach_tree(self._original_kwargs)
+        with self._replay_environment():
+            replay_parameters = tuple(self._wrapped_module.trainable_params())
+            return _VjpTape.record(
+                self._wrapped_module,
+                replay_args,
+                replay_kwargs,
+                replay_parameters,
+            )
+
+    def recompute(self, session_id: Any) -> None:
+        """Pre-fire replay and retain its graph under *session_id*.
+
+        Args:
+            session_id: Identifier used by the later backward traversal.
+        """
+        with self._lock:
+            if session_id not in self._replay_tapes:
+                self._replay_tapes[session_id] = self._record_replay()
+        with _SESSION_LOCK:
+            _SESSION_CALLS[session_id].add(self)
+
+    def _get_replay_tape(self, replay_key: Any) -> _VjpTape:
+        """Get or lazily record the replay tape for one backward session."""
+        with self._lock:
+            tape = self._replay_tapes.get(replay_key)
+            if tape is None:
+                tape = self._record_replay()
+                self._replay_tapes[replay_key] = tape
+        if replay_key is not _DEFAULT_REPLAY_KEY:
+            with _SESSION_LOCK:
+                _SESSION_CALLS[replay_key].add(self)
+        return tape
+
+    def backward(self, sensitivity: Any) -> Tuple[Tuple[Any, ...], Tuple[Any, ...]]:
+        """Replay if needed and calculate checkpoint gradients.
+
+        Args:
+            sensitivity: Output gradients supplied to the custom backward.
+        """
+        session = _CURRENT_SESSION.get()
+        replay_key = session.session_id if session is not None else _DEFAULT_REPLAY_KEY
+        retain_graph = session is not None and session.retain_graph
+        tape = self._get_replay_tape(replay_key)
+        input_grads, parameter_grads = tape.vjp(
+            sensitivity,
+            keep_graph=retain_graph,
+            accumulate_parameters=True,
+        )
+        if not retain_graph:
+            self._finish_replay(replay_key)
+        return input_grads, parameter_grads
+
+    def _finish_replay(self, replay_key: Any) -> None:
+        """Drop replay and excluded graphs after their terminal consumer."""
+        with self._lock:
+            self._replay_tapes.pop(replay_key, None)
+        self._invocation.clear()
+        self._original_args = None
+        self._original_kwargs = None
+
+    def clear_recompute_session(self, session_id: Any) -> None:
+        """Release replay state retained by one schedule session.
+
+        Args:
+            session_id: Identifier of the replay session to clear.
+        """
+        with self._lock:
+            tape = self._replay_tapes.pop(session_id, None)
+        if tape is not None:
+            tape.release()
+        self._invocation.clear()
+        self._original_args = None
+        self._original_kwargs = None
+
+
+@lru_cache(maxsize=1)
+def _get_reentrant_checkpoint_function() -> type:
+    """Create the outer custom autograd checkpoint node lazily."""
+    class _ReentrantCheckpointFunction(_Function):
+        """Run forward without a graph and replay it from custom backward."""
+
+        @staticmethod
+        def forward(
+            ctx: Any,
+            call: _ReentrantCheckpointCall,
+            input_count: int,
+            args: Tuple[Any, ...],
+            kwargs: Dict[str, Any],
+            *tensors: Any,
+        ) -> Any:
+            """Execute and retain one original checkpoint invocation.
+
+            Args:
+                ctx: Autograd context for this checkpoint call.
+                call: Per-invocation checkpoint state.
+                input_count: Number of activation inputs.
+                args: Original positional arguments.
+                kwargs: Original keyword arguments.
+                tensors: Activation tensors attached to the node.
+            """
+            del tensors
+            ctx.call = call
+            ctx.input_count = input_count
+            return call.run_forward(args, kwargs)
+
+        @staticmethod
+        def backward(ctx: Any, *grad_outputs: Any) -> Tuple[Any, ...]:
+            """Replay the checkpoint and return its gradients.
+
+            Args:
+                ctx: Autograd context created in forward.
+                grad_outputs: Gradients of checkpoint outputs.
+            """
+            sensitivity = grad_outputs[0] if len(grad_outputs) == 1 else grad_outputs
+            input_grads, _ = ctx.call.backward(sensitivity)
+            if len(input_grads) != ctx.input_count:
+                raise RuntimeError(
+                    "Checkpoint Tensor input count changed between original forward and replay"
+                )
+            return (None, None, None, None, *input_grads)
+
+    return _ReentrantCheckpointFunction
+
+
+class ReentrantCheckpointWrapper(ActivationWrapper):
+    """Wrap a MindSpore Cell or method with hook-free reentrant checkpointing."""
+
+    def __init__(
+        self,
+        module: Callable[..., Any],
+        context_fn: Optional[Callable[[], Tuple[Any, Any]]] = None,
+        save_rng_state: bool = True,
+    ) -> None:
+        """Initialize a reentrant checkpoint wrapper."""
+        if not callable(module):
+            raise ValueError("module must be a MindSpore Cell or callable")
+        super().__init__(module)
+        self.context_fn = context_fn
+        self.save_rng_state = save_rng_state
+
+    def construct(self, *args: Any, **kwargs: Any) -> Any:
+        """Create and execute one per-invocation reentrant checkpoint call."""
+        if not _pynative_executor.enable_grad():
+            return self._wrapped_module(*args, **kwargs)
+        call = _ReentrantCheckpointCall(
+            self._wrapped_module,
+            context_fn=self.context_fn,
+            save_rng_state=self.save_rng_state,
+        )
+        input_tensors = tuple(_tensor_leaves((args, kwargs)))
+        checkpoint_function = _get_reentrant_checkpoint_function()
+        return checkpoint_function.apply(
+            call,
+            len(input_tensors),
+            args,
+            kwargs,
+            *input_tensors,
+        )
+
+
+def reentrant_checkpoint_wrapper(
+    module: Callable[..., Any],
+    context_fn: Optional[Callable[[], Tuple[Any, Any]]] = None,
+    save_rng_state: bool = True,
+) -> ReentrantCheckpointWrapper:
+    """Wrap *module* with the experimental hook-free reentrant checkpoint.
+
+    Args:
+        module: Cell or callable to checkpoint.
+        context_fn: Optional factory returning forward and replay contexts.
+        save_rng_state: Preserve default generators across replay.
+    """
+    return ReentrantCheckpointWrapper(
+        module,
+        context_fn=context_fn,
+        save_rng_state=save_rng_state,
+    )
+
+
+def reentrant_checkpoint_exclude_wrapper(
+    module: Callable[..., Any],
+    save_rng_state: bool = True,
+) -> ReentrantCheckpointExcludeWrapper:
+    """Wrap a callable so its region is not executed during reentrant replay.
+
+    Args:
+        module: Cell or callable to exclude.
+        save_rng_state: Advance default generators as in the original forward.
+    """
+    return ReentrantCheckpointExcludeWrapper(module, save_rng_state=save_rng_state)
+
+
+__all__ = [
+    "ReentrantCheckpointExcludeWrapper",
+    "ReentrantCheckpointWrapper",
+    "clear_reentrant_recompute_session",
+    "reentrant_recompute_backward_compat_ctx",
+    "reentrant_checkpoint_exclude_wrapper",
+    "reentrant_checkpoint_wrapper",
+    "reentrant_recompute_handle_collector_ctx",
+    "reentrant_recompute_session_ctx",
+    "is_in_reentrant_top_level_backward",
+]

--- a/hyper_parallel/platform/torch/activation_checkpoint/reentrant_checkpoint.py
+++ b/hyper_parallel/platform/torch/activation_checkpoint/reentrant_checkpoint.py
@@ -1,0 +1,789 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Hook-free reentrant activation checkpoint with excluded regions for Torch.
+
+This module is intentionally independent from the public activation checkpoint
+entry points.  The outer checkpoint is a custom autograd function.  An excluded
+region records a small ordinary autograd graph during the original forward and
+reuses its detached output through another custom autograd bridge during replay.
+
+The prototype supports eager execution, top-level Tensor inputs, and Tensor or
+flat tuple/list Tensor outputs.  Selective checkpointing, activation swapping,
+nested Tensor input containers, autocast, and non-default generators are not
+supported yet.
+"""
+import contextlib
+import contextvars
+from collections import defaultdict
+from dataclasses import dataclass
+from functools import lru_cache
+import threading
+from typing import Any, Callable, Dict, Iterator, List, Optional, Sequence, Tuple
+import weakref
+
+import torch
+
+from hyper_parallel.core.activation_checkpoint.recompute_state import create_recompute_contexts
+from hyper_parallel.platform.torch.activation_checkpoint.activation_swap import ActivationWrapper, FuncModule
+
+
+_DEFAULT_REPLAY_KEY = object()
+
+
+@lru_cache(maxsize=1)
+def _get_tensor_type() -> type:
+    """Return the Torch Tensor type."""
+    return torch.Tensor
+
+
+def _is_tensor(value: Any) -> bool:
+    """Return whether *value* is a Torch Tensor."""
+    return isinstance(value, _get_tensor_type())
+
+
+def _tensor_leaves(value: Any) -> List[Any]:
+    """Collect Tensor leaves from supported Python containers."""
+    if _is_tensor(value):
+        return [value]
+    leaves = []
+    if isinstance(value, (tuple, list)):
+        for item in value:
+            leaves.extend(_tensor_leaves(item))
+    elif isinstance(value, dict):
+        for item in value.values():
+            leaves.extend(_tensor_leaves(item))
+    return leaves
+
+
+def _map_tensors(function: Callable[[Any], Any], value: Any) -> Any:
+    """Apply *function* to Tensor leaves while preserving container types."""
+    if _is_tensor(value):
+        return function(value)
+    if isinstance(value, list):
+        return [_map_tensors(function, item) for item in value]
+    if isinstance(value, tuple):
+        items = [_map_tensors(function, item) for item in value]
+        if hasattr(value, "_fields"):
+            return type(value)(*items)
+        return tuple(items)
+    if isinstance(value, dict):
+        return type(value)((key, _map_tensors(function, item)) for key, item in value.items())
+    return value
+
+
+def _detach_tree(value: Any, requires_grad: bool) -> Any:
+    """Detach Tensor leaves and optionally make differentiable leaves VJP roots."""
+    def detach(tensor: Any) -> Any:
+        """Detach one Tensor and preserve its differentiability when requested.
+
+        Args:
+            tensor: Tensor leaf to detach.
+        """
+        detached = tensor.detach()
+        differentiable = detached.is_floating_point() or detached.is_complex()
+        if requires_grad and differentiable:
+            detached.requires_grad_(True)
+        return detached
+
+    return _map_tensors(detach, value)
+
+
+def _validate_output(output: Any) -> None:
+    """Validate the output structure supported by the custom bridge."""
+    if _is_tensor(output):
+        return
+    if isinstance(output, (tuple, list)) and output and all(_is_tensor(item) for item in output):
+        return
+    raise ValueError(
+        "reentrant checkpoint currently requires a Tensor or a non-empty flat tuple/list of Tensors output"
+    )
+
+
+def _normalize_sensitivities(output: Any, sensitivity: Any) -> Tuple[Any, ...]:
+    """Flatten sensitivities and materialize zeros for unused outputs."""
+    output_tensors = tuple(_tensor_leaves(output))
+    if _is_tensor(output):
+        sensitivity_tensors = (sensitivity,)
+    elif isinstance(sensitivity, (tuple, list)):
+        sensitivity_tensors = tuple(sensitivity)
+    else:
+        sensitivity_tensors = tuple(_tensor_leaves(sensitivity))
+    if len(output_tensors) != len(sensitivity_tensors):
+        raise RuntimeError(
+            "The number of reentrant checkpoint output sensitivities does not match its Tensor outputs: "
+            f"expected {len(output_tensors)}, but got {len(sensitivity_tensors)}"
+        )
+    return tuple(
+        torch.zeros_like(tensor) if grad is None else grad
+        for tensor, grad in zip(output_tensors, sensitivity_tensors)
+    )
+
+
+def _differentiable_mask(tensors: Sequence[Any]) -> Tuple[bool, ...]:
+    """Return which tensors can participate in autograd."""
+    return tuple(tensor.requires_grad and (tensor.is_floating_point() or tensor.is_complex()) for tensor in tensors)
+
+
+class _VjpTape:
+    """Retain one eager autograd graph and expose a repeatable VJP."""
+
+    def __init__(self, output: Any, inputs: Sequence[Any], parameters: Sequence[Any]) -> None:
+        """Initialize a tape from a recorded output and its gradient targets."""
+        _validate_output(output)
+        self.output = output
+        self.inputs = tuple(inputs)
+        self.parameters = tuple(parameters)
+        self._input_mask = _differentiable_mask(self.inputs)
+        self._parameter_mask = _differentiable_mask(self.parameters)
+        self._released = False
+
+    @classmethod
+    def record(
+        cls,
+        function: Callable[..., Any],
+        args: Tuple[Any, ...],
+        kwargs: Dict[str, Any],
+        parameters: Sequence[Any],
+    ) -> "_VjpTape":
+        """Execute *function* with eager grad recording enabled.
+
+        Args:
+            function: Callable to record.
+            args: Positional arguments passed to the callable.
+            kwargs: Keyword arguments passed to the callable.
+            parameters: Parameters included as gradient targets.
+        """
+        with torch.enable_grad():
+            output = function(*args, **kwargs)
+        return cls(output, _tensor_leaves((args, kwargs)), parameters)
+
+    def vjp(self, sensitivity: Any, keep_graph: bool) -> Tuple[Tuple[Any, ...], Tuple[Any, ...]]:
+        """Calculate gradients for recorded inputs and parameters.
+
+        Args:
+            sensitivity: Output gradients supplied by the caller.
+            keep_graph: Whether to retain the local graph for another traversal.
+        """
+        if self._released:
+            raise RuntimeError("The retained reentrant checkpoint graph has already been released")
+        outputs = tuple(_tensor_leaves(self.output))
+        grad_outputs = _normalize_sensitivities(self.output, sensitivity)
+        targets = tuple(
+            tensor
+            for tensor, differentiable in zip(self.inputs + self.parameters, self._input_mask + self._parameter_mask)
+            if differentiable
+        )
+        if targets:
+            gradients = torch.autograd.grad(
+                outputs,
+                targets,
+                grad_outputs=grad_outputs,
+                allow_unused=True,
+                retain_graph=keep_graph,
+                create_graph=False,
+            )
+        else:
+            gradients = ()
+        gradient_iter = iter(gradients)
+        input_grads = tuple(next(gradient_iter) if differentiable else None for differentiable in self._input_mask)
+        parameter_grads = tuple(
+            next(gradient_iter) if differentiable else None for differentiable in self._parameter_mask
+        )
+        if not keep_graph:
+            self.release()
+        return input_grads, parameter_grads
+
+    def release(self) -> None:
+        """Release all Python references keeping the eager graph alive."""
+        self.output = None
+        self.inputs = ()
+        self.parameters = ()
+        self._released = True
+
+
+@dataclass(frozen=True)
+class _RngState:
+    """Store CPU and initialized accelerator default-generator states."""
+
+    cpu_state: Any
+    device_states: Dict[Tuple[str, int], Any]
+
+
+def _capture_rng_state(values: Any) -> _RngState:
+    """Capture default RNG states for CPU and Tensor devices in *values*."""
+    device_states = {}
+    devices = {
+        (tensor.device.type, tensor.device.index or 0)
+        for tensor in _tensor_leaves(values)
+        if tensor.device.type != "cpu"
+    }
+    for device_type, device_index in devices:
+        device_module = getattr(torch, device_type, None)
+        is_initialized = getattr(device_module, "is_initialized", None)
+        if device_module is None or (callable(is_initialized) and not is_initialized()):
+            continue
+        device_states[(device_type, device_index)] = device_module.get_rng_state(device_index)
+    return _RngState(torch.get_rng_state(), device_states)
+
+
+def _restore_rng_state(state: Optional[_RngState]) -> None:
+    """Restore a state captured by :func:`_capture_rng_state`."""
+    if state is None:
+        return
+    torch.set_rng_state(state.cpu_state)
+    for (device_type, device_index), device_state in state.device_states.items():
+        getattr(torch, device_type).set_rng_state(device_state, device_index)
+
+
+@dataclass(frozen=True)
+class _SessionState:
+    """Describe the active recompute session on the current thread."""
+
+    session_id: Any
+    retain_graph: bool
+
+
+_CURRENT_HANDLE_COLLECTOR: contextvars.ContextVar[Optional[List[Any]]] = contextvars.ContextVar(
+    "hyper_parallel_torch_reentrant_handle_collector",
+    default=None,
+)
+_CURRENT_SESSION: contextvars.ContextVar[Optional[_SessionState]] = contextvars.ContextVar(
+    "hyper_parallel_torch_reentrant_session",
+    default=None,
+)
+_SESSION_LOCK = threading.RLock()
+_SESSION_CALLS: Dict[Any, weakref.WeakSet] = defaultdict(weakref.WeakSet)
+
+
+@contextlib.contextmanager
+def reentrant_recompute_handle_collector_ctx() -> Iterator[List[Any]]:
+    """Collect reentrant checkpoint handles created by forward execution."""
+    handles = []
+    token = _CURRENT_HANDLE_COLLECTOR.set(handles)
+    try:
+        yield handles
+    finally:
+        _CURRENT_HANDLE_COLLECTOR.reset(token)
+
+
+@contextlib.contextmanager
+def reentrant_recompute_session_ctx(session_id: Any, retain_graph: bool = False) -> Iterator[None]:
+    """Bind replay selection and graph retention to the current thread.
+
+    Args:
+        session_id: Stable identifier shared by pre-fired replay and backward.
+        retain_graph: Retain outer replay and excluded local graphs for another
+            backward traversal.
+    """
+    token = _CURRENT_SESSION.set(_SessionState(session_id, retain_graph))
+    try:
+        yield
+    finally:
+        _CURRENT_SESSION.reset(token)
+
+
+def clear_reentrant_recompute_session(session_id: Any) -> None:
+    """Release all checkpoint graphs retained by *session_id*.
+
+    Args:
+        session_id: Identifier of the replay session to clear.
+    """
+    with _SESSION_LOCK:
+        calls = list(_SESSION_CALLS.pop(session_id, ()))
+    for call in calls:
+        call.clear_recompute_session(session_id)
+
+
+class _CheckpointInvocation:
+    """Own excluded-region graphs belonging to one checkpoint call."""
+
+    def __init__(self) -> None:
+        """Initialize an empty ordered call registry."""
+        self.exclude_entries: Dict[int, List[_ExcludeEntry]] = defaultdict(list)
+
+    def add_entry(self, wrapper_id: int, entry: "_ExcludeEntry") -> None:
+        """Append one original-forward excluded call.
+
+        Args:
+            wrapper_id: Identity of the exclusion wrapper.
+            entry: Retained graph for one invocation.
+        """
+        self.exclude_entries[wrapper_id].append(entry)
+
+    def get_entry(self, wrapper_id: int, index: int) -> "_ExcludeEntry":
+        """Return the excluded call matching replay order.
+
+        Args:
+            wrapper_id: Identity of the exclusion wrapper.
+            index: Invocation index within the wrapper.
+        """
+        entries = self.exclude_entries.get(wrapper_id)
+        if entries is None or index >= len(entries):
+            raise RuntimeError("Checkpoint replay executed an unmatched checkpoint exclusion wrapper call")
+        return entries[index]
+
+    def clear(self) -> None:
+        """Release all retained excluded-region graphs."""
+        for entries in self.exclude_entries.values():
+            for entry in entries:
+                entry.release()
+        self.exclude_entries.clear()
+
+
+class _ExecutionState:
+    """Expose one checkpoint invocation and phase to nested wrappers."""
+
+    def __init__(self, invocation: _CheckpointInvocation, recomputing: bool) -> None:
+        """Initialize forward or replay state."""
+        self.invocation = invocation
+        self.recomputing = recomputing
+        self._positions: Dict[int, int] = defaultdict(int)
+
+    def next_entry(self, wrapper_id: int) -> "_ExcludeEntry":
+        """Consume the next original call entry for *wrapper_id*.
+
+        Args:
+            wrapper_id: Identity of the exclusion wrapper.
+        """
+        index = self._positions[wrapper_id]
+        entry = self.invocation.get_entry(wrapper_id, index)
+        self._positions[wrapper_id] += 1
+        return entry
+
+
+_CURRENT_EXECUTION_STATE: contextvars.ContextVar[Optional[_ExecutionState]] = contextvars.ContextVar(
+    "hyper_parallel_torch_reentrant_execution_state",
+    default=None,
+)
+
+
+@contextlib.contextmanager
+def _execution_state_ctx(state: _ExecutionState) -> Iterator[None]:
+    """Install a checkpoint execution phase in the current dynamic scope."""
+    token = _CURRENT_EXECUTION_STATE.set(state)
+    try:
+        yield
+    finally:
+        _CURRENT_EXECUTION_STATE.reset(token)
+
+
+@contextlib.contextmanager
+def _stack_contexts(contexts: Sequence[Any]) -> Iterator[None]:
+    """Enter a sequence of contexts in order and exit them in reverse."""
+    with contextlib.ExitStack() as stack:
+        for context in contexts:
+            stack.enter_context(context)
+        yield
+
+
+def _create_phase_contexts(
+    context_fn: Optional[Callable[[], Tuple[Any, Any]]],
+) -> Tuple[Tuple[Any, ...], Tuple[Any, ...]]:
+    """Create framework and optional user contexts for both phases."""
+    pairs = [create_recompute_contexts()]
+    if context_fn is not None:
+        user_pair = context_fn()
+        if not isinstance(user_pair, tuple) or len(user_pair) != 2:
+            raise ValueError("context_fn must return a (forward_context, recompute_context) tuple")
+        pairs.append(user_pair)
+    return tuple(pair[0] for pair in pairs), tuple(pair[1] for pair in pairs)
+
+
+class _ExcludeEntry:
+    """Retain one excluded forward output and its local VJP graph."""
+
+    def __init__(self, output: Any, tape: _VjpTape, parameter_count: int, rng_state_after: Optional[_RngState]) -> None:
+        """Initialize one excluded call entry."""
+        self.output = output
+        self.tape = tape
+        self.input_count = len(tape.inputs)
+        self.parameter_count = parameter_count
+        self.rng_state_after = rng_state_after
+
+    def vjp(self, sensitivity: Any, keep_graph: bool) -> Tuple[Tuple[Any, ...], Tuple[Any, ...]]:
+        """Run the retained excluded-region backward graph.
+
+        Args:
+            sensitivity: Output gradients supplied by the bridge.
+            keep_graph: Whether to retain the graph for another traversal.
+        """
+        return self.tape.vjp(sensitivity, keep_graph)
+
+    def release(self) -> None:
+        """Release output and local VJP graph references."""
+        self.output = None
+        self.tape.release()
+
+
+@lru_cache(maxsize=1)
+def _get_exclude_replay_function() -> type:
+    """Create the private Torch custom autograd bridge lazily."""
+    class _ExcludeReplayFunction(torch.autograd.Function):
+        """Return a cached output and connect it to replay inputs in backward."""
+
+        @staticmethod
+        def forward(ctx: Any, entry: _ExcludeEntry, input_count: int, *tensors: Any) -> Any:
+            """Return the cached output without executing the excluded module.
+
+            Args:
+                ctx: Autograd context for the bridge call.
+                entry: Retained excluded-region graph.
+                input_count: Number of activation inputs.
+                tensors: Activation and parameter tensors attached to the bridge.
+            """
+            del tensors
+            ctx.entry = entry
+            ctx.input_count = input_count
+            return _detach_tree(entry.output, requires_grad=False)
+
+        @staticmethod
+        def backward(ctx: Any, *grad_outputs: Any) -> Tuple[Any, ...]:
+            """Route the bridge VJP through the original excluded graph.
+
+            Args:
+                ctx: Autograd context created in forward.
+                grad_outputs: Gradients of the cached outputs.
+            """
+            session = _CURRENT_SESSION.get()
+            keep_graph = session is not None and session.retain_graph
+            sensitivity = grad_outputs[0] if len(grad_outputs) == 1 else grad_outputs
+            input_grads, parameter_grads = ctx.entry.vjp(sensitivity, keep_graph)
+            if len(input_grads) != ctx.input_count:
+                raise RuntimeError(
+                    "Checkpoint exclusion input count changed between original forward and replay"
+                )
+            return (None, None, *input_grads, *parameter_grads)
+
+    return _ExcludeReplayFunction
+
+
+def _apply_exclude_replay(
+    entry: _ExcludeEntry,
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+    parameters: Sequence[Any],
+) -> Any:
+    """Apply an autograd bridge from current replay tensors to cached output."""
+    _restore_rng_state(entry.rng_state_after)
+    input_tensors = tuple(_tensor_leaves((args, kwargs)))
+    if len(input_tensors) != entry.input_count:
+        raise RuntimeError(
+            "Checkpoint exclusion Tensor input count changed between original forward and replay: "
+            f"expected {entry.input_count}, but got {len(input_tensors)}"
+        )
+    if len(parameters) != entry.parameter_count:
+        raise RuntimeError(
+            "Checkpoint exclusion parameter count changed between original forward and replay: "
+            f"expected {entry.parameter_count}, but got {len(parameters)}"
+        )
+    differentiable_tensors = input_tensors + tuple(parameters)
+    if not any(tensor.requires_grad for tensor in differentiable_tensors):
+        return _detach_tree(entry.output, requires_grad=False)
+    replay_function = _get_exclude_replay_function()
+    return replay_function.apply(entry, len(input_tensors), *differentiable_tensors)
+
+
+class ReentrantCheckpointExcludeWrapper(ActivationWrapper):
+    """Execute a region once and reuse its output during reentrant replay."""
+
+    def __init__(self, module: Callable[..., Any], save_rng_state: bool = True) -> None:
+        """Initialize a reentrant checkpoint exclusion wrapper.
+
+        Args:
+            module: Module or callable whose original forward graph is retained.
+            save_rng_state: Preserve the default generators around the excluded region.
+        """
+        if not callable(module):
+            raise ValueError("module must be a Torch Module or callable")
+        if not isinstance(module, torch.nn.Module):
+            module = FuncModule(module)
+        torch.nn.Module.__init__(self)
+        self._swap_wrapped_module = module
+        self._is_wrapped = False
+        self._register_state_dict_hook(self._post_state_dict_hook)
+        self.register_load_state_dict_pre_hook(self._pre_load_state_dict_hook)
+        self.save_rng_state = save_rng_state
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        """Record a local VJP in forward and insert a bridge during replay."""
+        state = _CURRENT_EXECUTION_STATE.get()
+        if state is None:
+            return self._wrapped_module(*args, **kwargs)  # pylint: disable=not-callable
+        parameters = tuple(self.parameters())
+        if state.recomputing:
+            entry = state.next_entry(id(self))
+            return _apply_exclude_replay(entry, args, kwargs, parameters)
+
+        detached_args = _detach_tree(args, requires_grad=True)
+        detached_kwargs = _detach_tree(kwargs, requires_grad=True)
+        tape = _VjpTape.record(self._wrapped_module, detached_args, detached_kwargs, parameters)
+        rng_state_after = None
+        if self.save_rng_state:
+            rng_state_after = _capture_rng_state((detached_args, detached_kwargs, parameters, tape.output))
+        entry = _ExcludeEntry(tape.output, tape, len(parameters), rng_state_after)
+        state.invocation.add_entry(id(self), entry)
+        return tape.output
+
+
+class _ReentrantCheckpointCall:
+    """Own the state and retained graphs for one checkpoint invocation."""
+
+    def __init__(
+        self,
+        module: Callable[..., Any],
+        args: Tuple[Any, ...],
+        kwargs: Dict[str, Any],
+        context_fn: Optional[Callable[[], Tuple[Any, Any]]],
+        save_rng_state: bool,
+    ) -> None:
+        """Initialize one checkpoint invocation."""
+        self._wrapped_module = module
+        self.context_fn = context_fn
+        self.save_rng_state = save_rng_state
+        self._invocation = _CheckpointInvocation()
+        self._original_args = args
+        self._original_kwargs = dict(kwargs)
+        self.parameters = tuple(module.parameters())
+        self._rng_state = _capture_rng_state((args, kwargs, self.parameters)) if save_rng_state else None
+        self._forward_contexts, self._recompute_contexts = _create_phase_contexts(context_fn)
+        self._replay_tapes: Dict[Any, _VjpTape] = {}
+        self._lock = threading.RLock()
+
+    @staticmethod
+    def validate_inputs(args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> None:
+        """Validate native reentrant-style top-level Tensor inputs.
+
+        Args:
+            args: Positional checkpoint arguments.
+            kwargs: Keyword checkpoint arguments.
+        """
+        has_tensor = False
+        for value in args + tuple(kwargs.values()):
+            if _is_tensor(value):
+                has_tensor = True
+                continue
+            if _tensor_leaves(value):
+                raise ValueError(
+                    "reentrant checkpoint does not yet support Tensor inputs nested in tuple/list/dict values"
+                )
+        if not has_tensor:
+            raise ValueError("reentrant checkpoint requires at least one Tensor input")
+
+    def run_forward(self) -> Any:
+        """Execute the original checkpoint forward without recording its graph."""
+        execution_state = _ExecutionState(self._invocation, recomputing=False)
+        with _stack_contexts(self._forward_contexts), _execution_state_ctx(execution_state), torch.no_grad():
+            output = self._wrapped_module(*self._original_args, **self._original_kwargs)
+        _validate_output(output)
+        collector = _CURRENT_HANDLE_COLLECTOR.get()
+        if collector is not None:
+            collector.append(self)
+        return output
+
+    @contextlib.contextmanager
+    def _replay_environment(self) -> Iterator[None]:
+        """Restore RNG and recompute contexts around replay."""
+        current_rng_state = None
+        if self.save_rng_state:
+            current_rng_state = _capture_rng_state((self._original_args, self._original_kwargs, self.parameters))
+            _restore_rng_state(self._rng_state)
+        execution_state = _ExecutionState(self._invocation, recomputing=True)
+        try:
+            with _stack_contexts(self._recompute_contexts), _execution_state_ctx(execution_state):
+                yield
+        finally:
+            _restore_rng_state(current_rng_state)
+
+    def _record_replay(self) -> _VjpTape:
+        """Replay the checkpoint function once and retain its eager graph."""
+        if self._original_args is None or self._original_kwargs is None:
+            raise RuntimeError("Cannot replay a reentrant checkpoint after its state was released")
+        replay_args = _detach_tree(self._original_args, requires_grad=True)
+        replay_kwargs = _detach_tree(self._original_kwargs, requires_grad=True)
+        with self._replay_environment():
+            return _VjpTape.record(self._wrapped_module, replay_args, replay_kwargs, self.parameters)
+
+    def recompute(self, session_id: Any) -> None:
+        """Pre-fire replay and retain its graph under *session_id*.
+
+        Args:
+            session_id: Identifier used by the later backward traversal.
+        """
+        with self._lock:
+            if session_id not in self._replay_tapes:
+                self._replay_tapes[session_id] = self._record_replay()
+        with _SESSION_LOCK:
+            _SESSION_CALLS[session_id].add(self)
+
+    def _get_replay_tape(self, replay_key: Any) -> _VjpTape:
+        """Get or lazily record the replay tape for one backward session."""
+        with self._lock:
+            tape = self._replay_tapes.get(replay_key)
+            if tape is None:
+                tape = self._record_replay()
+                self._replay_tapes[replay_key] = tape
+        if replay_key is not _DEFAULT_REPLAY_KEY:
+            with _SESSION_LOCK:
+                _SESSION_CALLS[replay_key].add(self)
+        return tape
+
+    def backward(self, sensitivity: Any) -> Tuple[Tuple[Any, ...], Tuple[Any, ...]]:
+        """Replay if needed and calculate checkpoint gradients.
+
+        Args:
+            sensitivity: Output gradients supplied to the custom backward.
+        """
+        session = _CURRENT_SESSION.get()
+        replay_key = session.session_id if session is not None else _DEFAULT_REPLAY_KEY
+        retain_graph = session is not None and session.retain_graph
+        tape = self._get_replay_tape(replay_key)
+        input_grads, parameter_grads = tape.vjp(sensitivity, keep_graph=retain_graph)
+        if not retain_graph:
+            self._finish_replay(replay_key)
+        return input_grads, parameter_grads
+
+    def _finish_replay(self, replay_key: Any) -> None:
+        """Drop replay and excluded graphs after their terminal consumer."""
+        with self._lock:
+            self._replay_tapes.pop(replay_key, None)
+        self._invocation.clear()
+        self._original_args = None
+        self._original_kwargs = None
+
+    def clear_recompute_session(self, session_id: Any) -> None:
+        """Release replay state retained by one schedule session.
+
+        Args:
+            session_id: Identifier of the replay session to clear.
+        """
+        with self._lock:
+            tape = self._replay_tapes.pop(session_id, None)
+        if tape is not None:
+            tape.release()
+        self._invocation.clear()
+        self._original_args = None
+        self._original_kwargs = None
+
+
+@lru_cache(maxsize=1)
+def _get_reentrant_checkpoint_function() -> type:
+    """Create the outer custom autograd checkpoint node lazily."""
+    class _ReentrantCheckpointFunction(torch.autograd.Function):
+        """Run forward without a graph and replay it from custom backward."""
+
+        @staticmethod
+        def forward(ctx: Any, call: _ReentrantCheckpointCall, input_count: int, *tensors: Any) -> Any:
+            """Execute and retain one original checkpoint invocation.
+
+            Args:
+                ctx: Autograd context for this checkpoint call.
+                call: Per-invocation checkpoint state.
+                input_count: Number of activation inputs.
+                tensors: Activation and parameter tensors attached to the node.
+            """
+            del tensors
+            ctx.call = call
+            ctx.input_count = input_count
+            return call.run_forward()
+
+        @staticmethod
+        def backward(ctx: Any, *grad_outputs: Any) -> Tuple[Any, ...]:
+            """Replay the checkpoint and return its gradients.
+
+            Args:
+                ctx: Autograd context created in forward.
+                grad_outputs: Gradients of checkpoint outputs.
+            """
+            sensitivity = grad_outputs[0] if len(grad_outputs) == 1 else grad_outputs
+            input_grads, parameter_grads = ctx.call.backward(sensitivity)
+            if len(input_grads) != ctx.input_count:
+                raise RuntimeError(
+                    "Checkpoint Tensor input count changed between original forward and replay"
+                )
+            return (None, None, *input_grads, *parameter_grads)
+
+    return _ReentrantCheckpointFunction
+
+
+class ReentrantCheckpointWrapper(ActivationWrapper):
+    """Wrap a Torch Module or callable with hook-free reentrant checkpointing."""
+
+    def __init__(
+        self,
+        module: Callable[..., Any],
+        context_fn: Optional[Callable[[], Tuple[Any, Any]]] = None,
+        save_rng_state: bool = True,
+    ) -> None:
+        """Initialize a reentrant checkpoint wrapper."""
+        if not callable(module):
+            raise ValueError("module must be a Torch Module or callable")
+        super().__init__(module)
+        self.context_fn = context_fn
+        self.save_rng_state = save_rng_state
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        """Create and execute one per-invocation reentrant checkpoint call."""
+        if not torch.is_grad_enabled():
+            return self._wrapped_module(*args, **kwargs)  # pylint: disable=not-callable
+        _ReentrantCheckpointCall.validate_inputs(args, kwargs)
+        call = _ReentrantCheckpointCall(
+            self._wrapped_module,
+            args,
+            kwargs,
+            context_fn=self.context_fn,
+            save_rng_state=self.save_rng_state,
+        )
+        input_tensors = tuple(_tensor_leaves((args, kwargs)))
+        checkpoint_function = _get_reentrant_checkpoint_function()
+        return checkpoint_function.apply(call, len(input_tensors), *input_tensors, *call.parameters)
+
+
+def reentrant_checkpoint_wrapper(
+    module: Callable[..., Any],
+    context_fn: Optional[Callable[[], Tuple[Any, Any]]] = None,
+    save_rng_state: bool = True,
+) -> ReentrantCheckpointWrapper:
+    """Wrap *module* with the experimental hook-free reentrant checkpoint.
+
+    Args:
+        module: Module or callable to checkpoint.
+        context_fn: Optional factory returning forward and replay contexts.
+        save_rng_state: Preserve default generators across replay.
+    """
+    return ReentrantCheckpointWrapper(module, context_fn=context_fn, save_rng_state=save_rng_state)
+
+
+def reentrant_checkpoint_exclude_wrapper(
+    module: Callable[..., Any],
+    save_rng_state: bool = True,
+) -> ReentrantCheckpointExcludeWrapper:
+    """Wrap a callable so its region is not executed during reentrant replay.
+
+    Args:
+        module: Module or callable to exclude.
+        save_rng_state: Advance default generators as in the original forward.
+    """
+    return ReentrantCheckpointExcludeWrapper(module, save_rng_state=save_rng_state)
+
+
+__all__ = [
+    "ReentrantCheckpointExcludeWrapper",
+    "ReentrantCheckpointWrapper",
+    "clear_reentrant_recompute_session",
+    "reentrant_checkpoint_exclude_wrapper",
+    "reentrant_checkpoint_wrapper",
+    "reentrant_recompute_handle_collector_ctx",
+    "reentrant_recompute_session_ctx",
+]

--- a/tests/mindspore/st/activation_checkpoint/reentrant_checkpoint.py
+++ b/tests/mindspore/st/activation_checkpoint/reentrant_checkpoint.py
@@ -1,0 +1,288 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""MindSpore correctness, performance, and memory checks for reentrant exclude."""
+import gc
+import math
+import statistics
+import time
+
+import numpy as np
+import psutil
+import pytest
+import mindspore as ms
+from mindspore import nn, ops, Tensor
+from mindspore.graph.api import _pynative_executor
+
+from hyper_parallel.platform.mindspore.activation_checkpoint.checkpoint_wrapper import ckpt_wrapper
+from hyper_parallel.platform.mindspore.activation_checkpoint.reentrant_checkpoint import (
+    reentrant_checkpoint_exclude_wrapper,
+    reentrant_checkpoint_wrapper,
+)
+from hyper_parallel.platform.mindspore.autograd_compat import enable_mindspore_backward_compat
+
+
+_MIB = 1024 * 1024
+
+enable_mindspore_backward_compat()
+ms.set_context(mode=ms.PYNATIVE_MODE)
+
+
+def _enable_compat_grad_recording() -> None:
+    """Restore grad flags cleared by the PyNative executor reset."""
+    _pynative_executor.set_enable_grad(True)
+    _pynative_executor.set_grad_flag(True)
+
+
+@pytest.fixture(autouse=True)
+def _clear_pynative_state():
+    """Isolate PyNative graphs and allocator state between test cases."""
+    _pynative_executor.clear_res()
+    _enable_compat_grad_recording()
+    yield
+    _pynative_executor.clear_res()
+    gc.collect()
+    ms.runtime.empty_cache()
+
+
+def _require_accelerator() -> None:
+    """Skip hardware-only checks when MindSpore targets CPU."""
+    if ms.get_context("device_target") == "CPU":
+        pytest.skip("device-memory validation requires an NPU or GPU")
+
+
+class _Middle(nn.Cell):
+    """Small parameterized nonlinear region that can be excluded."""
+
+    def __init__(self, calls: dict) -> None:
+        """Initialize a deterministic scale and shared call counter."""
+        super().__init__()
+        self.calls = calls
+        self.scale = ms.Parameter(Tensor(0.9, ms.float32), name="scale")
+
+    def construct(self, value: Tensor) -> Tensor:
+        """Apply the excluded nonlinear operation.
+
+        Args:
+            value: Input activation.
+        """
+        self.calls["middle"] += 1
+        return ops.tanh(value * self.scale)
+
+
+class _Workload(nn.Cell):
+    """Pointwise workload with an excluded region between two op sequences."""
+
+    def __init__(self, calls: dict, depth: int, exclude_middle: bool) -> None:
+        """Initialize the workload."""
+        super().__init__()
+        middle = _Middle(calls)
+        self.middle = reentrant_checkpoint_exclude_wrapper(middle) if exclude_middle else middle
+        self.depth = depth
+
+    def construct(self, value: Tensor) -> Tensor:
+        """Return a scalar loss with enough saved activations for memory checks.
+
+        Args:
+            value: Input activation.
+        """
+        for _ in range(self.depth):
+            value = ops.sin(value * 1.01) + value * 0.01
+        value = self.middle(value)
+        for _ in range(self.depth):
+            value = ops.cos(value * 0.99) + value * 0.01
+        return (value * value).mean()
+
+
+class _DispatchWorkload(nn.Cell):
+    """Small-tensor workload dominated by eager host dispatch."""
+
+    def __init__(self, depth: int = 40) -> None:
+        """Store the number of pointwise operator pairs."""
+        super().__init__()
+        self.depth = depth
+
+    def construct(self, value: Tensor) -> Tensor:
+        """Dispatch a fixed sequence of lightweight operators.
+
+        Args:
+            value: Input activation.
+        """
+        for _ in range(self.depth):
+            value = ops.sin(value) + value * 0.01
+        return value
+
+
+def _make_input(shape: tuple[int, ...]) -> Tensor:
+    """Create one deterministic differentiable Tensor."""
+    value = Tensor(np.linspace(-1.0, 1.0, num=math.prod(shape), dtype=np.float32).reshape(shape))
+    value.requires_grad = True
+    return value
+
+
+def _clear_parameter_grads(module: nn.Cell) -> None:
+    """Drop compatibility gradients before the next step."""
+    for parameter in module.trainable_params():
+        parameter.grad = None
+
+
+def _run_step(module: nn.Cell, shape: tuple[int, ...]) -> None:
+    """Run one compatibility-backward step and release graph roots."""
+    _clear_parameter_grads(module)
+    value = _make_input(shape)
+    loss = module(value)
+    loss.backward()
+    del loss
+    del value
+
+
+def _forward_peak_bytes(module: nn.Cell, shape: tuple[int, ...]) -> int:
+    """Measure device allocations added by one forward graph."""
+    gc.collect()
+    ms.runtime.empty_cache()
+    value = _make_input(shape)
+    ms.runtime.synchronize()
+    baseline = ms.runtime.memory_allocated()
+    ms.runtime.reset_peak_memory_stats()
+    output = module(value)
+    ms.runtime.synchronize()
+    peak_delta = ms.runtime.max_memory_allocated() - baseline
+    del output
+    del value
+    _pynative_executor.clear_res()
+    _enable_compat_grad_recording()
+    gc.collect()
+    ms.runtime.empty_cache()
+    return peak_delta
+
+
+def _measure_dispatch_seconds(module: nn.Cell, value: Tensor, iterations: int) -> float:
+    """Return median host submission time for forward-only iterations."""
+    for _ in range(5):
+        output = module(value)
+        del output
+    ms.runtime.synchronize()
+    samples = []
+    for _ in range(3):
+        start = time.perf_counter()
+        for _ in range(iterations):
+            output = module(value)
+            del output
+        samples.append(time.perf_counter() - start)
+        ms.runtime.synchronize()
+        gc.collect()
+    return statistics.median(samples)
+
+
+def test_reentrant_exclude_result_correctness() -> None:
+    """Compatibility backward should match eager values and all gradients."""
+    reference_calls = {"middle": 0}
+    actual_calls = {"middle": 0}
+    reference = _Workload(reference_calls, depth=3, exclude_middle=False)
+    actual = reentrant_checkpoint_wrapper(_Workload(actual_calls, depth=3, exclude_middle=True))
+    reference_input = _make_input((16, 64))
+    actual_input = _make_input((16, 64))
+
+    reference_loss = reference(reference_input)
+    reference_loss.backward()
+    actual_loss = actual(actual_input)
+    actual_loss.backward()
+
+    np.testing.assert_allclose(actual_loss.asnumpy(), reference_loss.asnumpy(), atol=1e-6, rtol=1e-6)
+    np.testing.assert_allclose(actual_input.grad.asnumpy(), reference_input.grad.asnumpy(), atol=1e-6, rtol=1e-5)
+    np.testing.assert_allclose(
+        actual.middle.scale.grad.asnumpy(), reference.middle.scale.grad.asnumpy(), atol=1e-6, rtol=1e-5
+    )
+    assert reference_calls == {"middle": 1}
+    assert actual_calls == {"middle": 1}
+
+
+def test_reentrant_checkpoint_device_peak_memory() -> None:
+    """Reentrant forward should retain materially less device activation memory."""
+    _require_accelerator()
+    reference = _Workload({"middle": 0}, depth=8, exclude_middle=False)
+    actual = reentrant_checkpoint_wrapper(_Workload({"middle": 0}, depth=8, exclude_middle=True))
+    shape = (1024, 1024)
+
+    reference_peak = _forward_peak_bytes(reference, shape)
+    actual_peak = _forward_peak_bytes(actual, shape)
+    print(
+        "MindSpore reentrant forward peak: "
+        f"actual={actual_peak / _MIB:.2f} MiB, reference={reference_peak / _MIB:.2f} MiB, "
+        f"ratio={actual_peak / reference_peak:.3f}"
+    )
+
+    assert actual_peak < reference_peak * 0.7, (
+        f"reentrant peak memory did not decrease enough: actual={actual_peak / _MIB:.2f} MiB, "
+        f"reference={reference_peak / _MIB:.2f} MiB"
+    )
+
+
+def test_reentrant_checkpoint_host_dispatch_performance() -> None:
+    """Hook-free forward dispatch should be faster than non-reentrant checkpoint."""
+    value = _make_input((64,))
+    non_reentrant = ckpt_wrapper(_DispatchWorkload())
+    reentrant = reentrant_checkpoint_wrapper(_DispatchWorkload())
+
+    non_reentrant_seconds = _measure_dispatch_seconds(non_reentrant, value, iterations=20)
+    reentrant_seconds = _measure_dispatch_seconds(reentrant, value, iterations=20)
+    print(
+        "MindSpore checkpoint host dispatch: "
+        f"reentrant={reentrant_seconds:.6f}s, non_reentrant={non_reentrant_seconds:.6f}s, "
+        f"speedup={non_reentrant_seconds / reentrant_seconds:.3f}x"
+    )
+
+    assert reentrant_seconds < non_reentrant_seconds, (
+        f"hook-free host dispatch was not faster: reentrant={reentrant_seconds:.6f}s, "
+        f"non_reentrant={non_reentrant_seconds:.6f}s"
+    )
+
+
+def test_reentrant_checkpoint_device_memory_no_leak() -> None:
+    """Repeated compatibility backward should not retain device allocations."""
+    _require_accelerator()
+    module = reentrant_checkpoint_wrapper(_Workload({"middle": 0}, depth=3, exclude_middle=True))
+    samples = []
+    for step in range(20):
+        _run_step(module, (64, 64))
+        ms.runtime.synchronize()
+        if step >= 5:
+            gc.collect()
+            samples.append(ms.runtime.memory_allocated())
+
+    growth = max(samples) - min(samples)
+    print(f"MindSpore steady-state device allocation range: {growth / _MIB:.2f} MiB")
+    assert max(samples) - min(samples) <= 4 * _MIB, (
+        f"device allocations grew across steady-state steps: {[value / _MIB for value in samples]}"
+    )
+
+
+def test_reentrant_checkpoint_host_memory_no_leak() -> None:
+    """Repeated compatibility-backward graphs should not cause sustained RSS growth."""
+    module = reentrant_checkpoint_wrapper(_Workload({"middle": 0}, depth=2, exclude_middle=True))
+    process = psutil.Process()
+    for _ in range(10):
+        _run_step(module, (32, 32))
+    ms.runtime.synchronize()
+    gc.collect()
+    baseline_rss = process.memory_info().rss
+
+    for _ in range(40):
+        _run_step(module, (32, 32))
+    ms.runtime.synchronize()
+    gc.collect()
+    growth = process.memory_info().rss - baseline_rss
+
+    print(f"MindSpore steady-state host RSS growth: {growth / _MIB:.2f} MiB")
+    assert growth <= 32 * _MIB, f"host RSS grew by {growth / _MIB:.2f} MiB"

--- a/tests/mindspore/st/activation_checkpoint/test_reentrant_checkpoint.py
+++ b/tests/mindspore/st/activation_checkpoint/test_reentrant_checkpoint.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Launch MindSpore reentrant-checkpoint validation on one Ascend device."""
+from tests.common.mark_utils import arg_mark
+from tests.common.parallel_case import parallel_run, MindSporeCase
+
+
+_CASE_FILE = "reentrant_checkpoint.py"
+_CASES = (
+    "test_reentrant_exclude_result_correctness",
+    "test_reentrant_checkpoint_device_peak_memory",
+    "test_reentrant_checkpoint_host_dispatch_performance",
+    "test_reentrant_checkpoint_device_memory_no_leak",
+    "test_reentrant_checkpoint_host_memory_no_leak",
+)
+
+
+@arg_mark(plat_marks=["platform_ascend910b"], level_mark="level1", card_mark="onecard", essential_mark="essential")
+def test_reentrant_checkpoint_validation() -> None:
+    """Run every validation in a clean process to isolate memory statistics.
+
+    Feature: Reentrant checkpoint exclusion.
+    Description: Run correctness, memory, dispatch, and leak cases independently.
+    Expectation: Every worker exits successfully and satisfies its assertions.
+    """
+    for index, case_name in enumerate(_CASES):
+        parallel_run([MindSporeCase(_CASE_FILE, case_name, 11660 + index, 1)])

--- a/tests/torch/activation_checkpoint/reentrant_checkpoint.py
+++ b/tests/torch/activation_checkpoint/reentrant_checkpoint.py
@@ -1,0 +1,278 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Torch correctness, performance, and memory checks for reentrant exclude."""
+import gc
+import statistics
+import time
+
+import psutil
+import pytest
+import torch
+from torch import nn
+
+from hyper_parallel.platform.torch.activation_checkpoint.checkpoint_wrapper import ckpt_wrapper
+from hyper_parallel.platform.torch.activation_checkpoint.reentrant_checkpoint import (
+    reentrant_checkpoint_exclude_wrapper,
+    reentrant_checkpoint_wrapper,
+)
+
+
+_MIB = 1024 * 1024
+
+
+def _get_device() -> torch.device:
+    """Return the active accelerator, falling back to CPU for correctness."""
+    if hasattr(torch, "npu") and torch.npu.is_available():
+        return torch.device("npu")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+def _require_accelerator() -> torch.device:
+    """Return an accelerator device or skip the hardware-only test."""
+    device = _get_device()
+    if device.type == "cpu":
+        pytest.skip("device-memory validation requires an NPU or GPU")
+    return device
+
+
+def _device_module(device: torch.device) -> object:
+    """Return the Torch device module exposing memory statistics."""
+    return getattr(torch, device.type)
+
+
+def _synchronize(device: torch.device) -> None:
+    """Wait for outstanding accelerator work when needed."""
+    if device.type != "cpu":
+        _device_module(device).synchronize()
+
+
+class _Middle(nn.Module):
+    """Small parameterized nonlinear region that can be excluded."""
+
+    def __init__(self, calls: dict) -> None:
+        """Initialize a deterministic scale and shared call counter."""
+        super().__init__()
+        self.calls = calls
+        self.scale = nn.Parameter(torch.tensor(0.9, dtype=torch.float32))
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        """Apply the excluded nonlinear operation.
+
+        Args:
+            value: Input activation.
+        """
+        self.calls["middle"] += 1
+        return torch.tanh(value * self.scale)
+
+
+class _Workload(nn.Module):
+    """Pointwise workload with an excluded region between two op sequences."""
+
+    def __init__(self, calls: dict, depth: int, exclude_middle: bool) -> None:
+        """Initialize the workload."""
+        super().__init__()
+        middle = _Middle(calls)
+        self.middle = reentrant_checkpoint_exclude_wrapper(middle) if exclude_middle else middle
+        self.depth = depth
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        """Return a scalar loss with enough saved activations for memory checks.
+
+        Args:
+            value: Input activation.
+        """
+        for _ in range(self.depth):
+            value = torch.sin(value * 1.01) + value * 0.01
+        value = self.middle(value)
+        for _ in range(self.depth):
+            value = torch.cos(value * 0.99) + value * 0.01
+        return (value * value).mean()
+
+
+class _DispatchWorkload(nn.Module):
+    """Small-tensor workload dominated by eager host dispatch."""
+
+    def __init__(self, depth: int = 40) -> None:
+        """Store the number of pointwise operator pairs."""
+        super().__init__()
+        self.depth = depth
+
+    def forward(self, value: torch.Tensor) -> torch.Tensor:
+        """Dispatch a fixed sequence of lightweight operators.
+
+        Args:
+            value: Input activation.
+        """
+        for _ in range(self.depth):
+            value = torch.sin(value) + value * 0.01
+        return value
+
+
+def _run_step(module: nn.Module, device: torch.device, shape: tuple[int, ...]) -> None:
+    """Run one complete backward step and promptly release graph roots."""
+    module.zero_grad(set_to_none=True)
+    value = torch.linspace(-1.0, 1.0, steps=int(torch.tensor(shape).prod()), device=device)
+    value = value.reshape(shape).requires_grad_(True)
+    loss = module(value)
+    loss.backward()
+    del loss
+    del value
+
+
+def _forward_peak_bytes(module: nn.Module, device: torch.device, shape: tuple[int, ...]) -> int:
+    """Measure device allocations added by one forward graph."""
+    device_api = _device_module(device)
+    gc.collect()
+    device_api.empty_cache()
+    value = torch.linspace(-1.0, 1.0, steps=int(torch.tensor(shape).prod()), device=device)
+    value = value.reshape(shape).requires_grad_(True)
+    _synchronize(device)
+    baseline = device_api.memory_allocated()
+    device_api.reset_peak_memory_stats()
+    output = module(value)
+    _synchronize(device)
+    peak_delta = device_api.max_memory_allocated() - baseline
+    del output
+    del value
+    gc.collect()
+    device_api.empty_cache()
+    return peak_delta
+
+
+def _measure_dispatch_seconds(module: nn.Module, value: torch.Tensor, iterations: int) -> float:
+    """Return median host submission time for forward-only iterations."""
+    device = value.device
+    for _ in range(5):
+        output = module(value)
+        del output
+    _synchronize(device)
+    samples = []
+    for _ in range(3):
+        start = time.perf_counter()
+        for _ in range(iterations):
+            output = module(value)
+            del output
+        samples.append(time.perf_counter() - start)
+        _synchronize(device)
+        gc.collect()
+    return statistics.median(samples)
+
+
+def test_reentrant_exclude_result_correctness() -> None:
+    """Values, input gradients, and parameter gradients should match eager mode."""
+    device = _get_device()
+    reference_calls = {"middle": 0}
+    actual_calls = {"middle": 0}
+    reference = _Workload(reference_calls, depth=3, exclude_middle=False).to(device)
+    actual = reentrant_checkpoint_wrapper(_Workload(actual_calls, depth=3, exclude_middle=True)).to(device)
+    actual.middle.scale.data.copy_(reference.middle.scale.data)
+    reference_input = torch.linspace(-1.0, 1.0, steps=1024, device=device).reshape(16, 64).requires_grad_(True)
+    actual_input = reference_input.detach().clone().requires_grad_(True)
+
+    reference_loss = reference(reference_input)
+    reference_loss.backward()
+    actual_loss = actual(actual_input)
+    actual_loss.backward()
+
+    torch.testing.assert_close(actual_loss, reference_loss, atol=1e-6, rtol=1e-6)
+    torch.testing.assert_close(actual_input.grad, reference_input.grad, atol=1e-6, rtol=1e-5)
+    torch.testing.assert_close(actual.middle.scale.grad, reference.middle.scale.grad, atol=1e-6, rtol=1e-5)
+    assert reference_calls == {"middle": 1}
+    assert actual_calls == {"middle": 1}
+
+
+def test_reentrant_checkpoint_device_peak_memory() -> None:
+    """Reentrant forward should retain materially less device activation memory."""
+    device = _require_accelerator()
+    reference = _Workload({"middle": 0}, depth=8, exclude_middle=False).to(device)
+    actual = reentrant_checkpoint_wrapper(_Workload({"middle": 0}, depth=8, exclude_middle=True)).to(device)
+    shape = (1024, 1024)
+
+    reference_peak = _forward_peak_bytes(reference, device, shape)
+    actual_peak = _forward_peak_bytes(actual, device, shape)
+    print(
+        "Torch reentrant forward peak: "
+        f"actual={actual_peak / _MIB:.2f} MiB, reference={reference_peak / _MIB:.2f} MiB, "
+        f"ratio={actual_peak / reference_peak:.3f}"
+    )
+
+    assert actual_peak < reference_peak * 0.7, (
+        f"reentrant peak memory did not decrease enough: actual={actual_peak / _MIB:.2f} MiB, "
+        f"reference={reference_peak / _MIB:.2f} MiB"
+    )
+
+
+def test_reentrant_checkpoint_host_dispatch_performance() -> None:
+    """Hook-free forward dispatch should be faster than non-reentrant checkpoint."""
+    device = _get_device()
+    value = torch.linspace(-1.0, 1.0, steps=64, device=device).requires_grad_(True)
+    non_reentrant = ckpt_wrapper(_DispatchWorkload())
+    reentrant = reentrant_checkpoint_wrapper(_DispatchWorkload())
+
+    non_reentrant_seconds = _measure_dispatch_seconds(non_reentrant, value, iterations=20)
+    reentrant_seconds = _measure_dispatch_seconds(reentrant, value, iterations=20)
+    print(
+        "Torch checkpoint host dispatch: "
+        f"reentrant={reentrant_seconds:.6f}s, non_reentrant={non_reentrant_seconds:.6f}s, "
+        f"speedup={non_reentrant_seconds / reentrant_seconds:.3f}x"
+    )
+
+    assert reentrant_seconds < non_reentrant_seconds, (
+        f"hook-free host dispatch was not faster: reentrant={reentrant_seconds:.6f}s, "
+        f"non_reentrant={non_reentrant_seconds:.6f}s"
+    )
+
+
+def test_reentrant_checkpoint_device_memory_no_leak() -> None:
+    """Repeated backward steps should not retain device graph allocations."""
+    device = _require_accelerator()
+    device_api = _device_module(device)
+    module = reentrant_checkpoint_wrapper(_Workload({"middle": 0}, depth=3, exclude_middle=True)).to(device)
+    samples = []
+    for step in range(20):
+        _run_step(module, device, (64, 64))
+        _synchronize(device)
+        if step >= 5:
+            gc.collect()
+            samples.append(device_api.memory_allocated())
+
+    growth = max(samples) - min(samples)
+    print(f"Torch steady-state device allocation range: {growth / _MIB:.2f} MiB")
+    assert max(samples) - min(samples) <= 4 * _MIB, (
+        f"device allocations grew across steady-state steps: {[value / _MIB for value in samples]}"
+    )
+
+
+def test_reentrant_checkpoint_host_memory_no_leak() -> None:
+    """Repeated checkpoint graphs should not cause sustained process RSS growth."""
+    device = _get_device()
+    module = reentrant_checkpoint_wrapper(_Workload({"middle": 0}, depth=2, exclude_middle=True)).to(device)
+    process = psutil.Process()
+    for _ in range(10):
+        _run_step(module, device, (32, 32))
+    _synchronize(device)
+    gc.collect()
+    baseline_rss = process.memory_info().rss
+
+    for _ in range(40):
+        _run_step(module, device, (32, 32))
+    _synchronize(device)
+    gc.collect()
+    growth = process.memory_info().rss - baseline_rss
+
+    print(f"Torch steady-state host RSS growth: {growth / _MIB:.2f} MiB")
+    assert growth <= 16 * _MIB, f"host RSS grew by {growth / _MIB:.2f} MiB"

--- a/tests/torch/activation_checkpoint/test_reentrant_checkpoint.py
+++ b/tests/torch/activation_checkpoint/test_reentrant_checkpoint.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Launch Torch reentrant-checkpoint validation cases on one Ascend device."""
+from tests.common.mark_utils import arg_mark
+from tests.common.parallel_case import parallel_run, TorchCase
+
+
+_CASE_FILE = "reentrant_checkpoint.py"
+_CASES = (
+    "test_reentrant_exclude_result_correctness",
+    "test_reentrant_checkpoint_device_peak_memory",
+    "test_reentrant_checkpoint_host_dispatch_performance",
+    "test_reentrant_checkpoint_device_memory_no_leak",
+    "test_reentrant_checkpoint_host_memory_no_leak",
+)
+
+
+@arg_mark(plat_marks=["platform_ascend910b"], level_mark="level1", card_mark="onecard", essential_mark="essential")
+def test_reentrant_checkpoint_validation() -> None:
+    """Run every validation in a clean process to isolate memory statistics.
+
+    Feature: Reentrant checkpoint exclusion.
+    Description: Run correctness, memory, dispatch, and leak cases independently.
+    Expectation: Every worker exits successfully and satisfies its assertions.
+    """
+    for index, case_name in enumerate(_CASES):
+        parallel_run([TorchCase(_CASE_FILE, case_name, 12520 + index, 1)])


### PR DESCRIPTION
Paired: [GitHub #67](https://github.com/mindspore-ai/hyper-parallel/pull/67) ↔ [GitCode !1538](https://gitcode.com/mindspore/hyper-parallel/merge_requests/1538)

/kind feature

----

**What does this PR do / why do we need it**:

新增基于自定义反向的 reentrant activation checkpoint 实现，避免
saved tensor hooks 对 PyNative 算子下发流水造成额外 host 开销。

- 为 MindSpore 和 Torch 后端提供一致的 reentrant checkpoint wrapper。
- 支持在 checkpoint 区域中排除指定子模块，使其仅执行一次。
- 通过局部 VJP graph 在重算反向阶段连接被排除区域。
- 保留并恢复随机数状态，保证随机算子的重算一致性。
- 支持流水调度预触发重算和多阶段反向图生命周期管理。
- MindSpore 使用参数梯度累积兼容路径，保留嵌套 FSDP hook 行为。
- 当前实现独立于已有 selective checkpoint 和 activation swap 入口。

----

**Which issue(s) this PR fixes**:

Fixes #

----

**Test Plan and Test result：What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

- AutoGit 静态检查通过。
- MindSpore Ascend 验证：5 项全部通过。
- Torch Ascend 验证：5 项全部通过。
- 输出、输入梯度及参数梯度与非重算路径一致。
- forward 峰值显存由 88.01 MiB 降至 24.00 MiB。
- MindSpore host 下发性能提升约 3.78x 至 4.16x。
- Torch host 下发性能提升约 1.75x 至 1.86x。
- device 稳态显存增长为 0 MiB。
- host RSS 未观察到持续增长。
- 已验证 exclude 区域仅执行一次。

----

**Self-checklist**:

- [ ] **设计**：PR对应的方案是否已经经过Maintainer评审
- [x] **测试**：新增测试用例已随本PR一并提交
- [x] **验证**：已包含功能、性能和内存验证结果
- [x] **接口**：当前实现未接入已有公共入口
- [x] **文档**：本次不涉及官网文档修改

<!-- atomgit-backport-meta -->
atomgit_repo: mindspore/hyper-parallel
atomgit_mr: 1290
source_branch: feat/reentrant-checkpoint-exclude
source_url: https://gitcode.com/mindspore/hyper-parallel/merge_requests/1290
<!-- /atomgit-backport-meta -->
