### PR TITLE
fix: defer MindSpore communication dump until wait

### DIFF
--- a/scripts/mindspore_op_stat_dump.py
+++ b/scripts/mindspore_op_stat_dump.py
@@ -1,0 +1,555 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""MindSpore operator statistics dumper.
+
+This helper wraps ``mindspore.MsDispatchMode`` and dumps per-operator tensor
+statistics into step-scoped CSV files so repeated runs can be diffed to locate
+the first nondeterministic operator.
+
+Example:
+    ```python
+    from scripts.mindspore_op_stat_dump import MindSporeOpStatDumpMode
+
+    op_dump = MindSporeOpStatDumpMode(
+        output_root="./op_stat_dump",
+        record_stack=True,
+        verbose=False,
+    )
+
+    for step, batch in enumerate(dataset):
+        op_dump.set_step(step)
+        with op_dump:
+            loss = train_step(batch)
+    ```
+"""
+
+import csv
+from dataclasses import dataclass, field
+from functools import wraps
+import logging
+import numbers
+import os
+from pathlib import Path
+import re
+from threading import RLock
+import traceback
+from typing import Any, Callable, Iterable, Iterator, Optional, Sequence, Tuple
+import zlib
+
+import numpy as np
+from mindspore import MsDispatchMode
+from mindspore._c_expression import CommHandle as NativeCommHandle, _DisableMsDispatchMode
+
+from hyper_parallel.platform import get_platform
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_OUTPUT_ROOT = "./mindspore_op_stat_dump"
+DEFAULT_IGNORED_OPS = {"StopGradient"}
+CSV_FIELDNAMES = [
+    "op_index",
+    "op_name",
+    "io_type",
+    "leaf_path",
+    "shape",
+    "dtype",
+    "numel",
+    "nbytes",
+    "l2_norm",
+    "crc32",
+    "completion_state",
+    "stack",
+]
+__all__ = ["MindSporeOpStatDumpMode"]
+
+COMM_INPLACE_OUTPUT_ARG_INDEX = {
+    "AllGather": 0,
+    "AllGatherIntoTensor": 0,
+    "AllGatherIntoTensorUneven": 0,
+    "AllReduce": 0,
+    "AllToAll": 0,
+    "AllToAllSingle": 0,
+    "AlltoAll": 0,
+    "AlltoAllV": 0,
+    "AlltoAllVC": 0,
+    "Broadcast": 0,
+    "Gather": 0,
+    "GatherIntoTensor": 0,
+    "Receive": 0,
+    "Recv": 0,
+    "Reduce": 0,
+    "ReduceScatter": 0,
+    "ReduceScatterTensor": 0,
+    "ReduceScatterTensorUneven": 0,
+    "Scatter": 0,
+    "ScatterTensor": 0,
+}
+
+platform = get_platform()
+
+
+@dataclass
+class _PendingCommRecord:
+    """Tensor outputs whose statistics become valid after communication wait."""
+
+    owner: "MindSporeOpStatDumpMode"
+    handles: dict[int, NativeCommHandle]
+    op_index: int
+    op_name: str
+    output_tree: Any
+    stack_text: str
+    csv_path: Path
+    _remaining_handle_ids: set[int] = field(init=False)
+    _lock: RLock = field(default_factory=RLock, init=False)
+
+    def __post_init__(self) -> None:
+        self._remaining_handle_ids = set(self.handles)
+
+    def mark_waited(self, handle: NativeCommHandle) -> None:
+        """Dump outputs once every native handle associated with the op has waited."""
+        should_complete = False
+        with self._lock:
+            self._remaining_handle_ids.discard(id(handle))
+            if not self._remaining_handle_ids:
+                should_complete = True
+        if should_complete:
+            self.owner._complete_pending_record(self)  # pylint: disable=W0212
+
+
+class _NativeCommWaitHook:
+    """Process-wide native CommHandle.wait hook with per-handle pending records."""
+
+    _lock = RLock()
+    _active_users = 0
+    _installed = False
+    _original_wait: Optional[Callable[..., Any]] = None
+    _records_by_handle_id: dict[int, list[_PendingCommRecord]] = {}
+
+    @classmethod
+    def acquire(cls) -> None:
+        """Install the native wait hook and retain one active dump context."""
+        with cls._lock:
+            if not cls._installed:
+                cls._install()
+            cls._active_users += 1
+
+    @classmethod
+    def release(cls) -> None:
+        """Release one dump context and restore wait when no pending work remains."""
+        with cls._lock:
+            cls._active_users = max(0, cls._active_users - 1)
+            cls._maybe_uninstall()
+
+    @classmethod
+    def register(cls, record: _PendingCommRecord) -> None:
+        """Associate one pending communication record with all of its handles."""
+        with cls._lock:
+            if not cls._installed:
+                cls._install()
+            for handle_id in record.handles:
+                cls._records_by_handle_id.setdefault(handle_id, []).append(record)
+
+    @classmethod
+    def pending_count(cls, owner: "MindSporeOpStatDumpMode") -> int:
+        """Return the number of unique pending records owned by a dump mode."""
+        with cls._lock:
+            return len({
+                id(record)
+                for records in cls._records_by_handle_id.values()
+                for record in records
+                if record.owner is owner
+            })
+
+    @classmethod
+    def _install(cls) -> None:
+        original_wait: Callable[..., Any] = NativeCommHandle.wait
+        cls._original_wait = original_wait
+
+        @wraps(original_wait)
+        def wait_with_dump(handle: NativeCommHandle, *args: Any, **kwargs: Any) -> Any:
+            """Delegate to native wait, then collect outputs registered for this handle."""
+            result = original_wait(handle, *args, **kwargs)
+            cls._on_wait_completed(handle)
+            return result
+
+        NativeCommHandle.wait = wait_with_dump
+        cls._installed = True
+
+    @classmethod
+    def _on_wait_completed(cls, handle: NativeCommHandle) -> None:
+        with cls._lock:
+            records = cls._records_by_handle_id.pop(id(handle), [])
+        for record in records:
+            record.mark_waited(handle)
+        with cls._lock:
+            cls._maybe_uninstall()
+
+    @classmethod
+    def _maybe_uninstall(cls) -> None:
+        if cls._installed and cls._active_users == 0 and not cls._records_by_handle_id:
+            NativeCommHandle.wait = cls._original_wait
+            cls._original_wait = None
+            cls._installed = False
+
+
+class MindSporeOpStatDumpMode(MsDispatchMode):
+    """Dump MindSpore operator tensor statistics into CSV files.
+
+    Args:
+        output_root: Root directory used to store dumped CSV files.
+        record_stack: Whether to record a compact Python call stack per op.
+        stack_limit: Maximum number of retained stack frames.
+        verbose: Whether to log one line for each dispatched op.
+        ignored_ops: Optional iterable of operator names to skip.
+        flush_every_op: Whether to flush the CSV file after each op.
+    """
+
+    def __init__(
+        self,
+        output_root: str = DEFAULT_OUTPUT_ROOT,
+        *,
+        record_stack: bool = False,
+        stack_limit: int = 12,
+        verbose: bool = False,
+        ignored_ops: Optional[Iterable[str]] = None,
+        flush_every_op: bool = True,
+    ) -> None:
+        """Initialize a step-aware MindSpore operator statistics dump mode."""
+        super().__init__()
+        self.output_root = Path(output_root)
+        self.record_stack = record_stack
+        self.stack_limit = stack_limit
+        self.verbose = verbose
+        self.flush_every_op = flush_every_op
+        self.ignored_ops = set(DEFAULT_IGNORED_OPS)
+        if ignored_ops is not None:
+            self.ignored_ops.update(ignored_ops)
+
+        self._rank: Optional[int] = None
+        self._step_value: Optional[Any] = None
+        self._step_dir_name = "step_unset"
+        self._op_index = 0
+        self._csv_files: dict[Path, Any] = {}
+        self._csv_writers: dict[Path, csv.DictWriter] = {}
+        self._csv_path: Optional[Path] = None
+        self._script_path = os.path.abspath(__file__)
+        self._state_lock = RLock()
+
+    def __enter__(self) -> "MindSporeOpStatDumpMode":
+        """Enter dispatch mode and install the native communication wait hook."""
+        _NativeCommWaitHook.acquire()
+        try:
+            return super().__enter__()
+        except Exception:
+            _NativeCommWaitHook.release()
+            raise
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback_value: Any) -> bool:
+        """Exit dispatch mode while retaining hooks needed by pending communication."""
+        try:
+            return super().__exit__(exc_type, exc_value, traceback_value)
+        finally:
+            _NativeCommWaitHook.release()
+
+    def set_step(self, step: Any) -> None:
+        """Switch the active dump directory for the given step."""
+        next_dir_name = self._format_step_dir(step)
+        if next_dir_name == self._step_dir_name and step == self._step_value:
+            return
+        self._step_value = step
+        self._step_dir_name = next_dir_name
+        self._op_index = 0
+
+    def step(self, step: Any) -> "MindSporeOpStatDumpMode":
+        """Set the active step and return ``self`` for chaining."""
+        self.set_step(step)
+        return self
+
+    def flush(self) -> None:
+        """Flush every open CSV file."""
+        with self._state_lock:
+            for csv_file in self._csv_files.values():
+                csv_file.flush()
+
+    def close(self) -> None:
+        """Close CSV files without forcing unfinished communication to wait."""
+        pending_count = _NativeCommWaitHook.pending_count(self)
+        if pending_count:
+            LOGGER.warning(
+                "closing MindSpore op dump with %s communication record(s) still waiting; "
+                "their outputs will be written if the handles are waited later",
+                pending_count,
+            )
+        self._close_csv_files()
+
+    def __ms_dispatch__(self, func, args=(), kwargs=None):
+        kwargs = {} if kwargs is None else kwargs
+        op_name = getattr(func, "name", type(func).__name__)
+        if op_name in self.ignored_ops:
+            return func(*args, **kwargs)
+
+        csv_path = self._current_csv_path()
+        with self._state_lock:
+            self._op_index += 1
+            op_index = self._op_index
+        stack_text = self._capture_stack() if self.record_stack else ""
+        input_tree = {"args": args, "kwargs": kwargs}
+        input_rows = self._build_rows(
+            op_index, op_name, "input", "input", input_tree, stack_text, "ready"
+        )
+        self._write_rows(input_rows, csv_path)
+
+        out = func(*args, **kwargs)
+
+        handles = self._find_native_comm_handles(out)
+        if handles:
+            output_tree = self._resolve_comm_output_tree(op_name, args, out)
+            record = _PendingCommRecord(
+                owner=self,
+                handles={id(handle): handle for handle in handles},
+                op_index=op_index,
+                op_name=op_name,
+                output_tree=output_tree,
+                stack_text=stack_text,
+                csv_path=csv_path,
+            )
+            _NativeCommWaitHook.register(record)
+        else:
+            output_rows = self._build_rows(
+                op_index, op_name, "output", "output", out, stack_text, "ready"
+            )
+            self._write_rows(output_rows, csv_path)
+        if self.verbose:
+            LOGGER.info(
+                "dumped op=%s step=%s rank=%s op_index=%s deferred=%s csv=%s",
+                op_name,
+                self._step_dir_name,
+                self._resolve_rank(),
+                op_index,
+                bool(handles),
+                csv_path,
+            )
+        return out
+
+    def __del__(self):
+        self._close_csv_files()
+
+    def _current_csv_path(self) -> Path:
+        rank = self._resolve_rank()
+        step_dir = self.output_root / self._step_dir_name
+        step_dir.mkdir(parents=True, exist_ok=True)
+        self._csv_path = step_dir / f"rank_{rank}.csv"
+        return self._csv_path
+
+    def _ensure_csv_writer(self, csv_path: Path) -> csv.DictWriter:
+        writer = self._csv_writers.get(csv_path)
+        if writer is not None:
+            return writer
+        is_new_file = not csv_path.exists() or csv_path.stat().st_size == 0
+        csv_file = csv_path.open("a", encoding="utf-8", newline="")
+        writer = csv.DictWriter(csv_file, fieldnames=CSV_FIELDNAMES)
+        self._csv_files[csv_path] = csv_file
+        self._csv_writers[csv_path] = writer
+        if is_new_file:
+            writer.writeheader()
+        return writer
+
+    def _close_csv_files(self) -> None:
+        state_lock = getattr(self, "_state_lock", None)
+        if state_lock is None:
+            return
+        with state_lock:
+            for csv_file in self._csv_files.values():
+                csv_file.close()
+            self._csv_files.clear()
+            self._csv_writers.clear()
+
+    def _resolve_rank(self) -> int:
+        if self._rank is not None:
+            return self._rank
+        try:
+            self._rank = int(platform.get_rank())
+            return self._rank
+        except Exception:  # pylint: disable=W0718
+            pass
+        for env_name in ("RANK_ID", "RANK", "OMPI_COMM_WORLD_RANK"):
+            env_value = os.environ.get(env_name)
+            if env_value is not None:
+                self._rank = int(env_value)
+                return self._rank
+        self._rank = 0
+        return self._rank
+
+    def _build_rows(
+        self,
+        op_index: int,
+        op_name: str,
+        io_type: str,
+        root_name: str,
+        tree: Any,
+        stack_text: str,
+        completion_state: str,
+    ) -> list[dict[str, Any]]:
+        rows = []
+        for leaf_path, leaf in self._iter_named_leaves(tree, root_name):
+            if not platform.is_tensor(leaf):
+                continue
+            tensor_stats = self._tensor_stats(leaf)
+            rows.append(
+                {
+                    "op_index": op_index,
+                    "op_name": op_name,
+                    "io_type": io_type,
+                    "leaf_path": leaf_path,
+                    "shape": tensor_stats["shape"],
+                    "dtype": tensor_stats["dtype"],
+                    "numel": tensor_stats["numel"],
+                    "nbytes": tensor_stats["nbytes"],
+                    "l2_norm": tensor_stats["l2_norm"],
+                    "crc32": tensor_stats["crc32"],
+                    "completion_state": completion_state,
+                    "stack": stack_text,
+                }
+            )
+        return rows
+
+    def _write_rows(self, rows: Sequence[dict[str, Any]], csv_path: Path) -> None:
+        if not rows:
+            return
+        with self._state_lock:
+            writer = self._ensure_csv_writer(csv_path)
+            for row in rows:
+                writer.writerow(row)
+            if self.flush_every_op:
+                self._csv_files[csv_path].flush()
+
+    def _complete_pending_record(self, record: _PendingCommRecord) -> None:
+        """Collect communication outputs after native wait has established stream ordering."""
+        with _DisableMsDispatchMode():
+            output_rows = self._build_rows(
+                record.op_index,
+                record.op_name,
+                "output",
+                "output",
+                record.output_tree,
+                record.stack_text,
+                "waited",
+            )
+            self._write_rows(output_rows, record.csv_path)
+
+    @staticmethod
+    def _find_native_comm_handles(tree: Any) -> list[NativeCommHandle]:
+        handles = []
+        seen_handle_ids = set()
+        for _, leaf in MindSporeOpStatDumpMode._iter_named_leaves(tree, "output"):
+            if isinstance(leaf, NativeCommHandle) and id(leaf) not in seen_handle_ids:
+                handles.append(leaf)
+                seen_handle_ids.add(id(leaf))
+        return handles
+
+    @staticmethod
+    def _resolve_comm_output_tree(op_name: str, args: tuple[Any, ...], out: Any) -> Any:
+        for _, leaf in MindSporeOpStatDumpMode._iter_named_leaves(out, "output"):
+            if platform.is_tensor(leaf):
+                return out
+        output_arg_index = COMM_INPLACE_OUTPUT_ARG_INDEX.get(op_name)
+        if output_arg_index is None:
+            # MindSpore's generated primitives use names such as
+            # ``DistCommAllReduce`` and ``InnerCommAllReduce``.
+            matching_names = (
+                name for name in COMM_INPLACE_OUTPUT_ARG_INDEX if op_name.endswith(name)
+            )
+            matched_name = max(matching_names, key=len, default=None)
+            if matched_name is not None:
+                output_arg_index = COMM_INPLACE_OUTPUT_ARG_INDEX[matched_name]
+        if output_arg_index is None or output_arg_index >= len(args):
+            return ()
+        return args[output_arg_index]
+
+    def _capture_stack(self) -> str:
+        frames = traceback.extract_stack()
+        formatted_frames = []
+        for frame in frames[:-2]:
+            frame_path = os.path.abspath(frame.filename)
+            if frame_path == self._script_path:
+                continue
+            if "/mindspore/" in frame_path:
+                continue
+            formatted_frames.append(f"{frame.filename}:{frame.lineno}:{frame.name}")
+        if self.stack_limit > 0:
+            formatted_frames = formatted_frames[-self.stack_limit:]
+        return " | ".join(formatted_frames)
+
+    @staticmethod
+    def _iter_named_leaves(tree: Any, prefix: str) -> Iterator[Tuple[str, Any]]:
+        if isinstance(tree, dict):
+            for key, value in tree.items():
+                child_prefix = f"{prefix}.{key}"
+                yield from MindSporeOpStatDumpMode._iter_named_leaves(value, child_prefix)
+            return
+        if isinstance(tree, tuple):
+            for index, value in enumerate(tree):
+                child_prefix = f"{prefix}[{index}]"
+                yield from MindSporeOpStatDumpMode._iter_named_leaves(value, child_prefix)
+            return
+        if isinstance(tree, list):
+            for index, value in enumerate(tree):
+                child_prefix = f"{prefix}[{index}]"
+                yield from MindSporeOpStatDumpMode._iter_named_leaves(value, child_prefix)
+            return
+        yield prefix, tree
+
+    @staticmethod
+    def _tensor_stats(tensor: Any) -> dict[str, Any]:
+        source_tensor = MindSporeOpStatDumpMode._tensor_to_numpy_ready(tensor)
+        array = np.ascontiguousarray(source_tensor.asnumpy())
+        payload = array.tobytes()
+        return {
+            "shape": str(tuple(array.shape)),
+            "dtype": str(tensor.dtype),
+            "numel": int(array.size),
+            "nbytes": int(array.nbytes),
+            "l2_norm": MindSporeOpStatDumpMode._l2_norm(array),
+            "crc32": f"{zlib.crc32(payload) & 0xFFFFFFFF:08x}",
+        }
+
+    @staticmethod
+    def _tensor_to_numpy_ready(tensor: Any) -> Any:
+        tensor_dtype = str(tensor.dtype).lower()
+        if "bfloat16" in tensor_dtype:
+            # MindSpore BF16 tensors cannot always be materialized via asnumpy directly.
+            return tensor.float()
+        return tensor
+
+    @staticmethod
+    def _l2_norm(array: np.ndarray) -> Any:
+        if array.size == 0:
+            return 0.0
+        try:
+            if np.issubdtype(array.dtype, np.complexfloating):
+                flat = np.abs(array.astype(np.complex128, copy=False).reshape(-1))
+            elif np.issubdtype(array.dtype, np.number) or np.issubdtype(array.dtype, np.bool_):
+                flat = array.astype(np.float64, copy=False).reshape(-1)
+            else:
+                return ""
+        except TypeError:
+            return ""
+        return float(np.linalg.norm(flat))
+
+    @staticmethod
+    def _format_step_dir(step: Any) -> str:
+        if isinstance(step, numbers.Integral):
+            return f"step_{int(step)}"
+        step_text = re.sub(r"[^0-9A-Za-z_.=-]", "_", str(step))
+        return f"step_{step_text}"

--- a/tests/mindspore/st/fully_shard/_test_mindspore_op_stat_dump.py
+++ b/tests/mindspore/st/fully_shard/_test_mindspore_op_stat_dump.py
@@ -1,0 +1,239 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""MindSpore FSDP + TP-MoE + Muon validation for deferred communication dump."""
+
+# The backend must be selected before importing HyperParallel.
+# pylint: disable=wrong-import-position
+
+import csv
+import os
+from pathlib import Path
+import tempfile
+
+os.environ["HYPER_PARALLEL_PLATFORM"] = "mindspore"
+
+import mindspore as ms
+import mindspore.communication.management as dist
+from mindspore import Tensor, nn, ops
+from mindspore._c_expression import NoFallbackGuard
+from mindspore.ops import communication as comm_ops
+import numpy as np
+
+from hyper_parallel import DTensor, SkipDTensorDispatch, init_device_mesh, shard_module
+from hyper_parallel.core.dtensor.placement_types import Replicate, Shard
+from hyper_parallel.core.fully_shard.api import fully_shard
+from hyper_parallel.core.fully_shard.utils import MixedPrecisionPolicy
+from hyper_parallel.core.shard.sharding_plan import ShardingPlan
+from hyper_parallel.platform.mindspore.autograd_compat import enable_mindspore_backward_compat
+from scripts.mindspore_op_stat_dump import MindSporeOpStatDumpMode
+
+enable_mindspore_backward_compat()
+
+
+class _TinyTPMoE(nn.Cell):
+    """Two-expert soft MoE whose expert output dimensions are tensor parallel."""
+
+    def __init__(self, input_size: int, output_size: int) -> None:
+        """Initialize deterministic expert weights."""
+        super().__init__()
+        rng = np.random.default_rng(2026)
+        self.expert_0_weight = ms.Parameter(
+            Tensor(rng.standard_normal((input_size, output_size)).astype(np.float32) * 0.05),
+            name="expert_0_weight",
+        )
+        self.expert_1_weight = ms.Parameter(
+            Tensor(rng.standard_normal((input_size, output_size)).astype(np.float32) * 0.05),
+            name="expert_1_weight",
+        )
+
+    def construct(self, inputs: Tensor) -> Tensor:
+        """Evaluate both TP experts and combine them with deterministic soft routing."""
+        expert_0 = ms.mint.matmul(inputs, self.expert_0_weight)
+        expert_1 = ms.mint.matmul(inputs, self.expert_1_weight)
+        return expert_0 * 0.375 + expert_1 * 0.625
+
+
+def _build_model(dp_mesh, tp_mesh) -> tuple[_TinyTPMoE, tuple[Replicate, ...]]:
+    """Apply expert tensor parallelism followed by FSDP parameter sharding."""
+    model = _TinyTPMoE(input_size=8, output_size=8)
+    input_placements = tuple(Replicate() for _ in range(tp_mesh.ndim))
+    expert_placements = (Shard(1),) + tuple(Replicate() for _ in range(tp_mesh.ndim - 1))
+    model = shard_module(
+        model,
+        device_mesh=tp_mesh,
+        sharding_plan=ShardingPlan(
+            plan={
+                "expert_0_weight": expert_placements,
+                "expert_1_weight": expert_placements,
+            },
+            input_plan={"input": input_placements},
+            output_plan={"output": expert_placements},
+        ),
+    )
+    model = fully_shard(
+        model,
+        mesh=dp_mesh,
+        reshard_after_forward=True,
+        mp_policy=MixedPrecisionPolicy(
+            param_dtype=ms.float32,
+            reduce_dtype=ms.float32,
+            output_dtype=ms.float32,
+            cast_forward_inputs=False,
+        ),
+    )
+    model.set_reduce_op_type("sum")
+    return model, input_placements
+
+
+def _to_local(tensor):
+    """Return the local tensor for either a Tensor or DTensor."""
+    return tensor.to_local() if isinstance(tensor, DTensor) else tensor
+
+
+def _zeropower_via_newton_schulz(gradient: Tensor, steps: int = 3) -> Tensor:
+    """Compute the Muon orthogonalized update for one local 2-D gradient shard."""
+    mat_x = ops.cast(gradient, ms.float32)
+    transposed = mat_x.shape[-2] > mat_x.shape[-1]
+    if transposed:
+        mat_x = ms.mint.transpose(mat_x, -2, -1)
+    mat_x = mat_x / (ms.mint.norm(mat_x) + 1e-7)
+    coefficients = (
+        (4.0848, -6.8946, 2.9270),
+        (3.9505, -6.3029, 2.6377),
+        (3.7418, -5.5913, 2.3037),
+    )
+    for coeff_a, coeff_b, coeff_c in coefficients[:steps]:
+        mat_a = ms.mint.matmul(mat_x, ms.mint.transpose(mat_x, -2, -1))
+        mat_b = coeff_b * mat_a + coeff_c * ms.mint.matmul(mat_a, mat_a)
+        mat_x = coeff_a * mat_x + ms.mint.matmul(mat_b, mat_x)
+    if transposed:
+        mat_x = ms.mint.transpose(mat_x, -2, -1)
+    return mat_x
+
+
+def _muon_step(parameters, learning_rate: float = 0.01, momentum: float = 0.95) -> None:
+    """Apply one test-local Muon step to FSDP-local expert parameter shards."""
+    for parameter in parameters:
+        gradient = _to_local(parameter.grad)
+        if gradient is None or gradient.ndim != 2:
+            continue
+        momentum_buffer = ops.zeros_like(gradient)
+        momentum_buffer = momentum * momentum_buffer + gradient
+        update = _zeropower_via_newton_schulz(momentum_buffer)
+        ops.assign_sub(parameter, ops.cast(learning_rate * update, parameter.dtype))
+
+
+def _run_training_step(model, tp_mesh, input_placements) -> None:
+    """Run FSDP + TP-MoE forward/backward and one Muon parameter update."""
+    rank = dist.get_rank()
+    rng = np.random.default_rng(1000 + rank // tp_mesh.size())
+    local_input = Tensor(rng.standard_normal((4, 8)).astype(np.float32))
+    local_target = Tensor(rng.standard_normal((4, 8)).astype(np.float32))
+    dist_input = DTensor.from_local(local_input, tp_mesh, input_placements)
+    dist_target = DTensor.from_local(local_target, tp_mesh, input_placements)
+
+    model.zero_grad()
+    prediction = model(dist_input)
+    target_shard = dist_target.redistribute(tp_mesh, prediction.placements)
+    loss = ms.mint.sum(ms.mint.square(prediction - target_shard))
+    if isinstance(loss, DTensor):
+        loss = loss.reduce_partial()
+    loss.backward(Tensor(1.0 / tp_mesh.size(), ms.float32))
+    with SkipDTensorDispatch(), NoFallbackGuard():
+        _muon_step(model.trainable_params())
+
+
+def _unpack_all_reduce_result(source: Tensor, result) -> tuple[Tensor, object]:
+    """Normalize MindSpore's in-place and out-of-place collective returns."""
+    if isinstance(result, tuple):
+        return result
+    return source, result
+
+
+def _run_sync_async_reference_collectives() -> None:
+    """Run equal synchronous and asynchronous AllReduce calls with a unique output shape."""
+    rank = dist.get_rank()
+    source = np.arange(7, dtype=np.float32) + float(rank)
+    sync_input = Tensor(source)
+    sync_output, _ = _unpack_all_reduce_result(
+        sync_input, comm_ops.all_reduce(sync_input, async_op=False)
+    )
+    async_input = Tensor(source)
+    async_output, async_handle = _unpack_all_reduce_result(
+        async_input, comm_ops.all_reduce(async_input, async_op=True)
+    )
+    assert async_handle is not None, "async AllReduce must return a communication handle"
+    async_handle.wait()
+    np.testing.assert_array_equal(sync_output.asnumpy(), async_output.asnumpy())
+
+
+def _assert_reference_dump_matches(csv_path: Path) -> None:
+    """Compare synchronous and asynchronous reference collective dump rows."""
+    with csv_path.open("r", encoding="utf-8", newline="") as csv_file:
+        rows = list(csv.DictReader(csv_file))
+    reference_rows = [
+        row for row in rows
+        if row["io_type"] == "output"
+        and row["shape"] == "(7,)"
+        and "allreduce" in row["op_name"].replace("_", "").lower()
+    ]
+    reference_rows.sort(key=lambda row: int(row["op_index"]))
+    assert len(reference_rows) >= 2, (
+        f"expected synchronous and asynchronous AllReduce output rows, got {reference_rows}"
+    )
+    sync_row, async_row = reference_rows[-2:]
+    assert sync_row["completion_state"] == "waited"
+    assert async_row["completion_state"] == "waited"
+    assert sync_row["crc32"] == async_row["crc32"]
+    assert sync_row["l2_norm"] == async_row["l2_norm"]
+
+
+def test_fsdp_tp_moe_muon_async_dump_matches_sync() -> None:
+    """
+    Feature: Native CommHandle.wait based operator statistics collection.
+    Description: Run a 4-rank `(fsdp=2, tp=2)` soft-MoE training step with
+        expert TP, outer FSDP, and a test-local Muon update. Then run the same
+        uniquely-shaped AllReduce synchronously and asynchronously under the
+        dump mode.
+    Expectation: Both communication outputs are collected after native wait and
+        have identical CRC32 and L2 norm.
+    """
+    dist.init()
+    world_size = dist.get_group_size()
+    assert world_size == 4, f"this case requires 4 ranks, got {world_size}"
+    root_mesh = init_device_mesh(
+        device_type="npu",
+        mesh_shape=(2, 2),
+        mesh_dim_names=("fsdp", "tp"),
+    )
+    dp_mesh = root_mesh["fsdp"]
+    tp_mesh = root_mesh["tp"]
+    model, input_placements = _build_model(dp_mesh, tp_mesh)
+
+    with tempfile.TemporaryDirectory(prefix=f"hp_op_dump_rank_{dist.get_rank()}_") as output_root:
+        dump_mode = MindSporeOpStatDumpMode(output_root, flush_every_op=True)
+        dump_mode.set_step(0)
+        with dump_mode:
+            _run_training_step(model, tp_mesh, input_placements)
+            _run_sync_async_reference_collectives()
+        dump_mode.close()
+        _assert_reference_dump_matches(
+            Path(output_root) / "step_0" / f"rank_{dist.get_rank()}.csv"
+        )
+
+    print(
+        f"[rank{dist.get_rank()}] FSDP+TP-MoE+Muon async dump matches sync: PASS",
+        flush=True,
+    )

--- a/tests/mindspore/st/fully_shard/test_mindspore_op_stat_dump.py
+++ b/tests/mindspore/st/fully_shard/test_mindspore_op_stat_dump.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Launch MindSpore communication dump validation on FSDP + TP-MoE + Muon."""
+
+from tests.common.mark_utils import arg_mark
+from tests.mindspore.st.utils import msrun_case
+
+_FILE_NAME = "_test_mindspore_op_stat_dump.py"
+
+
+@arg_mark(
+    plat_marks=["platform_ascend910b"],
+    level_mark="level1",
+    card_mark="allcards",
+    essential_mark="essential",
+)
+def test_fsdp_tp_moe_muon_async_dump_matches_sync() -> None:
+    """
+    Feature: Deferred MindSpore communication output dump.
+    Description: Run FSDP + TP-MoE + test-local Muon on four ranks, then compare
+        synchronous and asynchronous AllReduce output statistics.
+    Expectation: The wait-hook output CRC32 and L2 norm match the synchronous reference.
+    """
+    msrun_case(
+        3,
+        _FILE_NAME,
+        "test_fsdp_tp_moe_muon_async_dump_matches_sync",
+        18634,
+        worker_num=4,
+        local_worker_num=4,
+    )

--- a/tests/ut/test_mindspore_op_stat_dump.py
+++ b/tests/ut/test_mindspore_op_stat_dump.py
@@ -1,0 +1,251 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Unit tests for the MindSpore operator statistics dump wait hook."""
+
+import csv
+from contextlib import ExitStack
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+from types import ModuleType
+from typing import Any, Callable
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+
+
+class _FakeMsDispatchMode:
+    """Minimal context-manager replacement for MindSpore MsDispatchMode."""
+
+    def __enter__(self) -> "_FakeMsDispatchMode":
+        """Enter the fake dispatch mode."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback_value: Any) -> bool:
+        """Exit the fake dispatch mode without suppressing exceptions."""
+        return False
+
+
+class _FakeDisableMsDispatchMode:
+    """Track whether deferred tensor statistics disable MindSpore dispatch."""
+
+    depth = 0
+
+    def __enter__(self) -> "_FakeDisableMsDispatchMode":
+        """Mark MindSpore dispatch as disabled for the current fake scope."""
+        type(self).depth += 1
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback_value: Any) -> bool:
+        """Restore the fake dispatch state."""
+        type(self).depth -= 1
+        return False
+
+
+class _FakeTensor:
+    """Numpy-backed Tensor stub with a BF16 conversion guard."""
+
+    float_dispatch_depths = []
+
+    def __init__(self, value: Any, dtype: str = "Float32") -> None:
+        """Initialize a numpy-backed fake tensor."""
+        self.value = np.asarray(value)
+        self.dtype = dtype
+
+    def set_value(self, value: Any) -> None:
+        """Replace the fake device value when communication completes."""
+        self.value = np.asarray(value)
+
+    def asnumpy(self) -> np.ndarray:
+        """Return a host copy of the fake tensor value."""
+        return self.value.copy()
+
+    def float(self) -> "_FakeTensor":
+        """Convert to Float32 while recording the dispatch-disable depth."""
+        type(self).float_dispatch_depths.append(_FakeDisableMsDispatchMode.depth)
+        return _FakeTensor(self.value.astype(np.float32), dtype="Float32")
+
+
+class _FakeNativeCommHandle:
+    """Native communication handle stub whose wait materializes an output."""
+
+    def __init__(self, on_wait: Callable[[], None]) -> None:
+        """Initialize the completion callback."""
+        self._on_wait = on_wait
+        self.wait_count = 0
+
+    def wait(self) -> None:
+        """Materialize the fake communication output."""
+        self.wait_count += 1
+        self._on_wait()
+
+
+class _FakePlatform:
+    """Platform methods used by the dump helper."""
+
+    @staticmethod
+    def get_rank() -> int:
+        """Return the single-process fake rank."""
+        return 0
+
+    @staticmethod
+    def is_tensor(value: Any) -> bool:
+        """Identify fake tensors."""
+        return isinstance(value, _FakeTensor)
+
+
+class _FakeOp:
+    """Callable OpFunc replacement with a MindSpore-style name property."""
+
+    def __init__(self, name: str, callback: Callable[..., Any]) -> None:
+        """Initialize the fake operator name and callback."""
+        self.name = name
+        self._callback = callback
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Invoke the fake underlying operator."""
+        return self._callback(*args, **kwargs)
+
+
+def _read_rows(output_root: Path, step: int = 0) -> list[dict[str, str]]:
+    csv_path = output_root / f"step_{step}" / "rank_0.csv"
+    with csv_path.open("r", encoding="utf-8", newline="") as csv_file:
+        return list(csv.DictReader(csv_file))
+
+
+def _run_collective(dump_module, output_root: Path, wait_immediately: bool) -> list[dict[str, str]]:
+    output = _FakeTensor(np.zeros(4, dtype=np.float32))
+    handle = _FakeNativeCommHandle(
+        lambda: output.set_value(np.asarray([2.0, 4.0, 6.0, 8.0], dtype=np.float32))
+    )
+    op = _FakeOp("AllGatherIntoTensor", lambda *_args, **_kwargs: (output, handle))
+    dump_mode = dump_module.MindSporeOpStatDumpMode(str(output_root))
+    dump_mode.set_step(0)
+
+    with dump_mode:
+        result = dump_mode.__ms_dispatch__(op, (_FakeTensor([1.0]),), {})
+        if not wait_immediately:
+            rows_before_wait = _read_rows(output_root)
+            assert not [row for row in rows_before_wait if row["io_type"] == "output"]
+        result[1].wait()
+    dump_mode.close()
+    return _read_rows(output_root)
+
+
+class TestMindSporeOpStatDump(unittest.TestCase):
+    """Validate deferred communication collection without a MindSpore runtime."""
+
+    def setUp(self) -> None:
+        """Load the dump helper against small MindSpore/platform stubs."""
+        self.original_wait = _FakeNativeCommHandle.wait
+        _FakeTensor.float_dispatch_depths.clear()
+        mindspore_module = ModuleType("mindspore")
+        mindspore_module.MsDispatchMode = _FakeMsDispatchMode
+        c_expression_module = ModuleType("mindspore._c_expression")
+        c_expression_module.CommHandle = _FakeNativeCommHandle
+        c_expression_module._DisableMsDispatchMode = _FakeDisableMsDispatchMode
+        platform_module = ModuleType("hyper_parallel.platform")
+        platform_module.get_platform = _FakePlatform
+
+        module_name = "_test_mindspore_op_stat_dump"
+        script_path = Path(__file__).parents[2] / "scripts" / "mindspore_op_stat_dump.py"
+        spec = importlib.util.spec_from_file_location(module_name, script_path)
+        self.module = importlib.util.module_from_spec(spec)
+        self.assertIsNotNone(spec.loader)
+        with patch.dict(
+            sys.modules,
+            {
+                "mindspore": mindspore_module,
+                "mindspore._c_expression": c_expression_module,
+                "hyper_parallel.platform": platform_module,
+                module_name: self.module,
+            },
+        ):
+            spec.loader.exec_module(self.module)
+        self.exit_stack = ExitStack()
+        temp_dir = self.exit_stack.enter_context(tempfile.TemporaryDirectory())
+        self.output_root = Path(temp_dir)
+
+    def tearDown(self) -> None:
+        """Check that every test releases the global wait hook and temporary files."""
+        self.assertEqual(self.module._NativeCommWaitHook._active_users, 0)
+        self.assertFalse(self.module._NativeCommWaitHook._records_by_handle_id)
+        self.assertIs(_FakeNativeCommHandle.wait, self.original_wait)
+        self.exit_stack.close()
+
+    def test_async_wait_output_matches_synchronous_wait(self) -> None:
+        """Deferred async output has the same statistics as an immediate synchronous wait."""
+        sync_rows = _run_collective(self.module, self.output_root / "sync", wait_immediately=True)
+        async_rows = _run_collective(self.module, self.output_root / "async", wait_immediately=False)
+
+        sync_output = [row for row in sync_rows if row["io_type"] == "output"]
+        async_output = [row for row in async_rows if row["io_type"] == "output"]
+        self.assertEqual(len(sync_output), 1)
+        self.assertEqual(len(async_output), 1)
+        self.assertEqual(sync_output[0]["crc32"], async_output[0]["crc32"])
+        self.assertEqual(sync_output[0]["l2_norm"], async_output[0]["l2_norm"])
+        self.assertEqual(async_output[0]["completion_state"], "waited")
+        self.assertEqual(async_output[0]["op_index"], "1")
+
+    def test_inplace_bfloat16_output_is_collected_after_wait_with_dispatch_disabled(self) -> None:
+        """In-place communication resolves args[0] and disables dispatch during BF16 statistics."""
+        output = _FakeTensor(np.zeros(2, dtype=np.float32), dtype="BFloat16")
+        handle = _FakeNativeCommHandle(
+            lambda: output.set_value(np.asarray([3.0, 5.0], dtype=np.float32))
+        )
+        op = _FakeOp("DistCommAllReduce", lambda *_args, **_kwargs: handle)
+        dump_mode = self.module.MindSporeOpStatDumpMode(str(self.output_root))
+        dump_mode.set_step(0)
+
+        with dump_mode:
+            result = dump_mode.__ms_dispatch__(op, (output,), {})
+            self.assertIs(result, handle)
+            self.assertFalse([row for row in _read_rows(self.output_root) if row["io_type"] == "output"])
+            result.wait()
+            result.wait()
+        dump_mode.close()
+
+        output_rows = [row for row in _read_rows(self.output_root) if row["io_type"] == "output"]
+        self.assertEqual(len(output_rows), 1)
+        self.assertEqual(output_rows[0]["dtype"], "BFloat16")
+        self.assertEqual(output_rows[0]["l2_norm"], str(np.linalg.norm(np.asarray([3.0, 5.0]))))
+        self.assertEqual(handle.wait_count, 2)
+        self.assertEqual(_FakeTensor.float_dispatch_depths, [0, 1])
+        self.assertEqual(_FakeDisableMsDispatchMode.depth, 0)
+
+    def test_pending_output_keeps_launch_step_after_step_switch(self) -> None:
+        """A communication completed after set_step writes to its launch-step CSV."""
+        output = _FakeTensor(np.zeros(1, dtype=np.float32))
+        handle = _FakeNativeCommHandle(lambda: output.set_value(np.asarray([7.0], dtype=np.float32)))
+        op = _FakeOp("ReduceScatterTensor", lambda *_args, **_kwargs: (output, handle))
+        dump_mode = self.module.MindSporeOpStatDumpMode(str(self.output_root))
+        dump_mode.set_step(0)
+
+        with dump_mode:
+            dump_mode.__ms_dispatch__(op, (_FakeTensor([1.0]),), {})
+            dump_mode.set_step(1)
+            handle.wait()
+        dump_mode.close()
+
+        output_rows = [row for row in _read_rows(self.output_root, step=0) if row["io_type"] == "output"]
+        self.assertEqual(len(output_rows), 1)
+        self.assertEqual(output_rows[0]["completion_state"], "waited")
+        self.assertFalse((self.output_root / "step_1" / "rank_0.csv").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Paired: [GitHub #76](https://github.com/mindspore-ai/hyper-parallel/pull/76) ↔ [GitCode !1558](https://gitcode.com/mindspore/hyper-parallel/merge_requests/1558)

**What type of PR is this?**

/kind bug

----

**What does this PR do / why do we need it**:

MindSpore 通信算子支持异步执行，dispatch 返回时输出 Tensor 的数据可能尚未就绪。
原 dump 工具在 dispatch 阶段立即执行 Host CRC32 和 L2 统计，
可能读取未完成通信的数据并生成错误结果。

本 PR 保持 Host CRC32 统计方案，不引入设备侧 XOR 或额外编译依赖。

主要修改如下：

- 新增 `MindSporeOpStatDumpMode`，按 step 和 rank 输出算子输入输出统计。
- dispatch 阶段递归识别原生 `CommHandle`，登记待采集的通信输出。
- hook 原生 `CommHandle.wait`，在真实 wait 成功返回后采集通信输出。
- 支持返回值携带 Tensor 的非原地通信，以及输出位于参数中的原地通信。
- 支持一个通信算子关联多个 handle，并确保重复 wait 不会重复写入。
- 延迟采集通过 `_DisableMsDispatchMode` 禁用 dispatch，避免 BF16 转换等统计操作被再次记录。
- 待完成通信保留启动时的 step、op index 和 CSV 路径，避免跨 step 写错文件。
- CSV 增加 `op_index` 和 `completion_state` 字段，通信完成后的输出标记为 `waited`。

本次共新增 4 个文件，新增 1088 行：
- `scripts/mindspore_op_stat_dump.py`
- MindSpore FSDP + TP-MoE + Muon 分布式验证文件及启动入口
- MindSpore dump wait-hook 单元测试

----

**Which issue(s) this PR fixes**:

无关联 Issue。

----

**Test Plan and Test result：What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

- MindSpore dump 单元测试共 3 个场景，全部通过。
- 验证同步与异步通信输出的 CRC32、L2 统计一致。
- 验证 wait 前不写通信输出，wait 后只写一次。
- 验证原地 BF16 通信及跨 step 延迟完成场景。
- Python 语法编译检查通过。
- Pylint 检查通过。
- `git diff --check` 检查通过。
- PR 自动 UT/ST 门禁按调试工具场景跳过。
- 4 卡 FSDP + TP-MoE + Muon ST 已随 PR 提交；当前环境 MindSpore 2.8.0
  缺少 `MsDispatchMode` 和 `_DisableMsDispatchMode`，未在本机实际执行。

----

**Self-checklist**:

- [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
- [x] **测试**：PR中的代码已有UT/ST测试用例进行覆盖，新增测试用例已随本PR一并提交
- [x] **验证**：PR描述已包含本次Bugfix预期目标的详细验证结果
- [ ] **接口**：新增调试工具入口尚未经过接口评审
- [x] **文档**：本次不涉及官网文档修改

<!-- atomgit-backport-meta -->
atomgit_repo: mindspore/hyper-parallel
atomgit_mr: 1214
source_branch: hyper-parallel-dump
source_url: https://gitcode.com/mindspore/hyper-parallel/merge_requests/1214
<!-- /atomgit-backport-meta -->
