### PR TITLE
feat: 优化连续 SAVE 区域的输出显存

### DIFF
--- a/docs/api/api_reference.md
+++ b/docs/api/api_reference.md
@@ -900,11 +900,20 @@ checkpoint_wrapper(module, **checkpoint_kwargs) -> CheckpointWrapper
 重算阶段直接复用前向输出，以额外显存占用换取计算开销降低。
 
 ```python
-checkpoint_exclude_wrapper(module) -> CheckpointExcludeWrapper
+checkpoint_exclude_wrapper(
+    module,
+    *,
+    save_output: bool = True,
+) -> CheckpointExcludeWrapper
 ```
 
 当前仅支持 MindSpore PyNative 模式，并且需要在 HyperParallel 的 `checkpoint` 或
 `checkpoint_wrapper`（`use_reentrant=False`）内部使用。支持包装 MindSpore Cell 和普通 callable。
+
+`save_output=False` 用于连续 SAVE 区域的中间节点：该区域内部通过 saved-tensor hooks 保存的反向激活
+保持不变，但其边界输出不会为 replay 常驻显存。此时区域返回值必须作为一个参数整体直接传给另一个
+`checkpoint_exclude_wrapper`，不能在中间被解包、被 replay 中执行的普通算子读取，也不能作为 checkpoint
+的最终输出。
 
 ---
 

--- a/docs/guide/activation_checkpoint.md
+++ b/docs/guide/activation_checkpoint.md
@@ -81,6 +81,7 @@ SwapManager().set_forward_prefetch_layer(model.layers[i], model.layers[i + 1])
 from hyper_parallel.core.activation_checkpoint import (
     CheckpointPolicy,
     SwapManager,
+    checkpoint_exclude_wrapper,
     checkpoint_wrapper,
     swap_wrapper,
 )
@@ -95,6 +96,10 @@ def recompute_policy(ctx, op, *args, **kwargs):
     return CheckpointPolicy.MUST_RECOMPUTE
 
 model.layers[1] = checkpoint_wrapper(model.layers[1], policy_fn=recompute_policy)
+
+# 连续 SAVE 区域只保留链尾输出；两个区域内部为 backward 保存的激活不受影响。
+model.expensive_a = checkpoint_exclude_wrapper(model.expensive_a, save_output=False)
+model.expensive_b = checkpoint_exclude_wrapper(model.expensive_b)
 
 # 用 swap_wrapper 替换模块：模块 forward 中保存的中间激活会按策略 offload 到 CPU
 def tensor_swap_policy(tensor):

--- a/hyper_parallel/core/activation_checkpoint/activation_checkpoint.py
+++ b/hyper_parallel/core/activation_checkpoint/activation_checkpoint.py
@@ -182,16 +182,19 @@ def swap(function, *args, policy_fn=None, group_swap=False, **kwargs):
         return function(*args, **kwargs)
 
 
-def checkpoint_exclude_wrapper(module: Any) -> Any:
+def checkpoint_exclude_wrapper(module: Any, *, save_output: bool = True) -> Any:
     """Wrap a callable whose region is excluded from activation recomputation.
 
     Args:
         module: The module or callable to exclude from recomputation.
+        save_output: Whether to retain the region output for checkpoint replay.
+            Set this to ``False`` only when the output is passed directly as one
+            argument to another excluded region. Default: ``True``.
 
     Returns:
         The platform-specific checkpoint exclusion wrapper.
     """
-    return plat.checkpoint_exclude_wrapper(module)
+    return plat.checkpoint_exclude_wrapper(module, save_output=save_output)
 
 
 checkpoint_wrapper = plat.checkpoint_wrapper

--- a/hyper_parallel/platform/mindspore/activation_checkpoint/checkpoint_exclude_wrapper.py
+++ b/hyper_parallel/platform/mindspore/activation_checkpoint/checkpoint_exclude_wrapper.py
@@ -16,7 +16,7 @@
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Any, Callable, Deque, Dict, List, Tuple
+from typing import Any, Callable, Deque, Dict, List, Optional, Tuple
 
 import mindspore as ms
 from mindspore.common._grad_function import _Function
@@ -26,6 +26,7 @@ from hyper_parallel.platform.mindspore.activation_checkpoint.activation_swap imp
 
 
 _RECOMPUTE_INPUT_HANDLE_KEY = "hyper_parallel_recompute_input_handle"
+_SAVE_OUTPUT_SOURCE_KEY = "hyper_parallel_save_output_source"
 _InputPath = Tuple[Tuple[str, Any], ...]
 _TensorInput = Tuple[_InputPath, Any]
 
@@ -63,10 +64,11 @@ class _InputBinding:
 
 @dataclass
 class _ExcludeCacheEntry:
-    """Store one excluded call's output and deferred input bindings."""
+    """Store one excluded call's replay value and deferred input bindings."""
 
     output: Any
     input_bindings: List[_InputBinding]
+    output_tensor_count: int = 1
 
 
 class _ExcludeCache:
@@ -149,16 +151,21 @@ def _collect_tensor_inputs(args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> Lis
 
 
 def _mark_recompute_inputs(
+    invocation_id: object,
     args: Tuple[Any, ...],
     kwargs: Dict[str, Any],
 ) -> Tuple[List[_InputBinding], List[Tuple[Any, Any]]]:
-    """Attach deferred handles to non-parameter input tensors."""
+    """Attach deferred handles to inputs that replay reproduces."""
     bindings = []
     previous_handles = []
     seen_tensor_ids = set()
     try:
         for path, tensor in _collect_tensor_inputs(args, kwargs):
-            if isinstance(tensor, ms.Parameter) or id(tensor) in seen_tensor_ids:
+            if (
+                isinstance(tensor, ms.Parameter)
+                or id(tensor) in seen_tensor_ids
+                or tensor._get_user_data(_SAVE_OUTPUT_SOURCE_KEY) is invocation_id  # pylint: disable=protected-access
+            ):
                 continue
             handle = _RecomputedInputHandle()
             previous = tensor._get_user_data(_RECOMPUTE_INPUT_HANDLE_KEY)  # pylint: disable=protected-access
@@ -210,54 +217,92 @@ def _has_used_input(input_bindings: List[_InputBinding]) -> bool:
 
 
 @lru_cache(maxsize=1)
-def _get_recompute_trigger() -> Any:
-    """Lazily create the reusable zero-element recomputation trigger."""
+def _get_replay_placeholder() -> Any:
+    """Create a zero-element placeholder returned by an elided SAVE replay."""
     return ms.Tensor([], dtype=ms.float32)
+
+
+def _make_replay_placeholder_output(tensor_count: int) -> Any:
+    """Create one placeholder leaf for each forward output tensor."""
+    if tensor_count == 0:
+        return ()
+    placeholder = _get_replay_placeholder()
+    if tensor_count == 1:
+        return placeholder
+    return (placeholder,) * tensor_count
+
+
+@lru_cache(maxsize=1)
+def _get_recompute_trigger() -> Any:
+    """Create the differentiable zero-element input used by recompute boundaries."""
+    tensor = ms.Tensor([], dtype=ms.float32)
+    tensor.requires_grad_()
+    return tensor
 
 
 class _RecomputeBoundary(_Function):
     """Trigger the outer checkpoint hook before excluded-region backward."""
 
     @staticmethod
-    def forward(ctx: Any, tensor: Any) -> Any:
+    def forward(ctx: Any, tensor: Any, trigger: Any) -> Any:
         """Save one zero-element outer-hook dependency and return the tensor unchanged."""
-        ctx.save_for_backward(_get_recompute_trigger())
+        ctx.save_for_backward(trigger)
         return tensor
 
     @staticmethod
-    def backward(ctx: Any, grad_output: Any) -> Any:
+    def backward(ctx: Any, grad_output: Any) -> Tuple[Any, None]:
         """Trigger dependency unpack and pass the gradient through."""
         _ = ctx.saved_tensors
-        return grad_output
+        return grad_output, None
 
 
-def _apply_recompute_boundary(output: Any, input_bindings: List[_InputBinding]) -> Any:
-    """Wrap output tensor leaves when deferred inputs require checkpoint replay."""
-    if not _has_used_input(input_bindings):
-        return output
-
+def _finalize_save_outputs(
+    output: Any,
+    add_recompute_boundary: bool,
+    invocation_id: Optional[object],
+    tensor_leaf_count: Optional[List[int]] = None,
+) -> Any:
+    """Apply the required boundary and SAVE provenance to output tensor leaves."""
     if isinstance(output, ms.Tensor):
-        return _RecomputeBoundary.apply(output)
+        if tensor_leaf_count is not None:
+            tensor_leaf_count[0] += 1
+        if add_recompute_boundary:
+            output = _RecomputeBoundary.apply(output, _get_recompute_trigger())
+        if invocation_id is not None:
+            output._set_user_data(_SAVE_OUTPUT_SOURCE_KEY, invocation_id)  # pylint: disable=protected-access
+        return output
     if isinstance(output, list):
-        return [_apply_recompute_boundary(item, input_bindings) for item in output]
+        return [
+            _finalize_save_outputs(item, add_recompute_boundary, invocation_id, tensor_leaf_count)
+            for item in output
+        ]
     if isinstance(output, tuple):
-        items = [_apply_recompute_boundary(item, input_bindings) for item in output]
+        items = [
+            _finalize_save_outputs(item, add_recompute_boundary, invocation_id, tensor_leaf_count)
+            for item in output
+        ]
         if hasattr(output, "_fields"):
             return type(output)(*items)
         return tuple(items)
     if isinstance(output, dict):
-        return type(output)((key, _apply_recompute_boundary(value, input_bindings)) for key, value in output.items())
+        return type(output)(
+            (key, _finalize_save_outputs(value, add_recompute_boundary, invocation_id, tensor_leaf_count))
+            for key, value in output.items()
+        )
     return output
 
 
 class CheckpointExcludeWrapper(ActivationWrapper):
     """Exclude a callable region from checkpoint recomputation."""
 
-    def __init__(self, module: Callable[..., Any]) -> None:
+    def __init__(self, module: Callable[..., Any], *, save_output: bool = True) -> None:
         """Initialize a checkpoint exclusion wrapper for a MindSpore Cell or function."""
         if not callable(module):
             raise ValueError("module must be a MindSpore Cell or callable")
+        if not isinstance(save_output, bool):
+            raise ValueError(f"save_output must be a bool, got {type(save_output).__name__}")
         super().__init__(module, track_overlaps=False)
+        self.save_output = save_output
 
     def construct(self, *args: Any, **kwargs: Any) -> Any:
         """Execute normally outside recompute and return the cached output in recompute."""
@@ -268,24 +313,46 @@ class CheckpointExcludeWrapper(ActivationWrapper):
         if state.is_recomputing:
             entry = cache.pop(id(self))
             _materialize_recompute_inputs(entry, args, kwargs)
-            return _apply_recompute_boundary(entry.output, entry.input_bindings)
+            output = (
+                entry.output
+                if self.save_output
+                else _make_replay_placeholder_output(entry.output_tensor_count)
+            )
+            return _finalize_save_outputs(output, _has_used_input(entry.input_bindings), None)
 
-        input_bindings, previous_handles = _mark_recompute_inputs(args, kwargs)
+        input_bindings, previous_handles = _mark_recompute_inputs(state.invocation_id, args, kwargs)
         try:
             with _saved_tensors_context():
                 output = self._ckpt_wrapped_module(*args, **kwargs)
         finally:
             _restore_recompute_inputs(previous_handles)
-        cache.save(id(self), _ExcludeCacheEntry(output, input_bindings))
-        return _apply_recompute_boundary(output, input_bindings)
+        needs_recompute_boundary = _has_used_input(input_bindings)
+        tensor_leaf_count = None if self.save_output else [0]
+        finalized_output = _finalize_save_outputs(
+            output,
+            needs_recompute_boundary,
+            state.invocation_id,
+            tensor_leaf_count,
+        )
+        replay_output = output if self.save_output else None
+        output_tensor_count = 1 if tensor_leaf_count is None else tensor_leaf_count[0]
+        cache.save(id(self), _ExcludeCacheEntry(replay_output, input_bindings, output_tensor_count))
+        return finalized_output
 
 
-def checkpoint_exclude_wrapper(module: Callable[..., Any]) -> CheckpointExcludeWrapper:
+def checkpoint_exclude_wrapper(
+    module: Callable[..., Any],
+    *,
+    save_output: bool = True,
+) -> CheckpointExcludeWrapper:
     """Wrap a MindSpore Cell or function so its region is not recomputed.
 
     Args:
         module: MindSpore Cell or callable to execute only during the original
             checkpoint forward pass.
+        save_output: Whether to retain the region output for checkpoint replay.
+            Set this to ``False`` only when the output is passed directly as one
+            argument to another checkpoint exclusion wrapper. Default: ``True``.
 
     Returns:
         A wrapper that saves the callable's autograd tensors and reuses its
@@ -296,4 +363,4 @@ def checkpoint_exclude_wrapper(module: Callable[..., Any]) -> CheckpointExcludeW
         HyperParallel checkpoint configured with ``use_reentrant=False``.
         Nested checkpoint exclusion wrappers are not supported.
     """
-    return CheckpointExcludeWrapper(module)
+    return CheckpointExcludeWrapper(module, save_output=save_output)

--- a/hyper_parallel/platform/mindspore/activation_checkpoint/checkpoint_exclude_wrapper.py
+++ b/hyper_parallel/platform/mindspore/activation_checkpoint/checkpoint_exclude_wrapper.py
@@ -14,55 +14,240 @@
 # ============================================================================
 """MindSpore wrapper for regions that should be saved instead of recomputed."""
 from collections import defaultdict, deque
-from typing import Any, Callable, Deque, Dict
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, Callable, Deque, Dict, List, Tuple
+
+import mindspore as ms
+from mindspore.common._grad_function import _Function
 
 from hyper_parallel.core.activation_checkpoint.recompute_state import get_recompute_state
 from hyper_parallel.platform.mindspore.activation_checkpoint.activation_swap import ActivationWrapper
 
 
-class _CheckpointExcludeCache:
-    """Store excluded-region outputs for one checkpoint invocation."""
+_RECOMPUTE_INPUT_HANDLE_KEY = "hyper_parallel_recompute_input_handle"
+_InputPath = Tuple[Tuple[str, Any], ...]
+_TensorInput = Tuple[_InputPath, Any]
+
+
+class _RecomputedInputHandle:
+    """Defer one excluded-region saved input until checkpoint replay."""
+
+    def __init__(self) -> None:
+        """Initialize an unused and unresolved handle."""
+        self.used = False
+        self._tensor = None
+
+    def mark_used(self) -> None:
+        """Record that an exclude operation saved this input for backward."""
+        self.used = True
+
+    def materialize(self, tensor: Any) -> None:
+        """Bind the handle to the matching input produced during replay."""
+        self._tensor = tensor
+
+    def get_recomputed_tensor(self) -> Any:
+        """Return the replay-produced input for backward."""
+        if self._tensor is None:
+            raise RuntimeError("Checkpoint-excluded input was requested before recomputation")
+        return self._tensor
+
+
+@dataclass(frozen=True)
+class _InputBinding:
+    """Map one input path to its deferred saved-tensor handle."""
+
+    path: _InputPath
+    handle: _RecomputedInputHandle
+
+
+@dataclass
+class _ExcludeCacheEntry:
+    """Store one excluded call's output and deferred input bindings."""
+
+    output: Any
+    input_bindings: List[_InputBinding]
+
+
+class _ExcludeCache:
+    """Store excluded-region call entries for one checkpoint invocation."""
 
     def __init__(self) -> None:
         """Initialize an empty per-checkpoint output cache."""
-        self._outputs: Dict[int, Deque[Any]] = defaultdict(deque)
+        self._entries: Dict[int, Deque[_ExcludeCacheEntry]] = defaultdict(deque)
 
-    def save(self, wrapper_id: int, output: Any) -> None:
-        """Save one output produced by a checkpoint-excluded region."""
-        self._outputs[wrapper_id].append(output)
+    def save(self, wrapper_id: int, entry: _ExcludeCacheEntry) -> None:
+        """Save one call entry produced by a checkpoint-excluded region."""
+        self._entries[wrapper_id].append(entry)
 
-    def pop(self, wrapper_id: int) -> Any:
-        """Return the matching forward output during recomputation."""
-        outputs = self._outputs.get(wrapper_id)
-        if not outputs:
+    def pop(self, wrapper_id: int) -> _ExcludeCacheEntry:
+        """Return the matching forward call entry during recomputation."""
+        entries = self._entries.get(wrapper_id)
+        if not entries:
             raise RuntimeError("No cached forward output is available for this checkpoint exclusion wrapper")
-        output = outputs.popleft()
-        if not outputs:
-            self._outputs.pop(wrapper_id)
-        return output
+        entry = entries.popleft()
+        if not entries:
+            self._entries.pop(wrapper_id)
+        return entry
 
     def clear(self) -> None:
         """Release outputs not consumed because recomputation stopped early."""
-        self._outputs.clear()
+        self._entries.clear()
 
 
 def _pack_saved_tensor(tensor: Any) -> Any:
-    """Return the tensor data without retaining the input tensor object."""
+    """Return a deferred input handle or detached tensor data."""
+    handle = tensor._get_user_data(_RECOMPUTE_INPUT_HANDLE_KEY)  # pylint: disable=protected-access
+    if isinstance(handle, _RecomputedInputHandle):
+        handle.mark_used()
+        return handle
     return tensor.data
 
 
 def _unpack_saved_tensor(tensor: Any) -> Any:
     """Restore the saved tensor for backward."""
+    if isinstance(tensor, _RecomputedInputHandle):
+        return tensor.get_recomputed_tensor()
     return tensor
 
 
 def _saved_tensors_context() -> Any:
     """Create an inner hook that stores real tensors instead of placeholders."""
-    import mindspore as ms  # pylint: disable=C0415
     return ms.saved_tensors_hooks(_pack_saved_tensor, _unpack_saved_tensor)
 
 
-_CHECKPOINT_EXCLUDE_CACHE_KEY = object()
+_EXCLUDE_CACHE_KEY = object()
+
+
+def _append_tensor_inputs(
+    value: Any,
+    path: _InputPath,
+    leaves: List[_TensorInput],
+) -> None:
+    """Append tensor leaves without creating a self-referential local function."""
+    if isinstance(value, ms.Tensor):
+        leaves.append((path, value))
+        return
+    if isinstance(value, (tuple, list)):
+        for index, item in enumerate(value):
+            _append_tensor_inputs(item, path + (("index", index),), leaves)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _append_tensor_inputs(item, path + (("key", key),), leaves)
+
+
+def _collect_tensor_inputs(args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> List[_TensorInput]:
+    """Return tensor leaves and self-describing paths from one excluded-region call."""
+    leaves = []
+
+    for index, arg in enumerate(args):
+        _append_tensor_inputs(arg, (("arg", index),), leaves)
+    for key, value in kwargs.items():
+        _append_tensor_inputs(value, (("kwarg", key),), leaves)
+    return leaves
+
+
+def _mark_recompute_inputs(
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+) -> Tuple[List[_InputBinding], List[Tuple[Any, Any]]]:
+    """Attach deferred handles to non-parameter input tensors."""
+    bindings = []
+    previous_handles = []
+    seen_tensor_ids = set()
+    try:
+        for path, tensor in _collect_tensor_inputs(args, kwargs):
+            if isinstance(tensor, ms.Parameter) or id(tensor) in seen_tensor_ids:
+                continue
+            handle = _RecomputedInputHandle()
+            previous = tensor._get_user_data(_RECOMPUTE_INPUT_HANDLE_KEY)  # pylint: disable=protected-access
+            previous_handles.append((tensor, previous))
+            tensor._set_user_data(_RECOMPUTE_INPUT_HANDLE_KEY, handle)  # pylint: disable=protected-access
+            bindings.append(_InputBinding(path, handle))
+            seen_tensor_ids.add(id(tensor))
+    except BaseException:
+        _restore_recompute_inputs(previous_handles)
+        raise
+    return bindings, previous_handles
+
+
+def _restore_recompute_inputs(previous_handles: List[Tuple[Any, Any]]) -> None:
+    """Restore Tensor user data overwritten for one excluded call."""
+    for tensor, previous in previous_handles:
+        tensor._set_user_data(_RECOMPUTE_INPUT_HANDLE_KEY, previous)  # pylint: disable=protected-access
+
+
+def _resolve_input(args: Tuple[Any, ...], kwargs: Dict[str, Any], path: _InputPath) -> Any:
+    """Resolve one replay input from its forward argument path."""
+    root_kind, root_key = path[0]
+    value = args[root_key] if root_kind == "arg" else kwargs[root_key]
+    for _, token_value in path[1:]:
+        value = value[token_value]
+    return value
+
+
+def _materialize_recompute_inputs(
+    entry: _ExcludeCacheEntry,
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+) -> None:
+    """Bind used input handles to tensors produced during checkpoint replay."""
+    for binding in entry.input_bindings:
+        if not binding.handle.used:
+            continue
+        tensor = _resolve_input(args, kwargs, binding.path)
+        if not isinstance(tensor, ms.Tensor):
+            raise RuntimeError(
+                "Checkpoint replay did not reproduce a tensor input required by a checkpoint-excluded region"
+            )
+        binding.handle.materialize(tensor.data)
+
+
+def _has_used_input(input_bindings: List[_InputBinding]) -> bool:
+    """Return whether the excluded call saved any marked input."""
+    return any(binding.handle.used for binding in input_bindings)
+
+
+@lru_cache(maxsize=1)
+def _get_recompute_trigger() -> Any:
+    """Lazily create the reusable zero-element recomputation trigger."""
+    return ms.Tensor([], dtype=ms.float32)
+
+
+class _RecomputeBoundary(_Function):
+    """Trigger the outer checkpoint hook before excluded-region backward."""
+
+    @staticmethod
+    def forward(ctx: Any, tensor: Any) -> Any:
+        """Save one zero-element outer-hook dependency and return the tensor unchanged."""
+        ctx.save_for_backward(_get_recompute_trigger())
+        return tensor
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Any) -> Any:
+        """Trigger dependency unpack and pass the gradient through."""
+        _ = ctx.saved_tensors
+        return grad_output
+
+
+def _apply_recompute_boundary(output: Any, input_bindings: List[_InputBinding]) -> Any:
+    """Wrap output tensor leaves when deferred inputs require checkpoint replay."""
+    if not _has_used_input(input_bindings):
+        return output
+
+    if isinstance(output, ms.Tensor):
+        return _RecomputeBoundary.apply(output)
+    if isinstance(output, list):
+        return [_apply_recompute_boundary(item, input_bindings) for item in output]
+    if isinstance(output, tuple):
+        items = [_apply_recompute_boundary(item, input_bindings) for item in output]
+        if hasattr(output, "_fields"):
+            return type(output)(*items)
+        return tuple(items)
+    if isinstance(output, dict):
+        return type(output)((key, _apply_recompute_boundary(value, input_bindings)) for key, value in output.items())
+    return output
 
 
 class CheckpointExcludeWrapper(ActivationWrapper):
@@ -79,14 +264,20 @@ class CheckpointExcludeWrapper(ActivationWrapper):
         state = get_recompute_state()
         if state is None:
             return self._ckpt_wrapped_module(*args, **kwargs)
-        cache = state.get_resource(_CHECKPOINT_EXCLUDE_CACHE_KEY, _CheckpointExcludeCache)
+        cache = state.get_resource(_EXCLUDE_CACHE_KEY, _ExcludeCache)
         if state.is_recomputing:
-            return cache.pop(id(self))
+            entry = cache.pop(id(self))
+            _materialize_recompute_inputs(entry, args, kwargs)
+            return _apply_recompute_boundary(entry.output, entry.input_bindings)
 
-        with _saved_tensors_context():
-            output = self._ckpt_wrapped_module(*args, **kwargs)
-        cache.save(id(self), output)
-        return output
+        input_bindings, previous_handles = _mark_recompute_inputs(args, kwargs)
+        try:
+            with _saved_tensors_context():
+                output = self._ckpt_wrapped_module(*args, **kwargs)
+        finally:
+            _restore_recompute_inputs(previous_handles)
+        cache.save(id(self), _ExcludeCacheEntry(output, input_bindings))
+        return _apply_recompute_boundary(output, input_bindings)
 
 
 def checkpoint_exclude_wrapper(module: Callable[..., Any]) -> CheckpointExcludeWrapper:
@@ -103,5 +294,6 @@ def checkpoint_exclude_wrapper(module: Callable[..., Any]) -> CheckpointExcludeW
     Note:
         This feature requires MindSpore PyNative mode and a surrounding
         HyperParallel checkpoint configured with ``use_reentrant=False``.
+        Nested checkpoint exclusion wrappers are not supported.
     """
     return CheckpointExcludeWrapper(module)

--- a/hyper_parallel/platform/mindspore/platform.py
+++ b/hyper_parallel/platform/mindspore/platform.py
@@ -1753,18 +1753,21 @@ class MindSporePlatform(Platform):
         return ckpt_wrapper(module, **checkpoint_kwargs)
 
     @staticmethod
-    def checkpoint_exclude_wrapper(module: Any) -> Any:
+    def checkpoint_exclude_wrapper(module: Any, *, save_output: bool = True) -> Any:
         """Wrap a Cell or callable whose activations should not be recomputed.
 
         Args:
             module: MindSpore Cell or callable to exclude from checkpoint replay.
+            save_output: Whether to retain the excluded region output for replay.
 
         Returns:
             The platform-specific checkpoint exclusion wrapper.
         """
         # pylint: disable=C0415
-        from hyper_parallel.platform.mindspore.activation_checkpoint.checkpoint_exclude_wrapper import checkpoint_exclude_wrapper
-        return checkpoint_exclude_wrapper(module)
+        from hyper_parallel.platform.mindspore.activation_checkpoint.checkpoint_exclude_wrapper import (
+            checkpoint_exclude_wrapper,
+        )
+        return checkpoint_exclude_wrapper(module, save_output=save_output)
 
     @staticmethod
     def swap_wrapper(module, policy_fn=None, group_swap=False):

--- a/hyper_parallel/platform/platform.py
+++ b/hyper_parallel/platform/platform.py
@@ -1394,11 +1394,12 @@ class Platform:
         raise NotImplementedError("Platform subclasses must implement checkpoint_wrapper")
 
     @staticmethod
-    def checkpoint_exclude_wrapper(module: Any) -> Any:
+    def checkpoint_exclude_wrapper(module: Any, *, save_output: bool = True) -> Any:
         """Wrap a callable whose activations should be saved instead of recomputed.
 
         Args:
             module: The module or callable to exclude from activation recomputation.
+            save_output: Whether to retain the excluded region output for replay.
 
         Returns:
             The wrapped module or callable.

--- a/tests/mindspore/st/activation_checkpoint/checkpoint_exclude_matmul.py
+++ b/tests/mindspore/st/activation_checkpoint/checkpoint_exclude_matmul.py
@@ -1,0 +1,201 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Validate checkpoint exclusion memory with stacked RMSNorm, MatMul, and SiLU."""
+import importlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any, Dict
+
+import mindspore as ms
+from mindspore import nn, Tensor
+import numpy as np
+
+from hyper_parallel.core.activation_checkpoint import checkpoint_exclude_wrapper, checkpoint_wrapper
+from hyper_parallel.platform.mindspore.autograd_compat import enable_mindspore_backward_compat
+
+
+enable_mindspore_backward_compat()
+
+
+_TOKEN_NUM = 16384
+_HIDDEN_SIZE = 2048
+_LAYER_NUM = 20
+_RESULT_MARKER = "__RMSNORM_MATMUL_RESULT__"
+
+
+class _CountedMatmul(nn.Cell):
+    """MatMul that records whether checkpoint replay executes it."""
+
+    def __init__(self, calls: Dict[str, int]) -> None:
+        """Initialize a deterministic square projection."""
+        super().__init__()
+        self.calls = calls
+        rng = np.random.default_rng(2026)
+        weight = rng.normal(0.0, 0.02, (_HIDDEN_SIZE, _HIDDEN_SIZE)).astype(np.float32)
+        self.weight = ms.Parameter(Tensor(weight, ms.bfloat16), name="matmul_weight")
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """Apply the projection."""
+        self.calls["matmul"] += 1
+        return ms.ops.matmul(tensor, self.weight)
+
+
+class _RmsNormMatmulBlock(nn.Cell):
+    """Apply RMSNorm, an excluded MatMul, and SiLU."""
+
+    def __init__(self, calls: Dict[str, int]) -> None:
+        """Initialize one checkpointed layer."""
+        super().__init__()
+        self.rms_norm = ms.ops.RmsNorm(epsilon=1e-6)
+        self.norm_weight = ms.Parameter(ms.ops.ones((_HIDDEN_SIZE,), ms.bfloat16), name="norm_weight")
+        self.matmul = checkpoint_exclude_wrapper(_CountedMatmul(calls))
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """Run the layer."""
+        normalized = self.rms_norm(tensor, self.norm_weight)[0]
+        return ms.ops.silu(self.matmul(normalized))
+
+
+class _RmsNormMatmulNet(nn.Cell):
+    """Stack individually checkpointed layers."""
+
+    def __init__(self, calls: Dict[str, int]) -> None:
+        """Create one checkpoint for each layer."""
+        super().__init__()
+        self.layers = nn.CellList([
+            checkpoint_wrapper(_RmsNormMatmulBlock(calls))
+            for _ in range(_LAYER_NUM)
+        ])
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """Run all layers and return a scalar loss."""
+        for layer in self.layers:
+            tensor = layer(tensor)
+        return ms.ops.sum(ms.ops.square(tensor))
+
+
+def _run_exclude() -> Dict[str, Any]:
+    """Run one optimized or legacy exclusion step."""
+    ms.set_deterministic(True)
+    ms.set_context(mode=ms.PYNATIVE_MODE)
+    calls = {"matmul": 0}
+    net = _RmsNormMatmulNet(calls)
+    rng = np.random.default_rng(2027)
+    input_data = rng.normal(0.0, 0.5, (_TOKEN_NUM, _HIDDEN_SIZE)).astype(np.float32)
+
+    warmup_input = Tensor(input_data, ms.bfloat16)
+    warmup_input.requires_grad = True
+    warmup_loss = net(warmup_input)
+    warmup_loss.backward()
+    ms.runtime.synchronize()
+    for parameter in net.trainable_params():
+        parameter.grad = None
+    del warmup_input, warmup_loss
+    calls["matmul"] = 0
+    ms.runtime.empty_cache()
+
+    baseline_bytes = ms.runtime.memory_allocated()
+    ms.runtime.reset_peak_memory_stats()
+    tensor = Tensor(input_data, ms.bfloat16)
+    tensor.requires_grad = True
+    loss = net(tensor)
+    ms.runtime.synchronize()
+    forward_bytes = ms.runtime.memory_allocated() - baseline_bytes
+    loss.backward()
+    ms.runtime.synchronize()
+
+    return {
+        "loss": float(loss.asnumpy()),
+        "matmul_calls": calls["matmul"],
+        "forward_bytes": int(forward_bytes),
+        "peak_bytes": int(ms.runtime.max_memory_allocated() - baseline_bytes),
+    }
+
+
+def _disable_input_rematerialization(args: Any, kwargs: Any) -> tuple:
+    """Reproduce legacy exclusion, which retains saved input storage."""
+    del args, kwargs
+    return [], []
+
+
+def _run_mode(mode: str) -> Dict[str, Any]:
+    """Run optimized or legacy checkpoint exclusion."""
+    if mode == "exclude":
+        return _run_exclude()
+    if mode != "legacy_exclude":
+        raise ValueError(f"Unsupported RMSNorm/MatMul mode: {mode}")
+
+    exclude_module = importlib.import_module(
+        "hyper_parallel.platform.mindspore.activation_checkpoint.checkpoint_exclude_wrapper"
+    )
+    original_mark = exclude_module._mark_recompute_inputs  # pylint: disable=protected-access
+    exclude_module._mark_recompute_inputs = _disable_input_rematerialization  # pylint: disable=protected-access
+    try:
+        return _run_exclude()
+    finally:
+        exclude_module._mark_recompute_inputs = original_mark  # pylint: disable=protected-access
+
+
+def _run_mode_in_subprocess(mode: str) -> Dict[str, Any]:
+    """Run one mode in an isolated allocator process."""
+    project_root = Path(__file__).resolve().parents[4]
+    command = [
+        sys.executable,
+        "-c",
+        (
+            "import json; "
+            "from tests.mindspore.st.activation_checkpoint.checkpoint_exclude_matmul import _run_mode; "
+            f"print({_RESULT_MARKER!r} + json.dumps(_run_mode({mode!r})))"
+        ),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=1200,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"RMSNorm/MatMul subprocess exited with code {completed.returncode}.\n"
+            f"STDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+        )
+    for line in reversed(completed.stdout.splitlines()):
+        if _RESULT_MARKER in line:
+            return json.loads(line.split(_RESULT_MARKER, maxsplit=1)[1])
+    raise RuntimeError(
+        "RMSNorm/MatMul subprocess did not produce a result marker.\n"
+        f"STDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+    )
+
+
+def test_rmsnorm_matmul_checkpoint_exclude_memory() -> None:
+    """Optimized exclusion should retain less memory than legacy exclusion."""
+    excluded = _run_mode_in_subprocess("exclude")
+    legacy = _run_mode_in_subprocess("legacy_exclude")
+
+    assert excluded["loss"] == legacy["loss"]
+    assert excluded["matmul_calls"] == _LAYER_NUM
+    assert legacy["matmul_calls"] == _LAYER_NUM
+
+    expected_gap = _LAYER_NUM * _TOKEN_NUM * _HIDDEN_SIZE * 2
+    tolerance = expected_gap // 4
+    forward_gap = legacy["forward_bytes"] - excluded["forward_bytes"]
+    peak_gap = legacy["peak_bytes"] - excluded["peak_bytes"]
+    assert abs(forward_gap - expected_gap) <= tolerance
+    assert abs(peak_gap - expected_gap) <= tolerance

--- a/tests/mindspore/st/activation_checkpoint/checkpoint_exclude_matmul.py
+++ b/tests/mindspore/st/activation_checkpoint/checkpoint_exclude_matmul.py
@@ -18,6 +18,7 @@ import json
 from pathlib import Path
 import subprocess
 import sys
+import time
 from typing import Any, Dict
 
 import mindspore as ms
@@ -35,6 +36,9 @@ _TOKEN_NUM = 16384
 _HIDDEN_SIZE = 2048
 _LAYER_NUM = 20
 _RESULT_MARKER = "__RMSNORM_MATMUL_RESULT__"
+_EXCLUDE_MODULE = importlib.import_module(
+    "hyper_parallel.platform.mindspore.activation_checkpoint.checkpoint_exclude_wrapper"
+)
 
 
 class _CountedMatmul(nn.Cell):
@@ -88,6 +92,97 @@ class _RmsNormMatmulNet(nn.Cell):
         return ms.ops.sum(ms.ops.square(tensor))
 
 
+class _SaveInputSquare(nn.Cell):
+    """SAVE operator that needs its input but not its output for backward."""
+
+    calls = 0
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """Return a square whose backward saves the input tensor."""
+        _SaveInputSquare.calls += 1
+        return tensor * tensor
+
+
+class _SaveOutputExp(nn.Cell):
+    """SAVE operator whose backward needs only its own output."""
+
+    calls = 0
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """Return an exponential whose backward saves only its output."""
+        _SaveOutputExp.calls += 1
+        return ms.ops.exp(tensor)
+
+
+class _FirstSaveActivation(nn.Cell):
+    """First SAVE operator that saves its recomputed input and output activation."""
+
+    calls = 0
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """Save the square input and the ReLU output for backward."""
+        _FirstSaveActivation.calls += 1
+        return ms.ops.relu(ms.ops.square(tensor))
+
+
+class _SecondSaveAdd(nn.Cell):
+    """Second SAVE operator whose output is not a backward activation."""
+
+    calls = 0
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """Add a constant without saving the input or output for backward."""
+        _SecondSaveAdd.calls += 1
+        return tensor + 0.125
+
+
+class _ThirdSaveScale(nn.Cell):
+    """Third SAVE operator whose output is not a backward activation."""
+
+    calls = 0
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """Multiply by a fixed scalar without saving input or output."""
+        _ThirdSaveScale.calls += 1
+        return tensor * 1.5
+
+
+class _FourthSaveAdd(nn.Cell):
+    """Fourth SAVE operator that produces the retained final output."""
+
+    calls = 0
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """Add a fixed constant without saving input or output."""
+        _FourthSaveAdd.calls += 1
+        return tensor + 0.25
+
+
+class _SaveChainNet(nn.Cell):
+    """Chain four SAVE operators with two non-activation intermediate outputs."""
+
+    def __init__(self, save_intermediate_outputs: bool) -> None:
+        """Configure whether the first three SAVE outputs remain cached."""
+        super().__init__()
+        self.first = checkpoint_exclude_wrapper(
+            _FirstSaveActivation(),
+            save_output=save_intermediate_outputs,
+        )
+        self.second = checkpoint_exclude_wrapper(
+            _SecondSaveAdd(),
+            save_output=save_intermediate_outputs,
+        )
+        self.third = checkpoint_exclude_wrapper(
+            _ThirdSaveScale(),
+            save_output=save_intermediate_outputs,
+        )
+        self.fourth = checkpoint_exclude_wrapper(_FourthSaveAdd())
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """Return a scalar loss through four adjacent SAVE regions."""
+        return self.fourth(self.third(self.second(self.first(tensor * 2)))).sum()
+
+
 def _run_exclude() -> Dict[str, Any]:
     """Run one optimized or legacy exclusion step."""
     ms.set_deterministic(True)
@@ -126,28 +221,213 @@ def _run_exclude() -> Dict[str, Any]:
     }
 
 
-def _disable_input_rematerialization(args: Any, kwargs: Any) -> tuple:
+def _run_host_performance_comparison() -> Dict[str, Any]:
+    """Compare SAVE-fusion host overhead on one warmed 20-layer network."""
+    ms.set_deterministic(True)
+    ms.set_context(mode=ms.PYNATIVE_MODE)
+    net = _RmsNormMatmulNet({"matmul": 0})
+    rng = np.random.default_rng(2030)
+    input_data = rng.normal(0.0, 0.5, (_TOKEN_NUM, _HIDDEN_SIZE)).astype(np.float32)
+    original_mark = _EXCLUDE_MODULE._mark_recompute_inputs  # pylint: disable=protected-access
+    original_finalize = _EXCLUDE_MODULE._finalize_save_outputs  # pylint: disable=protected-access
+    timings = {
+        "current": {"forward": [], "backward": [], "loss": []},
+        "baseline": {"forward": [], "backward": [], "loss": []},
+    }
+
+    def set_mode(mode: str) -> None:
+        """Switch only the two Python paths introduced by SAVE fusion."""
+        if mode == "current":
+            mark_inputs = original_mark
+            finalize_outputs = original_finalize
+        else:
+            mark_inputs = _mark_recompute_inputs_before_save_fusion
+            finalize_outputs = _finalize_outputs_before_save_fusion
+        _EXCLUDE_MODULE._mark_recompute_inputs = mark_inputs  # pylint: disable=protected-access
+        _EXCLUDE_MODULE._finalize_save_outputs = finalize_outputs  # pylint: disable=protected-access
+
+    try:
+        set_mode("current")
+        warmup_input = Tensor(input_data, ms.bfloat16)
+        warmup_input.requires_grad = True
+        warmup_loss = net(warmup_input)
+        warmup_loss.backward()
+        ms.runtime.synchronize()
+        del warmup_input, warmup_loss
+        for parameter in net.trainable_params():
+            parameter.grad = None
+
+        order = (
+            "baseline", "current", "current", "baseline", "current",
+            "baseline", "baseline", "current", "baseline", "current",
+        )
+        for mode in order:
+            set_mode(mode)
+            tensor = Tensor(input_data, ms.bfloat16)
+            tensor.requires_grad = True
+            ms.runtime.synchronize()
+            start = time.perf_counter()
+            loss = net(tensor)
+            forward_end = time.perf_counter()
+            loss.backward()
+            backward_end = time.perf_counter()
+            ms.runtime.synchronize()
+            timings[mode]["forward"].append((forward_end - start) * 1000)
+            timings[mode]["backward"].append((backward_end - forward_end) * 1000)
+            timings[mode]["loss"].append(float(loss.asnumpy()))
+            for parameter in net.trainable_params():
+                parameter.grad = None
+            del tensor, loss
+    finally:
+        set_mode("current")
+
+    result = {}
+    for mode in ("current", "baseline"):
+        forward_values = sorted(timings[mode]["forward"])
+        backward_values = sorted(timings[mode]["backward"])
+        median_index = len(forward_values) // 2
+        forward_median = forward_values[median_index]
+        backward_median = backward_values[median_index]
+        result[mode] = {
+            "loss": timings[mode]["loss"][0],
+            "forward_host_ms": forward_median,
+            "backward_host_ms": backward_median,
+            "total_host_ms": forward_median + backward_median,
+            "samples": len(forward_values),
+        }
+    return result
+
+
+def _run_save_chain(save_intermediate_outputs: bool) -> Dict[str, Any]:
+    """Measure four SAVE regions with or without their intermediate outputs."""
+    ms.set_deterministic(True)
+    ms.set_context(mode=ms.PYNATIVE_MODE)
+    net = checkpoint_wrapper(_SaveChainNet(save_intermediate_outputs))
+    rng = np.random.default_rng(2028)
+    input_data = rng.normal(0.0, 0.01, (_TOKEN_NUM, _HIDDEN_SIZE)).astype(np.float32)
+
+    warmup_input = Tensor(input_data, ms.bfloat16)
+    warmup_input.requires_grad = True
+    warmup_loss = net(warmup_input)
+    warmup_loss.backward()
+    ms.runtime.synchronize()
+    del warmup_input, warmup_loss
+    _FirstSaveActivation.calls = 0
+    _SecondSaveAdd.calls = 0
+    _ThirdSaveScale.calls = 0
+    _FourthSaveAdd.calls = 0
+    ms.runtime.empty_cache()
+
+    baseline_bytes = ms.runtime.memory_allocated()
+    ms.runtime.reset_peak_memory_stats()
+    tensor = Tensor(input_data, ms.bfloat16)
+    tensor.requires_grad = True
+    loss = net(tensor)
+    ms.runtime.synchronize()
+    forward_bytes = ms.runtime.memory_allocated() - baseline_bytes
+    loss.backward()
+    ms.runtime.synchronize()
+
+    return {
+        "loss": float(loss.asnumpy()),
+        "input_grad": float(tensor.grad[0, 0].asnumpy()),
+        "first_calls": _FirstSaveActivation.calls,
+        "second_calls": _SecondSaveAdd.calls,
+        "third_calls": _ThirdSaveScale.calls,
+        "fourth_calls": _FourthSaveAdd.calls,
+        "forward_bytes": int(forward_bytes),
+    }
+
+
+def _disable_input_rematerialization(invocation_id: object, args: Any, kwargs: Any) -> tuple:
     """Reproduce legacy exclusion, which retains saved input storage."""
-    del args, kwargs
+    del invocation_id, args, kwargs
     return [], []
+
+
+def _mark_recompute_inputs_before_save_fusion(
+    invocation_id: object,
+    args: Any,
+    kwargs: Any,
+) -> tuple:
+    """Reproduce input marking before SAVE-output provenance was introduced."""
+    del invocation_id
+    bindings = []
+    previous_handles = []
+    seen_tensor_ids = set()
+    try:
+        for path, tensor in _EXCLUDE_MODULE._collect_tensor_inputs(args, kwargs):  # pylint: disable=protected-access
+            if isinstance(tensor, ms.Parameter) or id(tensor) in seen_tensor_ids:
+                continue
+            handle = _EXCLUDE_MODULE._RecomputedInputHandle()  # pylint: disable=protected-access
+            key = _EXCLUDE_MODULE._RECOMPUTE_INPUT_HANDLE_KEY  # pylint: disable=protected-access
+            previous = tensor._get_user_data(key)  # pylint: disable=protected-access
+            previous_handles.append((tensor, previous))
+            tensor._set_user_data(key, handle)  # pylint: disable=protected-access
+            binding = _EXCLUDE_MODULE._InputBinding(path, handle)  # pylint: disable=protected-access
+            bindings.append(binding)
+            seen_tensor_ids.add(id(tensor))
+    except BaseException:
+        _EXCLUDE_MODULE._restore_recompute_inputs(previous_handles)  # pylint: disable=protected-access
+        raise
+    return bindings, previous_handles
+
+
+def _finalize_outputs_before_save_fusion(
+    output: Any,
+    add_recompute_boundary: bool,
+    invocation_id: object,
+    tensor_leaf_count: Any = None,
+) -> Any:
+    """Apply boundaries without SAVE provenance as before fusion."""
+    del invocation_id
+    if isinstance(output, ms.Tensor):
+        if tensor_leaf_count is not None:
+            tensor_leaf_count[0] += 1
+        if add_recompute_boundary:
+            trigger = _EXCLUDE_MODULE._get_recompute_trigger()  # pylint: disable=protected-access
+            return _EXCLUDE_MODULE._RecomputeBoundary.apply(output, trigger)  # pylint: disable=protected-access
+        return output
+    if isinstance(output, list):
+        return [
+            _finalize_outputs_before_save_fusion(item, add_recompute_boundary, None, tensor_leaf_count)
+            for item in output
+        ]
+    if isinstance(output, tuple):
+        items = [
+            _finalize_outputs_before_save_fusion(item, add_recompute_boundary, None, tensor_leaf_count)
+            for item in output
+        ]
+        if hasattr(output, "_fields"):
+            return type(output)(*items)
+        return tuple(items)
+    if isinstance(output, dict):
+        return type(output)(
+            (key, _finalize_outputs_before_save_fusion(value, add_recompute_boundary, None, tensor_leaf_count))
+            for key, value in output.items()
+        )
+    return output
 
 
 def _run_mode(mode: str) -> Dict[str, Any]:
     """Run optimized or legacy checkpoint exclusion."""
     if mode == "exclude":
         return _run_exclude()
+    if mode == "save_chain":
+        return _run_save_chain(save_intermediate_outputs=False)
+    if mode == "legacy_save_chain":
+        return _run_save_chain(save_intermediate_outputs=True)
+    if mode == "host_performance_comparison":
+        return _run_host_performance_comparison()
     if mode != "legacy_exclude":
-        raise ValueError(f"Unsupported RMSNorm/MatMul mode: {mode}")
+        raise ValueError(f"Unsupported checkpoint exclusion mode: {mode}")
 
-    exclude_module = importlib.import_module(
-        "hyper_parallel.platform.mindspore.activation_checkpoint.checkpoint_exclude_wrapper"
-    )
-    original_mark = exclude_module._mark_recompute_inputs  # pylint: disable=protected-access
-    exclude_module._mark_recompute_inputs = _disable_input_rematerialization  # pylint: disable=protected-access
+    original_mark = _EXCLUDE_MODULE._mark_recompute_inputs  # pylint: disable=protected-access
+    _EXCLUDE_MODULE._mark_recompute_inputs = _disable_input_rematerialization  # pylint: disable=protected-access
     try:
         return _run_exclude()
     finally:
-        exclude_module._mark_recompute_inputs = original_mark  # pylint: disable=protected-access
+        _EXCLUDE_MODULE._mark_recompute_inputs = original_mark  # pylint: disable=protected-access
 
 
 def _run_mode_in_subprocess(mode: str) -> Dict[str, Any]:

--- a/tests/mindspore/st/activation_checkpoint/test_checkpoint_exclude_save_chain.py
+++ b/tests/mindspore/st/activation_checkpoint/test_checkpoint_exclude_save_chain.py
@@ -1,0 +1,52 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Validate memory optimization for adjacent checkpoint SAVE regions."""
+
+from tests.common.mark_utils import arg_mark
+from tests.mindspore.st.activation_checkpoint.checkpoint_exclude_matmul import (
+    _HIDDEN_SIZE,
+    _TOKEN_NUM,
+    _run_mode_in_subprocess,
+)
+
+
+@arg_mark(
+    plat_marks=["platform_ascend910b"],
+    level_mark="level0",
+    card_mark="onecard",
+    essential_mark="essential",
+)
+def test_adjacent_save_regions_elide_intermediate_output() -> None:
+    """A four-SAVE chain should elide two non-activation intermediate outputs."""
+    optimized = _run_mode_in_subprocess("save_chain")
+    legacy = _run_mode_in_subprocess("legacy_save_chain")
+
+    assert optimized["loss"] == legacy["loss"]
+    assert optimized["input_grad"] == legacy["input_grad"]
+    assert optimized["first_calls"] == 1
+    assert optimized["second_calls"] == 1
+    assert optimized["third_calls"] == 1
+    assert optimized["fourth_calls"] == 1
+    assert legacy["first_calls"] == 1
+    assert legacy["second_calls"] == 1
+    assert legacy["third_calls"] == 1
+    assert legacy["fourth_calls"] == 1
+
+    # The first output is already a ReLU backward activation. The second and
+    # third outputs account for two extra allocations in the legacy mode.
+    expected_gap = 2 * _TOKEN_NUM * _HIDDEN_SIZE * 2
+    tolerance = expected_gap // 4
+    forward_gap = legacy["forward_bytes"] - optimized["forward_bytes"]
+    assert abs(forward_gap - expected_gap) <= tolerance

--- a/tests/mindspore/st/activation_checkpoint/test_ckpt_activation.py
+++ b/tests/mindspore/st/activation_checkpoint/test_ckpt_activation.py
@@ -1,3 +1,8 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -30,5 +35,6 @@ def test_sac_group():
         MindSporeCase(BASE_SHARD, "test_swap_manager_manual_group_api", 11640, 1),
         MindSporeCase(BASE_SHARD, "test_inplace_modification", 11641, 1),
         MindSporeCase(BASE_SHARD, "test_wrapper_overlap_detection_cases", 11642, 1),
-        MindSporeCase(BASE_SHARD, "test_wrapper_non_overlapping_allowed_cases", 11643, 1)
+        MindSporeCase(BASE_SHARD, "test_wrapper_non_overlapping_allowed_cases", 11643, 1),
+        MindSporeCase("checkpoint_exclude_matmul.py", "test_rmsnorm_matmul_checkpoint_exclude_memory", 11644, 1),
     ])

--- a/tests/mindspore/st/activation_checkpoint/test_ckpt_activation.py
+++ b/tests/mindspore/st/activation_checkpoint/test_ckpt_activation.py
@@ -36,5 +36,7 @@ def test_sac_group():
         MindSporeCase(BASE_SHARD, "test_inplace_modification", 11641, 1),
         MindSporeCase(BASE_SHARD, "test_wrapper_overlap_detection_cases", 11642, 1),
         MindSporeCase(BASE_SHARD, "test_wrapper_non_overlapping_allowed_cases", 11643, 1),
-        MindSporeCase("checkpoint_exclude_matmul.py", "test_rmsnorm_matmul_checkpoint_exclude_memory", 11644, 1),
+        MindSporeCase(
+            "checkpoint_exclude_matmul.py", "test_rmsnorm_matmul_checkpoint_exclude_memory", 11644, 1
+        ),
     ])

--- a/tests/ut/core/activation_checkpoint/test_activation_checkpoint.py
+++ b/tests/ut/core/activation_checkpoint/test_activation_checkpoint.py
@@ -25,6 +25,7 @@ os.environ["HYPER_PARALLEL_PLATFORM"] = "torch"
 from hyper_parallel.core.activation_checkpoint.activation_checkpoint import (
     CheckpointPolicy,
     checkpoint,
+    checkpoint_exclude_wrapper,
     checkpoint_wrapper,
     swap,
 )
@@ -87,6 +88,16 @@ class TestCheckpointFunction(unittest.TestCase):
         with recompute_context:
             self.assertTrue(is_recomputing())
         self.assertFalse(is_recomputing())
+
+    def test_checkpoint_exclude_wrapper_forwards_save_output(self, mock_plat):
+        """The platform wrapper should receive the explicit output-retention policy."""
+        module = MagicMock()
+        mock_plat.checkpoint_exclude_wrapper.return_value = "wrapped"
+
+        result = checkpoint_exclude_wrapper(module, save_output=False)
+
+        self.assertEqual(result, "wrapped")
+        mock_plat.checkpoint_exclude_wrapper.assert_called_once_with(module, save_output=False)
 
     def test_checkpoint_with_swap_inputs(self, mock_plat):
         """Test checkpoint with swap_inputs=True."""

--- a/tests/ut/platform/mindspore/_ensure_mindspore_platform.py
+++ b/tests/ut/platform/mindspore/_ensure_mindspore_platform.py
@@ -134,6 +134,8 @@ def restore_torch_platform_for_ut() -> None:
             "hyper_parallel.core.expert_parallel.expert_parallel",
             *_FULLY_SHARD_PLATFORM_BIND_MODULES,
             "hyper_parallel.core.context_parallel.async_context_parallel",
+            "hyper_parallel.core.activation_checkpoint",
+            "hyper_parallel.core.activation_checkpoint.activation_checkpoint",
         )
     )
     try:

--- a/tests/ut/platform/mindspore/activation_checkpoint/test_checkpoint_exclude_wrapper.py
+++ b/tests/ut/platform/mindspore/activation_checkpoint/test_checkpoint_exclude_wrapper.py
@@ -14,9 +14,11 @@
 # ============================================================================
 """Tests for the MindSpore checkpoint exclusion wrapper."""
 import contextlib
+import gc
 import importlib
-from typing import Iterator, Tuple
+from typing import Any, Iterator, Tuple
 import unittest
+import weakref
 
 import numpy as np
 import pytest
@@ -26,9 +28,11 @@ from tests.ut.platform.mindspore._ensure_mindspore_platform import (
 
 ms = pytest.importorskip("mindspore")
 ParameterTuple = ms.ParameterTuple
+Parameter = ms.Parameter
 Tensor = ms.Tensor
 nn = ms.nn
 ops = ms.ops
+_Function = importlib.import_module("mindspore.common._grad_function")._Function
 _pynative_executor = importlib.import_module("mindspore.graph.api")._pynative_executor
 
 ensure_mindspore_platform_default()
@@ -45,6 +49,25 @@ checkpoint_exclude_wrapper_module = importlib.import_module(
     "hyper_parallel.platform.mindspore.activation_checkpoint.checkpoint_exclude_wrapper"
 )
 CheckpointExcludeWrapper = checkpoint_exclude_wrapper_module.CheckpointExcludeWrapper
+
+
+class _SaveExactInput(_Function):
+    """Autograd function that saves its exact input for backward."""
+
+    calls = 0
+
+    @staticmethod
+    def forward(ctx: Any, tensor: Tensor) -> Tensor:
+        """Save the input and return its square."""
+        _SaveExactInput.calls += 1
+        ctx.save_for_backward(tensor)
+        return tensor * tensor
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tensor:
+        """Use the saved input to compute the square gradient."""
+        (tensor,) = ctx.saved_tensors
+        return grad_output * 2 * tensor
 
 
 class _FunctionBlock(nn.Cell):
@@ -90,6 +113,27 @@ class _StateBlock(nn.Cell):
         self.states.append(is_recomputing())
         output = self.middle(x * 2)
         return (output * x).sum()
+
+
+class _SavedInputBlock(nn.Cell):
+    """Checkpointed block whose excluded tail saves its exact input."""
+
+    def __init__(self, calls: dict) -> None:
+        """Wrap a custom saved-input function and retain the shared counter."""
+        super().__init__()
+        self.calls = calls
+
+        def excluded(tensor: Tensor) -> Tensor:
+            """Save the exact recomputed input without rerunning on replay."""
+            self.calls["excluded"] += 1
+            return _SaveExactInput.apply(tensor)
+
+        self.excluded = checkpoint_exclude_wrapper(excluded)
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """End the checkpoint body at the excluded region's scalar output."""
+        self.calls["block"] += 1
+        return self.excluded(tensor * 3).sum()
 
 
 class _PrecisionMiddle(nn.Cell):
@@ -216,6 +260,158 @@ class TestCheckpointExcludeWrapper(unittest.TestCase):
         self.assertIsNot(packed, tensor)
         np.testing.assert_array_equal(packed.asnumpy(), tensor.asnumpy())
         self.assertIs(checkpoint_exclude_wrapper_module._unpack_saved_tensor(packed), packed)
+
+    def test_saved_tensor_hook_uses_tensor_user_data_handle(self):
+        """Tensor user data should carry the deferred handle into the pack hook."""
+        tensor = Tensor(np.arange(4, dtype=np.float32))
+        recomputed = Tensor(np.arange(4, dtype=np.float32) * 2)
+        handle = checkpoint_exclude_wrapper_module._RecomputedInputHandle()
+        key = checkpoint_exclude_wrapper_module._RECOMPUTE_INPUT_HANDLE_KEY
+        tensor._set_user_data(key, handle)
+
+        packed = checkpoint_exclude_wrapper_module._pack_saved_tensor(tensor)
+
+        self.assertIs(packed, handle)
+        self.assertTrue(handle.used)
+        with self.assertRaisesRegex(RuntimeError, "before recomputation"):
+            checkpoint_exclude_wrapper_module._unpack_saved_tensor(packed)
+        handle.materialize(recomputed.data)
+        unpacked = checkpoint_exclude_wrapper_module._unpack_saved_tensor(packed)
+        np.testing.assert_array_equal(unpacked.asnumpy(), recomputed.asnumpy())
+
+    def test_recompute_boundary_saves_zero_element_trigger(self):
+        """The replay boundary should not retain storage from its tensor output."""
+        packed_shapes = []
+        unpacked_shapes = []
+
+        def pack_hook(tensor: Tensor) -> Tensor:
+            """Record the tensor packed by the boundary."""
+            packed_shapes.append(tuple(tensor.shape))
+            return tensor
+
+        def unpack_hook(tensor: Tensor) -> Tensor:
+            """Record the tensor unpacked by the boundary."""
+            unpacked_shapes.append(tuple(tensor.shape))
+            return tensor
+
+        def apply_boundary(tensor: Tensor) -> Tensor:
+            """Apply the boundary in a differentiable function."""
+            return checkpoint_exclude_wrapper_module._RecomputeBoundary.apply(tensor).sum()
+
+        tensor = Tensor(np.arange(4, dtype=np.float32))
+        with ms.saved_tensors_hooks(pack_hook, unpack_hook):
+            _, grad = ms.value_and_grad(apply_boundary)(tensor)
+
+        self.assertEqual(packed_shapes, [(0,)])
+        self.assertEqual(unpacked_shapes, [(0,)])
+        np.testing.assert_array_equal(grad.asnumpy(), np.ones(4, dtype=np.float32))
+
+    def test_recompute_boundary_lazily_reuses_trigger(self):
+        """The boundary trigger should be created lazily and reused globally."""
+        get_trigger = checkpoint_exclude_wrapper_module._get_recompute_trigger
+        get_trigger.cache_clear()
+
+        self.assertEqual(get_trigger.cache_info().currsize, 0)
+        trigger = get_trigger()
+        self.assertIs(trigger, get_trigger())
+        self.assertEqual(trigger.dtype, ms.float32)
+        self.assertEqual(tuple(trigger.shape), (0,))
+        self.assertEqual(get_trigger.cache_info().currsize, 1)
+
+    def test_parameter_input_is_not_marked(self):
+        """Parameter inputs should keep the existing saved-tensor behavior."""
+        parameter = Parameter(Tensor(np.arange(4, dtype=np.float32)), name="exclude_parameter")
+
+        bindings, previous_handles = checkpoint_exclude_wrapper_module._mark_recompute_inputs((parameter,), {})
+
+        self.assertEqual(bindings, [])
+        self.assertEqual(previous_handles, [])
+
+    def test_input_marking_rolls_back_when_nested_traversal_fails(self):
+        """A traversal failure should not leave handles on inputs already visited."""
+        class _BrokenDict(dict):
+            """Raise while exposing nested items."""
+
+            def items(self) -> Any:
+                """Fail before returning nested items."""
+                raise RuntimeError("nested traversal failed")
+
+        tensor = Tensor(np.arange(4, dtype=np.float32))
+        key = checkpoint_exclude_wrapper_module._RECOMPUTE_INPUT_HANDLE_KEY
+
+        with self.assertRaisesRegex(RuntimeError, "nested traversal failed"):
+            checkpoint_exclude_wrapper_module._mark_recompute_inputs((tensor, _BrokenDict()), {})
+
+        self.assertIsNone(tensor._get_user_data(key))
+
+    def test_nested_input_paths_materialize_matching_replay_tensors(self):
+        """Nested args and kwargs should bind handles without retaining forward inputs."""
+        first = Tensor(np.array([1.0, 2.0], dtype=np.float32))
+        second = Tensor(np.array([3.0, 4.0], dtype=np.float32))
+        args = ({"items": [first]}, first)
+        kwargs = {"second": second}
+
+        bindings, previous_handles = checkpoint_exclude_wrapper_module._mark_recompute_inputs(args, kwargs)
+        checkpoint_exclude_wrapper_module._restore_recompute_inputs(previous_handles)
+        for binding in bindings:
+            binding.handle.mark_used()
+
+        replay_first = Tensor(np.array([5.0, 6.0], dtype=np.float32))
+        replay_second = Tensor(np.array([7.0, 8.0], dtype=np.float32))
+        entry = checkpoint_exclude_wrapper_module._ExcludeCacheEntry(output=None, input_bindings=bindings)
+        checkpoint_exclude_wrapper_module._materialize_recompute_inputs(
+            entry,
+            ({"items": [replay_first]}, replay_first),
+            {"second": replay_second},
+        )
+
+        self.assertEqual(len(bindings), 2)
+        self.assertEqual(bindings[0].path, (("arg", 0), ("key", "items"), ("index", 0)))
+        self.assertEqual(bindings[1].path, (("kwarg", "second"),))
+        np.testing.assert_array_equal(
+            bindings[0].handle.get_recomputed_tensor().asnumpy(), replay_first.asnumpy()
+        )
+        np.testing.assert_array_equal(
+            bindings[1].handle.get_recomputed_tensor().asnumpy(), replay_second.asnumpy()
+        )
+
+    def test_input_traversal_does_not_require_cycle_collection(self):
+        """Input traversal should release tensor leaves without waiting for cyclic GC."""
+        def traverse_tensor() -> weakref.ReferenceType:
+            """Collect a tensor input and return a non-owning reference to it."""
+            tensor = Tensor(np.arange(4, dtype=np.float32))
+            leaves = checkpoint_exclude_wrapper_module._collect_tensor_inputs(([tensor],), {})
+            self.assertEqual(len(leaves), 1)
+            return weakref.ref(tensor)
+
+        gc_was_enabled = gc.isenabled()
+        gc.disable()
+        try:
+            tensor_ref = traverse_tensor()
+            self.assertIsNone(tensor_ref())
+        finally:
+            if gc_was_enabled:
+                gc.enable()
+            gc.collect()
+
+    def test_recomputed_input_materializes_before_excluded_backward(self):
+        """A terminal excluded region should recover its saved input from replay."""
+        calls = {"block": 0, "excluded": 0}
+        _SaveExactInput.calls = 0
+        net = checkpoint_wrapper(_SavedInputBlock(calls))
+        tensor = Tensor(np.array([1.0, 2.0], dtype=np.float32))
+
+        value, grad = ms.value_and_grad(net, grad_position=0)(tensor)
+
+        np.testing.assert_allclose(value.asnumpy(), np.array(45.0, np.float32), atol=1e-6, rtol=1e-6)
+        np.testing.assert_allclose(
+            grad.asnumpy(),
+            np.array([18.0, 36.0], np.float32),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+        self.assertEqual(calls, {"block": 2, "excluded": 1})
+        self.assertEqual(_SaveExactInput.calls, 1)
 
     def test_function_wrapper_skips_middle_recompute(self):
         """A wrapped function should run in forward and reuse its output in recompute."""

--- a/tests/ut/platform/mindspore/activation_checkpoint/test_checkpoint_exclude_wrapper.py
+++ b/tests/ut/platform/mindspore/activation_checkpoint/test_checkpoint_exclude_wrapper.py
@@ -27,15 +27,17 @@ from tests.ut.platform.mindspore._ensure_mindspore_platform import (
 )
 
 ms = pytest.importorskip("mindspore")
-ParameterTuple = ms.ParameterTuple
 Parameter = ms.Parameter
 Tensor = ms.Tensor
 nn = ms.nn
 ops = ms.ops
-_Function = importlib.import_module("mindspore.common._grad_function")._Function
 _pynative_executor = importlib.import_module("mindspore.graph.api")._pynative_executor
 
 ensure_mindspore_platform_default()
+enable_mindspore_backward_compat = importlib.import_module(
+    "hyper_parallel.platform.mindspore.autograd_compat"
+).enable_mindspore_backward_compat
+enable_mindspore_backward_compat()
 
 activation_checkpoint = importlib.import_module("hyper_parallel.core.activation_checkpoint")
 checkpoint_wrapper = activation_checkpoint.checkpoint_wrapper
@@ -49,25 +51,6 @@ checkpoint_exclude_wrapper_module = importlib.import_module(
     "hyper_parallel.platform.mindspore.activation_checkpoint.checkpoint_exclude_wrapper"
 )
 CheckpointExcludeWrapper = checkpoint_exclude_wrapper_module.CheckpointExcludeWrapper
-
-
-class _SaveExactInput(_Function):
-    """Autograd function that saves its exact input for backward."""
-
-    calls = 0
-
-    @staticmethod
-    def forward(ctx: Any, tensor: Tensor) -> Tensor:
-        """Save the input and return its square."""
-        _SaveExactInput.calls += 1
-        ctx.save_for_backward(tensor)
-        return tensor * tensor
-
-    @staticmethod
-    def backward(ctx: Any, grad_output: Tensor) -> Tensor:
-        """Use the saved input to compute the square gradient."""
-        (tensor,) = ctx.saved_tensors
-        return grad_output * 2 * tensor
 
 
 class _FunctionBlock(nn.Cell):
@@ -126,7 +109,7 @@ class _SavedInputBlock(nn.Cell):
         def excluded(tensor: Tensor) -> Tensor:
             """Save the exact recomputed input without rerunning on replay."""
             self.calls["excluded"] += 1
-            return _SaveExactInput.apply(tensor)
+            return tensor * tensor
 
         self.excluded = checkpoint_exclude_wrapper(excluded)
 
@@ -134,6 +117,31 @@ class _SavedInputBlock(nn.Cell):
         """End the checkpoint body at the excluded region's scalar output."""
         self.calls["block"] += 1
         return self.excluded(tensor * 3).sum()
+
+
+class _MultiOutputSaveBlock(nn.Cell):
+    """Checkpointed block with two SAVE outputs consumed as one argument."""
+
+    def __init__(self, calls: dict) -> None:
+        """Initialize adjacent SAVE regions and their execution counters."""
+        super().__init__()
+
+        def first(tensor: Tensor) -> tuple:
+            """Return two differentiable outputs while saving the input."""
+            calls["first"] += 1
+            return tensor * tensor, tensor * tensor * tensor
+
+        def second(outputs: tuple) -> Tensor:
+            """Consume the complete structured output as one SAVE argument."""
+            calls["second"] += 1
+            return outputs[0] + outputs[1]
+
+        self.first = checkpoint_exclude_wrapper(first, save_output=False)
+        self.second = checkpoint_exclude_wrapper(second)
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """Return a loss depending on both outputs of the first SAVE region."""
+        return self.second(self.first(tensor)).sum()
 
 
 class _PrecisionMiddle(nn.Cell):
@@ -191,13 +199,19 @@ class _PrecisionBlock(nn.Cell):
 
 def _run_precision_sequence(net):
     """Run two different inputs through one network and collect all gradients."""
-    weights = ParameterTuple(net.trainable_params())
-    value_and_grad = ms.value_and_grad(net, grad_position=0, weights=weights)
+    weights = tuple(net.trainable_params())
     base_input = np.linspace(-1.5, 1.25, 24, dtype=np.float32).reshape(6, 4)
     results = []
     for scale in (1.0, 1.7):
-        value, (input_grad, param_grads) = value_and_grad(Tensor(base_input * scale))
+        tensor = Tensor(base_input * scale)
+        tensor.requires_grad = True
+        value = net(tensor)
+        value.backward()
+        input_grad = tensor.grad
+        param_grads = tuple(parameter.grad for parameter in weights)
         results.append((value, input_grad, tuple(param_grads)))
+        for parameter in weights:
+            parameter.grad = None
     return results
 
 
@@ -246,6 +260,7 @@ class TestCheckpointExcludeWrapper(unittest.TestCase):
         """Clear PyNative autodiff state left by earlier same-process tests."""
         ensure_mindspore_platform_default()
         _pynative_executor.clear_res()
+        _pynative_executor.set_grad_flag(True)
 
     def tearDown(self) -> None:
         """Keep this test's PyNative autodiff state away from later tests."""
@@ -296,33 +311,37 @@ class TestCheckpointExcludeWrapper(unittest.TestCase):
 
         def apply_boundary(tensor: Tensor) -> Tensor:
             """Apply the boundary in a differentiable function."""
-            return checkpoint_exclude_wrapper_module._RecomputeBoundary.apply(tensor).sum()
+            trigger = checkpoint_exclude_wrapper_module._get_recompute_trigger()
+            return checkpoint_exclude_wrapper_module._RecomputeBoundary.apply(tensor, trigger).sum()
 
         tensor = Tensor(np.arange(4, dtype=np.float32))
+        tensor.requires_grad = True
         with ms.saved_tensors_hooks(pack_hook, unpack_hook):
-            _, grad = ms.value_and_grad(apply_boundary)(tensor)
+            value = apply_boundary(tensor)
+            value.backward()
 
         self.assertEqual(packed_shapes, [(0,)])
         self.assertEqual(unpacked_shapes, [(0,)])
-        np.testing.assert_array_equal(grad.asnumpy(), np.ones(4, dtype=np.float32))
+        np.testing.assert_array_equal(tensor.grad.asnumpy(), np.ones(4, dtype=np.float32))
 
-    def test_recompute_boundary_lazily_reuses_trigger(self):
-        """The boundary trigger should be created lazily and reused globally."""
-        get_trigger = checkpoint_exclude_wrapper_module._get_recompute_trigger
-        get_trigger.cache_clear()
+    def test_replay_placeholder_is_lazily_reused(self):
+        """Replay should reuse one zero-element placeholder."""
+        get_placeholder = checkpoint_exclude_wrapper_module._get_replay_placeholder
+        get_placeholder.cache_clear()
 
-        self.assertEqual(get_trigger.cache_info().currsize, 0)
-        trigger = get_trigger()
-        self.assertIs(trigger, get_trigger())
-        self.assertEqual(trigger.dtype, ms.float32)
-        self.assertEqual(tuple(trigger.shape), (0,))
-        self.assertEqual(get_trigger.cache_info().currsize, 1)
+        self.assertEqual(get_placeholder.cache_info().currsize, 0)
+        placeholder = get_placeholder()
+        self.assertIs(placeholder, get_placeholder())
+        self.assertEqual(tuple(placeholder.shape), (0,))
+        self.assertEqual(get_placeholder.cache_info().currsize, 1)
 
     def test_parameter_input_is_not_marked(self):
         """Parameter inputs should keep the existing saved-tensor behavior."""
         parameter = Parameter(Tensor(np.arange(4, dtype=np.float32)), name="exclude_parameter")
 
-        bindings, previous_handles = checkpoint_exclude_wrapper_module._mark_recompute_inputs((parameter,), {})
+        bindings, previous_handles = checkpoint_exclude_wrapper_module._mark_recompute_inputs(
+            object(), (parameter,), {}
+        )
 
         self.assertEqual(bindings, [])
         self.assertEqual(previous_handles, [])
@@ -340,7 +359,9 @@ class TestCheckpointExcludeWrapper(unittest.TestCase):
         key = checkpoint_exclude_wrapper_module._RECOMPUTE_INPUT_HANDLE_KEY
 
         with self.assertRaisesRegex(RuntimeError, "nested traversal failed"):
-            checkpoint_exclude_wrapper_module._mark_recompute_inputs((tensor, _BrokenDict()), {})
+            checkpoint_exclude_wrapper_module._mark_recompute_inputs(
+                object(), (tensor, _BrokenDict()), {}
+            )
 
         self.assertIsNone(tensor._get_user_data(key))
 
@@ -351,14 +372,19 @@ class TestCheckpointExcludeWrapper(unittest.TestCase):
         args = ({"items": [first]}, first)
         kwargs = {"second": second}
 
-        bindings, previous_handles = checkpoint_exclude_wrapper_module._mark_recompute_inputs(args, kwargs)
+        bindings, previous_handles = checkpoint_exclude_wrapper_module._mark_recompute_inputs(
+            object(), args, kwargs
+        )
         checkpoint_exclude_wrapper_module._restore_recompute_inputs(previous_handles)
         for binding in bindings:
             binding.handle.mark_used()
 
         replay_first = Tensor(np.array([5.0, 6.0], dtype=np.float32))
         replay_second = Tensor(np.array([7.0, 8.0], dtype=np.float32))
-        entry = checkpoint_exclude_wrapper_module._ExcludeCacheEntry(output=None, input_bindings=bindings)
+        entry = checkpoint_exclude_wrapper_module._ExcludeCacheEntry(
+            output=None,
+            input_bindings=bindings,
+        )
         checkpoint_exclude_wrapper_module._materialize_recompute_inputs(
             entry,
             ({"items": [replay_first]}, replay_first),
@@ -397,21 +423,78 @@ class TestCheckpointExcludeWrapper(unittest.TestCase):
     def test_recomputed_input_materializes_before_excluded_backward(self):
         """A terminal excluded region should recover its saved input from replay."""
         calls = {"block": 0, "excluded": 0}
-        _SaveExactInput.calls = 0
         net = checkpoint_wrapper(_SavedInputBlock(calls))
         tensor = Tensor(np.array([1.0, 2.0], dtype=np.float32))
+        tensor.requires_grad = True
 
-        value, grad = ms.value_and_grad(net, grad_position=0)(tensor)
+        value = net(tensor)
+        value.backward()
 
         np.testing.assert_allclose(value.asnumpy(), np.array(45.0, np.float32), atol=1e-6, rtol=1e-6)
         np.testing.assert_allclose(
-            grad.asnumpy(),
+            tensor.grad.asnumpy(),
             np.array([18.0, 36.0], np.float32),
             atol=1e-6,
             rtol=1e-6,
         )
         self.assertEqual(calls, {"block": 2, "excluded": 1})
-        self.assertEqual(_SaveExactInput.calls, 1)
+
+    def test_save_output_source_is_not_marked_for_recomputation(self):
+        """Inputs produced by SAVE regions should remain owned by their downstream pack."""
+        invocation_id = object()
+        tensor = Tensor(np.arange(4, dtype=np.float32))
+        tensor.requires_grad = True
+        output = checkpoint_exclude_wrapper_module._finalize_save_outputs(tensor, True, invocation_id)
+
+        bindings, previous_handles = checkpoint_exclude_wrapper_module._mark_recompute_inputs(
+            invocation_id, (output,), {}
+        )
+
+        self.assertEqual(bindings, [])
+        self.assertEqual(previous_handles, [])
+
+        bindings, previous_handles = checkpoint_exclude_wrapper_module._mark_recompute_inputs(
+            object(), (output,), {}
+        )
+        checkpoint_exclude_wrapper_module._restore_recompute_inputs(previous_handles)
+        self.assertEqual(len(bindings), 1)
+
+    def test_elided_output_cache_does_not_retain_tensor_storage(self):
+        """An elided SAVE output cache should not own the forward tensor."""
+        tensor = Tensor(np.arange(4, dtype=np.float32))
+        tensor_ref = weakref.ref(tensor)
+
+        entry = checkpoint_exclude_wrapper_module._ExcludeCacheEntry(
+            output=None,
+            input_bindings=[],
+        )
+        del tensor
+
+        self.assertIsNone(tensor_ref())
+        self.assertIsNone(entry.output)
+        placeholder = checkpoint_exclude_wrapper_module._get_replay_placeholder()
+        self.assertEqual(tuple(placeholder.shape), (0,))
+        self.assertEqual(placeholder.dtype, ms.float32)
+        self.assertFalse(placeholder._requires_grad)  # pylint: disable=protected-access
+
+    def test_elided_multi_output_replay_preserves_boundary_count(self):
+        """Replay should create one placeholder boundary for each forward Tensor output."""
+        calls = {"first": 0, "second": 0}
+        net = checkpoint_wrapper(_MultiOutputSaveBlock(calls))
+        tensor = Tensor(np.array([1.0, 2.0], dtype=np.float32))
+        tensor.requires_grad = True
+
+        value = net(tensor)
+        value.backward()
+
+        np.testing.assert_allclose(value.asnumpy(), np.array(14.0, np.float32), atol=1e-6, rtol=1e-6)
+        np.testing.assert_allclose(
+            tensor.grad.asnumpy(),
+            np.array([5.0, 16.0], np.float32),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+        self.assertEqual(calls, {"first": 1, "second": 1})
 
     def test_function_wrapper_skips_middle_recompute(self):
         """A wrapped function should run in forward and reuse its output in recompute."""
@@ -420,8 +503,12 @@ class TestCheckpointExcludeWrapper(unittest.TestCase):
         net = checkpoint_wrapper(block)
         x = Tensor(np.arange(1, 5, dtype=np.float32))
         y = Tensor(np.full((4,), 2, dtype=np.float32))
+        x.requires_grad = True
+        y.requires_grad = True
 
-        value, grads = ms.value_and_grad(net, grad_position=(0, 1))(x, y)
+        value = net(x, y)
+        value.backward()
+        grads = (x.grad, y.grad)
 
         self.assertIsInstance(block.middle, CheckpointExcludeWrapper)
         self.assertEqual(calls["middle"], 1)
@@ -440,8 +527,10 @@ class TestCheckpointExcludeWrapper(unittest.TestCase):
         calls = {"middle": 0}
         net = checkpoint_wrapper(_StateBlock(states, calls))
         x = Tensor(np.arange(1, 5, dtype=np.float32))
+        x.requires_grad = True
 
-        _ = ms.value_and_grad(net, grad_position=0)(x)
+        value = net(x)
+        value.backward()
 
         self.assertEqual(states, [False, True])
         self.assertEqual(calls["middle"], 1)
@@ -476,8 +565,12 @@ class TestCheckpointExcludeWrapper(unittest.TestCase):
 
         x = Tensor(np.arange(1, 5, dtype=np.float32))
         y = Tensor(np.full((4,), 2, dtype=np.float32))
+        x.requires_grad = True
+        y.requires_grad = True
 
-        value, grads = ms.value_and_grad(forward, grad_position=(0, 1))(x, y)
+        value = forward(x, y)
+        value.backward()
+        grads = (x.grad, y.grad)
 
         self.assertEqual(calls["middle"], 2)
         np.testing.assert_allclose(value.asnumpy(), np.array(216.0, np.float32), atol=1e-6, rtol=1e-6)
@@ -510,26 +603,34 @@ class TestCheckpointExcludeWrapper(unittest.TestCase):
         net = checkpoint_wrapper(_FunctionBlock(calls), context_fn=context_fn)
         x = Tensor(np.arange(1, 5, dtype=np.float32))
         y = Tensor(np.full((4,), 2, dtype=np.float32))
+        x.requires_grad = True
+        y.requires_grad = True
 
-        value, grads = ms.value_and_grad(net, grad_position=(0, 1))(x, y)
+        value = net(x, y)
+        value.backward()
+        grads = (x.grad, y.grad)
 
         self.assertEqual(calls["middle"], 1)
         self.assertEqual(events, ["enter:forward", "exit:forward", "enter:recompute", "exit:recompute"])
         np.testing.assert_allclose(value.asnumpy(), np.array(80.0, np.float32), atol=1e-6, rtol=1e-6)
         np.testing.assert_allclose(grads[0].asnumpy(), np.full((4,), 8, np.float32), atol=1e-6, rtol=1e-6)
 
-    def test_platform_checkpoint_preserves_default_reentrant_behavior(self):
-        """The platform checkpoint API should retain MindSpore's reentrant default."""
+    def test_platform_checkpoint_supports_non_reentrant_compat_backward(self):
+        """The low-level checkpoint API should support compatibility backward."""
         calls = {"middle": 0}
         block = _FunctionBlock(calls)
         x = Tensor(np.arange(1, 5, dtype=np.float32))
         y = Tensor(np.full((4,), 2, dtype=np.float32))
+        x.requires_grad = True
+        y.requires_grad = True
 
         def forward(input_x: Tensor, input_y: Tensor) -> Tensor:
-            """Use the low-level platform checkpoint without checkpoint kwargs."""
-            return get_platform().checkpoint(block, input_x, input_y)
+            """Use the supported non-reentrant low-level checkpoint path."""
+            return get_platform().checkpoint(block, input_x, input_y, use_reentrant=False)
 
-        value, grads = ms.value_and_grad(forward, grad_position=(0, 1))(x, y)
+        value = forward(x, y)
+        value.backward()
+        grads = (x.grad, y.grad)
 
         self.assertEqual(calls["middle"], 2)
         np.testing.assert_allclose(value.asnumpy(), np.array(80.0, np.float32), atol=1e-6, rtol=1e-6)
@@ -539,6 +640,11 @@ class TestCheckpointExcludeWrapper(unittest.TestCase):
         """The public wrapper should reject values that cannot be executed."""
         with self.assertRaisesRegex(ValueError, "Cell or callable"):
             checkpoint_exclude_wrapper(1)
+
+    def test_rejects_non_boolean_save_output(self):
+        """The save_output option should reject ambiguous truthy values."""
+        with self.assertRaisesRegex(ValueError, "save_output must be a bool"):
+            checkpoint_exclude_wrapper(lambda tensor: tensor, save_output=1)
 
     def test_cell_wrapper_preserves_repeated_step_precision(self):
         """Repeated calls should match non-checkpoint values and all gradients."""


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

----

**What does this PR do / why do we need it**:

连续配置多个 checkpoint-excluded SAVE 区域时，
每个区域默认都会缓存完整输出，导致中间输出产生额外显存占用。

本 PR 为 `checkpoint_exclude_wrapper` 增加 `save_output` 参数，
默认值为 `True`，保持现有行为及前向兼容性。

当相邻 SAVE 区域显式配置 `save_output=False` 时，
区域内部通过 saved-tensor pack 保存的数据保持不变，
但不再缓存该区域的真实输出。

重放阶段根据正向输出中的 Tensor 叶子数量构造零元素占位结果，
保持正向和重放的自定义反向节点及 saved-tensor 序列一致。

通过 invocation 标记识别同一次 checkpoint 调用产生的 SAVE 输出，
直接传给后续 SAVE 时不再挂载多余的 recompute input handle。

RECOMPUTE→SAVE 边界继续通过延迟输入句柄触发重算，
并使用可微零元素 trigger 保证占位输出不参与求导时仍能建立边界节点。

同时合并输出边界处理和 SAVE 来源标记的递归遍历，
减少 Python Host 侧的重复结构遍历。

API 文档和 activation checkpoint 使用说明已同步更新。
本 PR 共修改 11 个文件，新增 1122 行，删除 50 行。

----

**Which issue(s) this PR fixes**:

Fixes #307

----

**Test Plan and Test result：What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

- MindSpore activation checkpoint UT：59 passed，1 skipped。
- Core activation checkpoint UT：23 passed。
- 单卡连续 SAVE 链 ST 通过。
- MindSpore activation checkpoint 并行 ST：8 个子场景全部通过。
- 覆盖 RECOMPUTE→SAVE、SAVE→SAVE→SAVE、多输出及嵌套输出场景。
- 覆盖默认 `save_output=True` 的兼容行为和非法调用校验。
- MindSpore 2.10.0 全局 trigger 长稳运行 50 万步，
  Device allocated 稳定为 512 B，10 万至 50 万步 RSS 仅增加 76 KiB。
- 每次新建 trigger 的对照实验运行 25 万步，
  Device 指标一致，10 万至 25 万步 RSS 仅增加 44 KiB。
- 未观察到 `lru_cache` 引入的持续 Device 或 Host 内存泄漏。

----

**Self-checklist**:

- [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
- [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
- [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
- [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
- [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- atomgit-backport-meta -->
atomgit_repo: mindspore/hyper-parallel
atomgit_mr: 1135
source_branch: feat/save-output-fusion-307
source_url: https://gitcode.com/mindspore/hyper-parallel/merge_requests/1135
<!-- /atomgit-backport-meta -->
