### PR TITLE
feat: rematerialize checkpoint-excluded saved inputs

### DIFF
--- a/hyper_parallel/platform/mindspore/activation_checkpoint/checkpoint_exclude_wrapper.py
+++ b/hyper_parallel/platform/mindspore/activation_checkpoint/checkpoint_exclude_wrapper.py
@@ -14,55 +14,240 @@
 # ============================================================================
 """MindSpore wrapper for regions that should be saved instead of recomputed."""
 from collections import defaultdict, deque
-from typing import Any, Callable, Deque, Dict
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, Callable, Deque, Dict, List, Tuple
+
+import mindspore as ms
+from mindspore.common._grad_function import _Function
 
 from hyper_parallel.core.activation_checkpoint.recompute_state import get_recompute_state
 from hyper_parallel.platform.mindspore.activation_checkpoint.activation_swap import ActivationWrapper
 
 
-class _CheckpointExcludeCache:
-    """Store excluded-region outputs for one checkpoint invocation."""
+_RECOMPUTE_INPUT_HANDLE_KEY = "hyper_parallel_recompute_input_handle"
+_InputPath = Tuple[Tuple[str, Any], ...]
+_TensorInput = Tuple[_InputPath, Any]
+
+
+class _RecomputedInputHandle:
+    """Defer one excluded-region saved input until checkpoint replay."""
+
+    def __init__(self) -> None:
+        """Initialize an unused and unresolved handle."""
+        self.used = False
+        self._tensor = None
+
+    def mark_used(self) -> None:
+        """Record that an exclude operation saved this input for backward."""
+        self.used = True
+
+    def materialize(self, tensor: Any) -> None:
+        """Bind the handle to the matching input produced during replay."""
+        self._tensor = tensor
+
+    def get_recomputed_tensor(self) -> Any:
+        """Return the replay-produced input for backward."""
+        if self._tensor is None:
+            raise RuntimeError("Checkpoint-excluded input was requested before recomputation")
+        return self._tensor
+
+
+@dataclass(frozen=True)
+class _InputBinding:
+    """Map one input path to its deferred saved-tensor handle."""
+
+    path: _InputPath
+    handle: _RecomputedInputHandle
+
+
+@dataclass
+class _ExcludeCacheEntry:
+    """Store one excluded call's output and deferred input bindings."""
+
+    output: Any
+    input_bindings: List[_InputBinding]
+
+
+class _ExcludeCache:
+    """Store excluded-region call entries for one checkpoint invocation."""
 
     def __init__(self) -> None:
         """Initialize an empty per-checkpoint output cache."""
-        self._outputs: Dict[int, Deque[Any]] = defaultdict(deque)
+        self._entries: Dict[int, Deque[_ExcludeCacheEntry]] = defaultdict(deque)
 
-    def save(self, wrapper_id: int, output: Any) -> None:
-        """Save one output produced by a checkpoint-excluded region."""
-        self._outputs[wrapper_id].append(output)
+    def save(self, wrapper_id: int, entry: _ExcludeCacheEntry) -> None:
+        """Save one call entry produced by a checkpoint-excluded region."""
+        self._entries[wrapper_id].append(entry)
 
-    def pop(self, wrapper_id: int) -> Any:
-        """Return the matching forward output during recomputation."""
-        outputs = self._outputs.get(wrapper_id)
-        if not outputs:
+    def pop(self, wrapper_id: int) -> _ExcludeCacheEntry:
+        """Return the matching forward call entry during recomputation."""
+        entries = self._entries.get(wrapper_id)
+        if not entries:
             raise RuntimeError("No cached forward output is available for this checkpoint exclusion wrapper")
-        output = outputs.popleft()
-        if not outputs:
-            self._outputs.pop(wrapper_id)
-        return output
+        entry = entries.popleft()
+        if not entries:
+            self._entries.pop(wrapper_id)
+        return entry
 
     def clear(self) -> None:
         """Release outputs not consumed because recomputation stopped early."""
-        self._outputs.clear()
+        self._entries.clear()
 
 
 def _pack_saved_tensor(tensor: Any) -> Any:
-    """Return the tensor data without retaining the input tensor object."""
+    """Return a deferred input handle or detached tensor data."""
+    handle = tensor._get_user_data(_RECOMPUTE_INPUT_HANDLE_KEY)  # pylint: disable=protected-access
+    if isinstance(handle, _RecomputedInputHandle):
+        handle.mark_used()
+        return handle
     return tensor.data
 
 
 def _unpack_saved_tensor(tensor: Any) -> Any:
     """Restore the saved tensor for backward."""
+    if isinstance(tensor, _RecomputedInputHandle):
+        return tensor.get_recomputed_tensor()
     return tensor
 
 
 def _saved_tensors_context() -> Any:
     """Create an inner hook that stores real tensors instead of placeholders."""
-    import mindspore as ms  # pylint: disable=C0415
     return ms.saved_tensors_hooks(_pack_saved_tensor, _unpack_saved_tensor)
 
 
-_CHECKPOINT_EXCLUDE_CACHE_KEY = object()
+_EXCLUDE_CACHE_KEY = object()
+
+
+def _append_tensor_inputs(
+    value: Any,
+    path: _InputPath,
+    leaves: List[_TensorInput],
+) -> None:
+    """Append tensor leaves without creating a self-referential local function."""
+    if isinstance(value, ms.Tensor):
+        leaves.append((path, value))
+        return
+    if isinstance(value, (tuple, list)):
+        for index, item in enumerate(value):
+            _append_tensor_inputs(item, path + (("index", index),), leaves)
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            _append_tensor_inputs(item, path + (("key", key),), leaves)
+
+
+def _collect_tensor_inputs(args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> List[_TensorInput]:
+    """Return tensor leaves and self-describing paths from one excluded-region call."""
+    leaves = []
+
+    for index, arg in enumerate(args):
+        _append_tensor_inputs(arg, (("arg", index),), leaves)
+    for key, value in kwargs.items():
+        _append_tensor_inputs(value, (("kwarg", key),), leaves)
+    return leaves
+
+
+def _mark_recompute_inputs(
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+) -> Tuple[List[_InputBinding], List[Tuple[Any, Any]]]:
+    """Attach deferred handles to non-parameter input tensors."""
+    bindings = []
+    previous_handles = []
+    seen_tensor_ids = set()
+    try:
+        for path, tensor in _collect_tensor_inputs(args, kwargs):
+            if isinstance(tensor, ms.Parameter) or id(tensor) in seen_tensor_ids:
+                continue
+            handle = _RecomputedInputHandle()
+            previous = tensor._get_user_data(_RECOMPUTE_INPUT_HANDLE_KEY)  # pylint: disable=protected-access
+            previous_handles.append((tensor, previous))
+            tensor._set_user_data(_RECOMPUTE_INPUT_HANDLE_KEY, handle)  # pylint: disable=protected-access
+            bindings.append(_InputBinding(path, handle))
+            seen_tensor_ids.add(id(tensor))
+    except BaseException:
+        _restore_recompute_inputs(previous_handles)
+        raise
+    return bindings, previous_handles
+
+
+def _restore_recompute_inputs(previous_handles: List[Tuple[Any, Any]]) -> None:
+    """Restore Tensor user data overwritten for one excluded call."""
+    for tensor, previous in previous_handles:
+        tensor._set_user_data(_RECOMPUTE_INPUT_HANDLE_KEY, previous)  # pylint: disable=protected-access
+
+
+def _resolve_input(args: Tuple[Any, ...], kwargs: Dict[str, Any], path: _InputPath) -> Any:
+    """Resolve one replay input from its forward argument path."""
+    root_kind, root_key = path[0]
+    value = args[root_key] if root_kind == "arg" else kwargs[root_key]
+    for _, token_value in path[1:]:
+        value = value[token_value]
+    return value
+
+
+def _materialize_recompute_inputs(
+    entry: _ExcludeCacheEntry,
+    args: Tuple[Any, ...],
+    kwargs: Dict[str, Any],
+) -> None:
+    """Bind used input handles to tensors produced during checkpoint replay."""
+    for binding in entry.input_bindings:
+        if not binding.handle.used:
+            continue
+        tensor = _resolve_input(args, kwargs, binding.path)
+        if not isinstance(tensor, ms.Tensor):
+            raise RuntimeError(
+                "Checkpoint replay did not reproduce a tensor input required by a checkpoint-excluded region"
+            )
+        binding.handle.materialize(tensor.data)
+
+
+def _has_used_input(input_bindings: List[_InputBinding]) -> bool:
+    """Return whether the excluded call saved any marked input."""
+    return any(binding.handle.used for binding in input_bindings)
+
+
+@lru_cache(maxsize=1)
+def _get_recompute_trigger() -> Any:
+    """Lazily create the reusable zero-element recomputation trigger."""
+    return ms.Tensor([], dtype=ms.float32)
+
+
+class _RecomputeBoundary(_Function):
+    """Trigger the outer checkpoint hook before excluded-region backward."""
+
+    @staticmethod
+    def forward(ctx: Any, tensor: Any) -> Any:
+        """Save one zero-element outer-hook dependency and return the tensor unchanged."""
+        ctx.save_for_backward(_get_recompute_trigger())
+        return tensor
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Any) -> Any:
+        """Trigger dependency unpack and pass the gradient through."""
+        _ = ctx.saved_tensors
+        return grad_output
+
+
+def _apply_recompute_boundary(output: Any, input_bindings: List[_InputBinding]) -> Any:
+    """Wrap output tensor leaves when deferred inputs require checkpoint replay."""
+    if not _has_used_input(input_bindings):
+        return output
+
+    if isinstance(output, ms.Tensor):
+        return _RecomputeBoundary.apply(output)
+    if isinstance(output, list):
+        return [_apply_recompute_boundary(item, input_bindings) for item in output]
+    if isinstance(output, tuple):
+        items = [_apply_recompute_boundary(item, input_bindings) for item in output]
+        if hasattr(output, "_fields"):
+            return type(output)(*items)
+        return tuple(items)
+    if isinstance(output, dict):
+        return type(output)((key, _apply_recompute_boundary(value, input_bindings)) for key, value in output.items())
+    return output
 
 
 class CheckpointExcludeWrapper(ActivationWrapper):
@@ -79,14 +264,20 @@ class CheckpointExcludeWrapper(ActivationWrapper):
         state = get_recompute_state()
         if state is None:
             return self._ckpt_wrapped_module(*args, **kwargs)
-        cache = state.get_resource(_CHECKPOINT_EXCLUDE_CACHE_KEY, _CheckpointExcludeCache)
+        cache = state.get_resource(_EXCLUDE_CACHE_KEY, _ExcludeCache)
         if state.is_recomputing:
-            return cache.pop(id(self))
+            entry = cache.pop(id(self))
+            _materialize_recompute_inputs(entry, args, kwargs)
+            return _apply_recompute_boundary(entry.output, entry.input_bindings)
 
-        with _saved_tensors_context():
-            output = self._ckpt_wrapped_module(*args, **kwargs)
-        cache.save(id(self), output)
-        return output
+        input_bindings, previous_handles = _mark_recompute_inputs(args, kwargs)
+        try:
+            with _saved_tensors_context():
+                output = self._ckpt_wrapped_module(*args, **kwargs)
+        finally:
+            _restore_recompute_inputs(previous_handles)
+        cache.save(id(self), _ExcludeCacheEntry(output, input_bindings))
+        return _apply_recompute_boundary(output, input_bindings)
 
 
 def checkpoint_exclude_wrapper(module: Callable[..., Any]) -> CheckpointExcludeWrapper:
@@ -103,5 +294,6 @@ def checkpoint_exclude_wrapper(module: Callable[..., Any]) -> CheckpointExcludeW
     Note:
         This feature requires MindSpore PyNative mode and a surrounding
         HyperParallel checkpoint configured with ``use_reentrant=False``.
+        Nested checkpoint exclusion wrappers are not supported.
     """
     return CheckpointExcludeWrapper(module)

--- a/tests/mindspore/st/activation_checkpoint/checkpoint_exclude_matmul.py
+++ b/tests/mindspore/st/activation_checkpoint/checkpoint_exclude_matmul.py
@@ -1,0 +1,201 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Validate checkpoint exclusion memory with stacked RMSNorm, MatMul, and SiLU."""
+import importlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any, Dict
+
+import mindspore as ms
+from mindspore import nn, Tensor
+import numpy as np
+
+from hyper_parallel.core.activation_checkpoint import checkpoint_exclude_wrapper, checkpoint_wrapper
+from hyper_parallel.platform.mindspore.autograd_compat import enable_mindspore_backward_compat
+
+
+enable_mindspore_backward_compat()
+
+
+_TOKEN_NUM = 16384
+_HIDDEN_SIZE = 2048
+_LAYER_NUM = 20
+_RESULT_MARKER = "__RMSNORM_MATMUL_RESULT__"
+
+
+class _CountedMatmul(nn.Cell):
+    """MatMul that records whether checkpoint replay executes it."""
+
+    def __init__(self, calls: Dict[str, int]) -> None:
+        """Initialize a deterministic square projection."""
+        super().__init__()
+        self.calls = calls
+        rng = np.random.default_rng(2026)
+        weight = rng.normal(0.0, 0.02, (_HIDDEN_SIZE, _HIDDEN_SIZE)).astype(np.float32)
+        self.weight = ms.Parameter(Tensor(weight, ms.bfloat16), name="matmul_weight")
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """Apply the projection."""
+        self.calls["matmul"] += 1
+        return ms.ops.matmul(tensor, self.weight)
+
+
+class _RmsNormMatmulBlock(nn.Cell):
+    """Apply RMSNorm, an excluded MatMul, and SiLU."""
+
+    def __init__(self, calls: Dict[str, int]) -> None:
+        """Initialize one checkpointed layer."""
+        super().__init__()
+        self.rms_norm = ms.ops.RmsNorm(epsilon=1e-6)
+        self.norm_weight = ms.Parameter(ms.ops.ones((_HIDDEN_SIZE,), ms.bfloat16), name="norm_weight")
+        self.matmul = checkpoint_exclude_wrapper(_CountedMatmul(calls))
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """Run the layer."""
+        normalized = self.rms_norm(tensor, self.norm_weight)[0]
+        return ms.ops.silu(self.matmul(normalized))
+
+
+class _RmsNormMatmulNet(nn.Cell):
+    """Stack individually checkpointed layers."""
+
+    def __init__(self, calls: Dict[str, int]) -> None:
+        """Create one checkpoint for each layer."""
+        super().__init__()
+        self.layers = nn.CellList([
+            checkpoint_wrapper(_RmsNormMatmulBlock(calls))
+            for _ in range(_LAYER_NUM)
+        ])
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """Run all layers and return a scalar loss."""
+        for layer in self.layers:
+            tensor = layer(tensor)
+        return ms.ops.sum(ms.ops.square(tensor))
+
+
+def _run_exclude() -> Dict[str, Any]:
+    """Run one optimized or legacy exclusion step."""
+    ms.set_deterministic(True)
+    ms.set_context(mode=ms.PYNATIVE_MODE)
+    calls = {"matmul": 0}
+    net = _RmsNormMatmulNet(calls)
+    rng = np.random.default_rng(2027)
+    input_data = rng.normal(0.0, 0.5, (_TOKEN_NUM, _HIDDEN_SIZE)).astype(np.float32)
+
+    warmup_input = Tensor(input_data, ms.bfloat16)
+    warmup_input.requires_grad = True
+    warmup_loss = net(warmup_input)
+    warmup_loss.backward()
+    ms.runtime.synchronize()
+    for parameter in net.trainable_params():
+        parameter.grad = None
+    del warmup_input, warmup_loss
+    calls["matmul"] = 0
+    ms.runtime.empty_cache()
+
+    baseline_bytes = ms.runtime.memory_allocated()
+    ms.runtime.reset_peak_memory_stats()
+    tensor = Tensor(input_data, ms.bfloat16)
+    tensor.requires_grad = True
+    loss = net(tensor)
+    ms.runtime.synchronize()
+    forward_bytes = ms.runtime.memory_allocated() - baseline_bytes
+    loss.backward()
+    ms.runtime.synchronize()
+
+    return {
+        "loss": float(loss.asnumpy()),
+        "matmul_calls": calls["matmul"],
+        "forward_bytes": int(forward_bytes),
+        "peak_bytes": int(ms.runtime.max_memory_allocated() - baseline_bytes),
+    }
+
+
+def _disable_input_rematerialization(args: Any, kwargs: Any) -> tuple:
+    """Reproduce legacy exclusion, which retains saved input storage."""
+    del args, kwargs
+    return [], []
+
+
+def _run_mode(mode: str) -> Dict[str, Any]:
+    """Run optimized or legacy checkpoint exclusion."""
+    if mode == "exclude":
+        return _run_exclude()
+    if mode != "legacy_exclude":
+        raise ValueError(f"Unsupported RMSNorm/MatMul mode: {mode}")
+
+    exclude_module = importlib.import_module(
+        "hyper_parallel.platform.mindspore.activation_checkpoint.checkpoint_exclude_wrapper"
+    )
+    original_mark = exclude_module._mark_recompute_inputs  # pylint: disable=protected-access
+    exclude_module._mark_recompute_inputs = _disable_input_rematerialization  # pylint: disable=protected-access
+    try:
+        return _run_exclude()
+    finally:
+        exclude_module._mark_recompute_inputs = original_mark  # pylint: disable=protected-access
+
+
+def _run_mode_in_subprocess(mode: str) -> Dict[str, Any]:
+    """Run one mode in an isolated allocator process."""
+    project_root = Path(__file__).resolve().parents[4]
+    command = [
+        sys.executable,
+        "-c",
+        (
+            "import json; "
+            "from tests.mindspore.st.activation_checkpoint.checkpoint_exclude_matmul import _run_mode; "
+            f"print({_RESULT_MARKER!r} + json.dumps(_run_mode({mode!r})))"
+        ),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=1200,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"RMSNorm/MatMul subprocess exited with code {completed.returncode}.\n"
+            f"STDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+        )
+    for line in reversed(completed.stdout.splitlines()):
+        if _RESULT_MARKER in line:
+            return json.loads(line.split(_RESULT_MARKER, maxsplit=1)[1])
+    raise RuntimeError(
+        "RMSNorm/MatMul subprocess did not produce a result marker.\n"
+        f"STDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+    )
+
+
+def test_rmsnorm_matmul_checkpoint_exclude_memory() -> None:
+    """Optimized exclusion should retain less memory than legacy exclusion."""
+    excluded = _run_mode_in_subprocess("exclude")
+    legacy = _run_mode_in_subprocess("legacy_exclude")
+
+    assert excluded["loss"] == legacy["loss"]
+    assert excluded["matmul_calls"] == _LAYER_NUM
+    assert legacy["matmul_calls"] == _LAYER_NUM
+
+    expected_gap = _LAYER_NUM * _TOKEN_NUM * _HIDDEN_SIZE * 2
+    tolerance = expected_gap // 4
+    forward_gap = legacy["forward_bytes"] - excluded["forward_bytes"]
+    peak_gap = legacy["peak_bytes"] - excluded["peak_bytes"]
+    assert abs(forward_gap - expected_gap) <= tolerance
+    assert abs(peak_gap - expected_gap) <= tolerance

--- a/tests/mindspore/st/activation_checkpoint/test_ckpt_activation.py
+++ b/tests/mindspore/st/activation_checkpoint/test_ckpt_activation.py
@@ -1,3 +1,8 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -30,5 +35,6 @@ def test_sac_group():
         MindSporeCase(BASE_SHARD, "test_swap_manager_manual_group_api", 11640, 1),
         MindSporeCase(BASE_SHARD, "test_inplace_modification", 11641, 1),
         MindSporeCase(BASE_SHARD, "test_wrapper_overlap_detection_cases", 11642, 1),
-        MindSporeCase(BASE_SHARD, "test_wrapper_non_overlapping_allowed_cases", 11643, 1)
+        MindSporeCase(BASE_SHARD, "test_wrapper_non_overlapping_allowed_cases", 11643, 1),
+        MindSporeCase("checkpoint_exclude_matmul.py", "test_rmsnorm_matmul_checkpoint_exclude_memory", 11644, 1),
     ])

--- a/tests/ut/platform/mindspore/activation_checkpoint/test_checkpoint_exclude_wrapper.py
+++ b/tests/ut/platform/mindspore/activation_checkpoint/test_checkpoint_exclude_wrapper.py
@@ -14,9 +14,11 @@
 # ============================================================================
 """Tests for the MindSpore checkpoint exclusion wrapper."""
 import contextlib
+import gc
 import importlib
-from typing import Iterator, Tuple
+from typing import Any, Iterator, Tuple
 import unittest
+import weakref
 
 import numpy as np
 import pytest
@@ -26,9 +28,11 @@ from tests.ut.platform.mindspore._ensure_mindspore_platform import (
 
 ms = pytest.importorskip("mindspore")
 ParameterTuple = ms.ParameterTuple
+Parameter = ms.Parameter
 Tensor = ms.Tensor
 nn = ms.nn
 ops = ms.ops
+_Function = importlib.import_module("mindspore.common._grad_function")._Function
 _pynative_executor = importlib.import_module("mindspore.graph.api")._pynative_executor
 
 ensure_mindspore_platform_default()
@@ -45,6 +49,25 @@ checkpoint_exclude_wrapper_module = importlib.import_module(
     "hyper_parallel.platform.mindspore.activation_checkpoint.checkpoint_exclude_wrapper"
 )
 CheckpointExcludeWrapper = checkpoint_exclude_wrapper_module.CheckpointExcludeWrapper
+
+
+class _SaveExactInput(_Function):
+    """Autograd function that saves its exact input for backward."""
+
+    calls = 0
+
+    @staticmethod
+    def forward(ctx: Any, tensor: Tensor) -> Tensor:
+        """Save the input and return its square."""
+        _SaveExactInput.calls += 1
+        ctx.save_for_backward(tensor)
+        return tensor * tensor
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> Tensor:
+        """Use the saved input to compute the square gradient."""
+        (tensor,) = ctx.saved_tensors
+        return grad_output * 2 * tensor
 
 
 class _FunctionBlock(nn.Cell):
@@ -90,6 +113,27 @@ class _StateBlock(nn.Cell):
         self.states.append(is_recomputing())
         output = self.middle(x * 2)
         return (output * x).sum()
+
+
+class _SavedInputBlock(nn.Cell):
+    """Checkpointed block whose excluded tail saves its exact input."""
+
+    def __init__(self, calls: dict) -> None:
+        """Wrap a custom saved-input function and retain the shared counter."""
+        super().__init__()
+        self.calls = calls
+
+        def excluded(tensor: Tensor) -> Tensor:
+            """Save the exact recomputed input without rerunning on replay."""
+            self.calls["excluded"] += 1
+            return _SaveExactInput.apply(tensor)
+
+        self.excluded = checkpoint_exclude_wrapper(excluded)
+
+    def construct(self, tensor: Tensor) -> Tensor:
+        """End the checkpoint body at the excluded region's scalar output."""
+        self.calls["block"] += 1
+        return self.excluded(tensor * 3).sum()
 
 
 class _PrecisionMiddle(nn.Cell):
@@ -216,6 +260,158 @@ class TestCheckpointExcludeWrapper(unittest.TestCase):
         self.assertIsNot(packed, tensor)
         np.testing.assert_array_equal(packed.asnumpy(), tensor.asnumpy())
         self.assertIs(checkpoint_exclude_wrapper_module._unpack_saved_tensor(packed), packed)
+
+    def test_saved_tensor_hook_uses_tensor_user_data_handle(self):
+        """Tensor user data should carry the deferred handle into the pack hook."""
+        tensor = Tensor(np.arange(4, dtype=np.float32))
+        recomputed = Tensor(np.arange(4, dtype=np.float32) * 2)
+        handle = checkpoint_exclude_wrapper_module._RecomputedInputHandle()
+        key = checkpoint_exclude_wrapper_module._RECOMPUTE_INPUT_HANDLE_KEY
+        tensor._set_user_data(key, handle)
+
+        packed = checkpoint_exclude_wrapper_module._pack_saved_tensor(tensor)
+
+        self.assertIs(packed, handle)
+        self.assertTrue(handle.used)
+        with self.assertRaisesRegex(RuntimeError, "before recomputation"):
+            checkpoint_exclude_wrapper_module._unpack_saved_tensor(packed)
+        handle.materialize(recomputed.data)
+        unpacked = checkpoint_exclude_wrapper_module._unpack_saved_tensor(packed)
+        np.testing.assert_array_equal(unpacked.asnumpy(), recomputed.asnumpy())
+
+    def test_recompute_boundary_saves_zero_element_trigger(self):
+        """The replay boundary should not retain storage from its tensor output."""
+        packed_shapes = []
+        unpacked_shapes = []
+
+        def pack_hook(tensor: Tensor) -> Tensor:
+            """Record the tensor packed by the boundary."""
+            packed_shapes.append(tuple(tensor.shape))
+            return tensor
+
+        def unpack_hook(tensor: Tensor) -> Tensor:
+            """Record the tensor unpacked by the boundary."""
+            unpacked_shapes.append(tuple(tensor.shape))
+            return tensor
+
+        def apply_boundary(tensor: Tensor) -> Tensor:
+            """Apply the boundary in a differentiable function."""
+            return checkpoint_exclude_wrapper_module._RecomputeBoundary.apply(tensor).sum()
+
+        tensor = Tensor(np.arange(4, dtype=np.float32))
+        with ms.saved_tensors_hooks(pack_hook, unpack_hook):
+            _, grad = ms.value_and_grad(apply_boundary)(tensor)
+
+        self.assertEqual(packed_shapes, [(0,)])
+        self.assertEqual(unpacked_shapes, [(0,)])
+        np.testing.assert_array_equal(grad.asnumpy(), np.ones(4, dtype=np.float32))
+
+    def test_recompute_boundary_lazily_reuses_trigger(self):
+        """The boundary trigger should be created lazily and reused globally."""
+        get_trigger = checkpoint_exclude_wrapper_module._get_recompute_trigger
+        get_trigger.cache_clear()
+
+        self.assertEqual(get_trigger.cache_info().currsize, 0)
+        trigger = get_trigger()
+        self.assertIs(trigger, get_trigger())
+        self.assertEqual(trigger.dtype, ms.float32)
+        self.assertEqual(tuple(trigger.shape), (0,))
+        self.assertEqual(get_trigger.cache_info().currsize, 1)
+
+    def test_parameter_input_is_not_marked(self):
+        """Parameter inputs should keep the existing saved-tensor behavior."""
+        parameter = Parameter(Tensor(np.arange(4, dtype=np.float32)), name="exclude_parameter")
+
+        bindings, previous_handles = checkpoint_exclude_wrapper_module._mark_recompute_inputs((parameter,), {})
+
+        self.assertEqual(bindings, [])
+        self.assertEqual(previous_handles, [])
+
+    def test_input_marking_rolls_back_when_nested_traversal_fails(self):
+        """A traversal failure should not leave handles on inputs already visited."""
+        class _BrokenDict(dict):
+            """Raise while exposing nested items."""
+
+            def items(self) -> Any:
+                """Fail before returning nested items."""
+                raise RuntimeError("nested traversal failed")
+
+        tensor = Tensor(np.arange(4, dtype=np.float32))
+        key = checkpoint_exclude_wrapper_module._RECOMPUTE_INPUT_HANDLE_KEY
+
+        with self.assertRaisesRegex(RuntimeError, "nested traversal failed"):
+            checkpoint_exclude_wrapper_module._mark_recompute_inputs((tensor, _BrokenDict()), {})
+
+        self.assertIsNone(tensor._get_user_data(key))
+
+    def test_nested_input_paths_materialize_matching_replay_tensors(self):
+        """Nested args and kwargs should bind handles without retaining forward inputs."""
+        first = Tensor(np.array([1.0, 2.0], dtype=np.float32))
+        second = Tensor(np.array([3.0, 4.0], dtype=np.float32))
+        args = ({"items": [first]}, first)
+        kwargs = {"second": second}
+
+        bindings, previous_handles = checkpoint_exclude_wrapper_module._mark_recompute_inputs(args, kwargs)
+        checkpoint_exclude_wrapper_module._restore_recompute_inputs(previous_handles)
+        for binding in bindings:
+            binding.handle.mark_used()
+
+        replay_first = Tensor(np.array([5.0, 6.0], dtype=np.float32))
+        replay_second = Tensor(np.array([7.0, 8.0], dtype=np.float32))
+        entry = checkpoint_exclude_wrapper_module._ExcludeCacheEntry(output=None, input_bindings=bindings)
+        checkpoint_exclude_wrapper_module._materialize_recompute_inputs(
+            entry,
+            ({"items": [replay_first]}, replay_first),
+            {"second": replay_second},
+        )
+
+        self.assertEqual(len(bindings), 2)
+        self.assertEqual(bindings[0].path, (("arg", 0), ("key", "items"), ("index", 0)))
+        self.assertEqual(bindings[1].path, (("kwarg", "second"),))
+        np.testing.assert_array_equal(
+            bindings[0].handle.get_recomputed_tensor().asnumpy(), replay_first.asnumpy()
+        )
+        np.testing.assert_array_equal(
+            bindings[1].handle.get_recomputed_tensor().asnumpy(), replay_second.asnumpy()
+        )
+
+    def test_input_traversal_does_not_require_cycle_collection(self):
+        """Input traversal should release tensor leaves without waiting for cyclic GC."""
+        def traverse_tensor() -> weakref.ReferenceType:
+            """Collect a tensor input and return a non-owning reference to it."""
+            tensor = Tensor(np.arange(4, dtype=np.float32))
+            leaves = checkpoint_exclude_wrapper_module._collect_tensor_inputs(([tensor],), {})
+            self.assertEqual(len(leaves), 1)
+            return weakref.ref(tensor)
+
+        gc_was_enabled = gc.isenabled()
+        gc.disable()
+        try:
+            tensor_ref = traverse_tensor()
+            self.assertIsNone(tensor_ref())
+        finally:
+            if gc_was_enabled:
+                gc.enable()
+            gc.collect()
+
+    def test_recomputed_input_materializes_before_excluded_backward(self):
+        """A terminal excluded region should recover its saved input from replay."""
+        calls = {"block": 0, "excluded": 0}
+        _SaveExactInput.calls = 0
+        net = checkpoint_wrapper(_SavedInputBlock(calls))
+        tensor = Tensor(np.array([1.0, 2.0], dtype=np.float32))
+
+        value, grad = ms.value_and_grad(net, grad_position=0)(tensor)
+
+        np.testing.assert_allclose(value.asnumpy(), np.array(45.0, np.float32), atol=1e-6, rtol=1e-6)
+        np.testing.assert_allclose(
+            grad.asnumpy(),
+            np.array([18.0, 36.0], np.float32),
+            atol=1e-6,
+            rtol=1e-6,
+        )
+        self.assertEqual(calls, {"block": 2, "excluded": 1})
+        self.assertEqual(_SaveExactInput.calls, 1)
 
     def test_function_wrapper_skips_middle_recompute(self):
         """A wrapped function should run in forward and reuse its output in recompute."""


### PR DESCRIPTION
Paired: [GitHub #88](https://github.com/mindspore-ai/hyper-parallel/pull/88) ↔ [GitCode !1555](https://gitcode.com/mindspore/hyper-parallel/merge_requests/1555)

Related issue: #307

Design document: https://gitcode.com/mindspore/hyper-parallel/issues/307#note_183780633

## Summary

- rematerialize checkpoint-excluded saved inputs from replay instead of retaining forward activation storage
- add input-path bindings, replay boundary ordering, Parameter filtering, and failure rollback
- add RMSNorm + GMM end-to-end ST with recompute/exclude/legacy memory comparison

## Tests

- MindSpore activation-checkpoint UT: `52 passed, 1 skipped`
- RMSNorm + GMM checkpoint-exclude ST: `1 passed`
- basic and function-level recompute ST: `2 passed`
- pylint, lizard, py_compile, and `git diff --check`

## GMM memory observation

For an `8192 x 2048` bf16 activation (32 MiB):

- forward allocated increment (recompute/exclude/legacy): `0/64/64 MiB`
- full-step peak increment (recompute/exclude/legacy): `256/288/256 MiB`

The saved RMSNorm input hits the rematerialization handle and GMM execution drops from two calls to one. MindSpore GMM output graph retention means this topology does not show a net forward-memory reduction; the ST validates correctness, call count, and explainable memory upper bounds.

<!-- atomgit-backport-meta -->
atomgit_repo: mindspore/hyper-parallel
atomgit_mr: 1131
source_branch: hyper-parallel-recompute-opt
source_url: https://gitcode.com/mindspore/hyper-parallel/merge_requests/1131
<!-- /atomgit-backport-meta -->
