### PR TITLE
feat: 支持算子级显存 dry-run 分析

### DIFF
--- a/design.md
+++ b/design.md
@@ -1,0 +1,367 @@
+# HyperDryRun：面向大模型分布式训练的无卡显存分析
+
+## 1. 背景与目标
+
+大模型参数规模、序列长度和并行规模持续增长后，显存是否足够通常只能通过申请真实 NPU/GPU 集群、启动完整训练任务来验证。一次配置调整需要经历资源申请、排队、环境启动、运行失败和重新配置，失败任务还会造成整组设备空转。
+
+静态参数量公式只能给出参数、梯度和优化器状态的理论常驻量，难以覆盖训练过程中的以下动态峰值：
+
+- HyperParallel FSDP/HSDP 参数 all-gather、reduce-scatter 和融合通信缓冲区；
+- 前向激活、反向临时张量、梯度累积和优化器首次建 state；
+- `reshard_after_forward`、激活重计算以及 `resize_(0)` 引起的生命周期变化；
+- TP、CP、EP 与 FSDP 组合后每个 rank 不同的本地 shape；
+- 峰值所在的模型层和前向/反向阶段。
+
+HyperDryRun 的目标是在不初始化真实加速卡、不执行数值计算的前提下，复用 Trainer 的模型构建和模型自有 `parallelize_fn`，模拟一个完整训练 step，输出目标 rank 的逻辑张量显存峰值、构成和模块定位信息。
+
+首版目标：
+
+1. 通过现有 `scripts/train_lm.py` 和训练 YAML 一键启用；
+2. 单进程模拟目标 world size 和 rank，不要求其他进程在线；
+3. 首个可验收基线覆盖 Torch Trainer 的 FSDP；runner 复用模型完整 `parallelize_fn`，HSDP、TP/CP/EP 和激活重计算组合按第 9 节兼容矩阵逐项纳入；
+4. 覆盖参数、buffer、激活、梯度、反向临时张量、优化器状态和通信张量；
+5. 输出稳定、可机读的 JSON 报告，并给出 OOM 风险判断；
+6. 对不支持的模型算子、数据依赖 shape 和配置给出明确错误，不回退到真实设备执行。
+
+## 2. 非目标与术语
+
+### 2.1 首版非目标
+
+- MindSpore 后端：配置入口保留，但启用时明确报错；待 MindSpore 提供等价 fake execution 和内存跟踪能力后扩展。
+- Pipeline Parallel：PP schedule 涉及跨 stage P2P 和仅首 stage 读数据，首版不输出估算结果，启用 `pp > 1` 时 fail-fast。
+- 加速卡 allocator 的 reserved memory、碎片、框架上下文、kernel workspace 和第三方 fused kernel 内部临时显存。
+- 通信耗时、计算耗时和吞吐量预测。
+- 数据依赖动态 shape（例如从 Tensor 值决定 token 数或分支）的自动求解。
+- 加载 checkpoint 的数值内容。Dry-run 只需要架构、dtype 和 shape；`weights_path` 仍可供模型读取配置，但不会加载权重 Tensor。
+
+### 2.2 统计口径
+
+报告中的“显存”是目标设备上、可由 TorchDispatch 观察到的**逻辑 live tensor bytes**，不是 `nvidia-smi`/NPU SMI 的 reserved bytes。分类沿用 PyTorch `MemTracker`：
+
+| 分类 | 含义 |
+| --- | --- |
+| Parameter | 当前 rank 的参数 shard，以及 FSDP unshard 后仍存活的参数存储 |
+| Buffer | module buffer |
+| Activation | 前向产生且仍存活的张量 |
+| Gradient | 参数梯度 |
+| Temp | 反向临时张量 |
+| Optstate | AdamW 首次 step 创建的优化器状态 |
+| Other | 显式纳入跟踪但无法归入上述类别的输入等张量 |
+
+通信算子由 PyTorch fake collectives 执行 meta kernel，产生的通信输出仍由 `MemTracker` 按其生命周期归入 Activation/Temp；报告额外记录所用并行拓扑和 `comm_fusion`，避免把通信张量误解为独立常驻项。
+
+## 3. 用户接口
+
+### 3.1 YAML 配置
+
+在严格三层配置的 `train` 下新增：
+
+```yaml
+train:
+  dry_run:
+    enabled: true
+    world_size: 8        # 可省略；仅当并行度能够完全推导时自动计算
+    rank: 0              # 需要分析的逻辑 rank
+    device_type: npu     # 可选 npu/cuda；CPU-only 环境建议显式填写
+    output_dir: outputs/dry_run
+    module_depth: 3      # JSON 中展开的 module FQN 深度，0 表示不限制
+    top_modules: 20      # 按局部峰值输出的热点模块数，0 表示全部
+    device_memory_gib: 64.0  # 可选；用于 OOM 风险判断
+```
+
+等价 CLI：
+
+```bash
+python scripts/train_lm.py train.yaml \
+  --train.dry_run.enabled=true \
+  --train.dry_run.world_size=8 \
+  --train.dry_run.rank=0
+```
+
+运行成功后不进入正常 `trainer.train()`，只执行一次 dry-run，并写入：
+
+```text
+<output_dir>/rank_<rank>.json
+<output_dir>/rank_<rank>_memory.csv
+```
+
+### 3.2 配置校验
+
+- `backend` 必须是 `torch`；
+- PyTorch 必须为 2.7 或更高版本。2.6 的 `MemTracker` 尚未集成 fake collectives/DTensor dispatch，不能可靠统计 HyperParallel 通信；
+- `rank >= 0`、`world_size > 0`、`rank < world_size`；
+- `device_type` 只能是 `npu`、`cuda` 或空；为空时按当前 Torch 扩展推断，CPU-only 环境应显式配置以避免目标歧义；
+- `module_depth >= 0`、`top_modules >= 0`、`device_memory_gib > 0`（若配置）；
+- `world_size` 与 `dp_replicate * dp_shard * ep * cp * tp * pp` 必须一致；当 `dp_shard` 为自动值时必须显式提供 `world_size`；
+- `pp` 必须为 1；
+- Phase 1 正式支持 `dp_shard` FSDP 和 `activation checkpoint=full`；`dp_replicate/tp/cp/ep/etp > 1`、CPU offload 或 selective activation checkpoint 当前 fail-fast，待对应 CPU fake 集成用例和内存不变量通过后再放开；
+- 为保证无卡，dry-run 内部强制使用 meta 初始化；用户的 `init_device` 只记录到报告，不触发真实分配；
+- `weights_path` 不加载权重数据，但仍允许模型 factory 从中读取纯配置文件。若 factory 自身无条件加载 Tensor，错误会被包装为不支持提示。
+
+## 4. 总体架构
+
+```text
+parse_args / discover_model_spec
+            |
+            v
+  dry_run.enabled ? ---------------------- no --> LLMTrainer.train()
+            |
+           yes
+            v
+ TorchDryRunRunner
+   1. 校验配置并复制 args（init_device 强制 meta）
+   2. 注册 fake ProcessGroup backend
+   3. 单进程创建目标 world_size/rank 的 DeviceMesh
+   4. 在 FakeTensorMode 外构造 meta model 并执行 parallelize
+   5. 进入 FakeTensorMode，复用 BaseTrainer materialize fake shard
+   6. 构造固定 shape 的 fake LM micro-batch
+   7. MemTracker：forward -> backward -> AdamW step -> zero_grad
+   8. 归一化 snapshot/module stats，写原子 JSON
+   9. 销毁 fake ProcessGroup，恢复全局 hook/context
+```
+
+### 4.1 为什么在 Trainer 构造前分流
+
+现有 `LLMTrainer.__init__` 会立即执行 `_setup()`、设置真实 device、构造 dataloader 并 materialize 参数。若只在 `train()` 外层套 FakeTensorMode，真实设备已经被初始化，违反“无卡”目标。因此 `scripts/train_lm.py` 必须在构造 `LLMTrainer` 之前判断 `dry_run.enabled`，改由专用 runner 驱动 `BaseTrainer` 的必要 build steps。
+
+### 4.2 通信组网模拟
+
+Torch 的 `FakeProcessGroup` 可以让单进程声明任意 `world_size/rank`，collective 不等待其他 rank。实现通过 platform 抽象新增 dry-run process-group 初始化接口：
+
+- Torch：注册 `fake` backend，使用 `HashStore` 和 `FakeProcessGroup`；
+- MindSpore/基类：抛出描述性 `NotImplementedError`；
+- BaseTrainer 在 dry-run 时跳过 `device_handle.set_device()` 和设备 RNG 初始化，但仍构造真实的逻辑 `ParallelDims`/`DeviceMesh`，从而复用现有模型 parallelize 逻辑。
+
+fake backend 只模拟 shape 和生命周期，collective 输出数值没有语义；dry-run 禁止任何依赖 collective 数值的控制流。
+
+### 4.3 FakeTensor 与模型构建
+
+DeviceMesh 必须在 FakeTensorMode 外创建，因为 mesh 初始化包含真实 CPU rank Tensor 和 Python 控制数据。模型构建及 parallelize 也在 mode 外使用零存储的 meta 参数完成，只有 materialize 和训练 step 进入 FakeTensorMode：
+
+1. `init_empty_weights()` 在 meta 上建立完整模型；
+2. 模型自己的 `parallelize_fn` 对 meta 参数应用 Phase 1 已校验的 FSDP；
+3. 进入 FakeTensorMode 后，`_post_parallelize()` 调用 `to_empty(device=<simulation>)` 得到 FakeTensor，不分配设备内存；
+4. dry-run 跳过 `_load_weights()`，保留 dtype 转换、FSDP lazy init 和训练模式设置；
+5. `MemTracker.track_external()` 注册已经创建的模型、优化器和输入。
+
+当当前 Torch wheel 编译了目标后端时，`simulation` 就是逻辑目标设备（`cuda` 或 `npu`）。CPU-only wheel 无法为加速卡 Tensor 建立 autograd device guard，此时 runner 自动使用 CPU FakeTensor 传播完全相同的 shape/dtype/lifecycle；报告同时记录 `device_type`（逻辑目标）和 `simulation_device_type=cpu`。这一回退不改变逻辑 tensor bytes，但仍不代表 allocator、kernel workspace 或真实后端自定义算子已经校准。
+
+### 4.4 代表性训练 step
+
+首版使用固定 shape 的 LM batch：
+
+- `input_ids`: `[micro_batch_size, max_seq_len]`, `int64`；
+- `labels`: 同 shape，`int64`；
+- token 数按 `micro_batch_size * max(max_seq_len - 1, 1)` 直接计算，避免对 FakeTensor 调用 `.item()`；
+- 调用 model spec 的 `prepare_batch_fn`（若有）并复用 Trainer CP 分片逻辑；
+- 复用 `BaseTrainer.forward_backward_step()` 完成模型 forward、loss 缩放和 backward；
+- 直接执行一次 `optimizer.step()` 以创建 AdamW state，再 `zero_grad(set_to_none=True)`。
+
+不构造 dataset/dataloader、tokenizer、callback、checkpoint 和 logger sink，避免真实数据 I/O 与无关内存进入统计。
+
+梯度累积的峰值通常由最后一个 micro-batch 决定；首版只执行一个 micro-batch，并在报告中标记 `gradient_accumulation_simulated=false`。后续可在确认 MemTracker 多次调用语义后扩展到完整 grad accumulation。
+
+## 5. 报告协议
+
+JSON 顶层字段：
+
+```json
+{
+  "schema_version": 2,
+  "status": "ok",
+  "metadata": {
+    "model": "qwen3_5",
+    "torch_version": "2.9.1",
+    "rank": 0,
+    "world_size": 8,
+    "device_type": "npu",
+    "simulation_device_type": "cpu",
+    "original_init_device": "meta",
+    "weights_loaded": false,
+    "gradient_accumulation_simulated": false,
+    "parallel": {}
+  },
+  "summary": {
+    "peak_bytes": 0,
+    "current_bytes": 0,
+    "peak_gib": 0.0,
+    "capacity_bytes": null,
+    "headroom_bytes": null,
+    "oom_risk": null,
+    "peak_breakdown_bytes": {},
+    "current_breakdown_bytes": {}
+  },
+  "devices": {},
+  "modules": [],
+  "memory_blocks": [],
+  "limitations": []
+}
+```
+
+规则：
+
+- 目标 rank 正常只出现一个 simulation device；`summary` 按 `simulation_device_type` 汇总，`devices` 保留 tracker 观察到的全部设备；逻辑目标仍以 `metadata.device_type` 为准；
+- 同一类别和 Total 均以 byte 整数保存；显示值由消费者换算，避免精度损失；
+- `peak_breakdown_bytes` 是全局峰值时刻的构成；优化器 state 可能在该时刻尚未创建，因此 `current_breakdown_bytes` 同时展示 step 结束后的常驻构成；
+- module 条目包含 FQN、参数/buffer/input/output bytes、局部 peak bytes 和各阶段 snapshots；
+- `top_modules` 在完成深度过滤后按 `local_peak_bytes` 降序截断；
+- 写文件使用临时文件 + `os.replace()`，防止中断后留下半份 JSON；
+- JSON 的 `memory_blocks` 与 CSV 同源：每个不与输入 alias 的新算子输出 storage 产生一条逻辑内存块；
+  对已有 storage 的 size 变更会关闭旧块，非零的新 size 作为该 resize 算子的输出块重新记录；
+- CSV 不包含 summary、rank、world size、容量或 OOM 字段，列名对齐 `ms_memory_block.csv`；
+- `start_time_stamp/end_time_stamp` 是从 0 开始的逻辑任务索引，不采集或暗示真实时间；使用该 storage
+  的后续任务写入 `user_tasks` 和 `last_user_task`，step 结束仍存活的 storage 使用
+  `9223372036854775807` 并设置 `is_persistent=1`；生命周期按 `[start_time_stamp, end_time_stamp)`
+  半开区间解释；
+- `device_addr` 来自从 `0xf00000000000` 开始、按 512 bytes 对齐的确定性虚拟地址空间，
+  `pool_type=FakeTensorLogicalMemoryPool` 明确其不是真实 HBM 地址；
+- `actual_used_memory/actual_peak_memory` 来自生产算子返回后的 MemTracker 当前/运行峰值；`size` 是
+  新输出 storage 的逻辑 bytes；`python_stack`、叶子 `file_name/line_num` 在算子 dispatch 时实时采集；
+- storage 的释放优先由 Python storage weakref 回调识别；对 FakeTensor 缓存仍持有 wrapper 的情况，
+  以 MemTracker 已删除该 storage 或其 size 归零作为释放信号。finalize 只将 MemTracker 中仍有正 size
+  的 storage 标记为 persistent，并采用其最终类别，避免把 FSDP 已 reshard 的全量 buffer 或 AdamW
+  state 错记为常驻 Activation；
+- C++ autograd engine 直接进入 dispatch 时可能不存在用户 Python frame，此时 backward/Temp 行的
+  `python_stack`、`file_name` 允许为空；`node_name`、`task_name=backward` 和 `graph_name` 仍保留算子、
+  phase 与 module 上下文，不生成伪造的 Python frame；
+- 根目录 `memory_analysis.html` 同时识别 MindSpore 的 `DefaultEnhancedAscendMemoryPool` 和 dry-run 的
+  `FakeTensorLogicalMemoryPool`，并优先读取标准列 `stream_id`（兼容旧列 `stream`）；生命周期视图额外
+  依赖在线加载固定版本的 PyTorch `MemoryViz.js`，离线时折线图仍可使用；
+- `task_name`（phase）按运行状态识别：optimizer hook 的 `_in_opt` 优先，其次
+  `recompute_state.is_recomputing()` 为 recompute，再次 `ModTracker.is_bw` 为 backward，其余为
+  forward；`graph_name`（FQN）取 `ModTracker.parents` 中嵌套最深的活跃 module，表示调用上下文
+  而不是算子身份，算子身份由 `node_name` 保存；
+- 若执行失败，不伪造成功报告。命令返回非零并输出异常类型、触发阶段和改进建议；能确定输出目录时额外写 `status=error` 的最小报告。
+
+## 6. 生命周期与资源清理
+
+FakeTensorMode、MemTracker、FakeProcessGroup 都修改或依赖进程级状态，必须严格按栈清理：
+
+1. tracker 先退出，恢复 `UntypedStorage.resize_`、DTensor dispatch 和 optimizer global hooks；
+2. FakeTensorMode 退出；
+3. fake process group 在 `finally` 中销毁；
+4. 报告写入失败不能掩盖原始执行异常；
+5. 同一进程只允许串行运行一个 dry-run，首版不承诺线程安全。
+
+## 7. 动态 shape 与不支持算子
+
+FakeTensor 可以传播由输入 shape 决定的静态 shape，但不能为 `.item()`、`nonzero()` 后参与 Python 分支等数据依赖表达式提供真实值。首版策略：
+
+- 统一包装 PyTorch 的数据依赖 shape 和 unsupported fake operator 错误，保留原始异常类型、文本和最后执行阶段；
+- 不自动填充值绕过分支，因为这会让峰值路径不可验证；
+- 后续版本可增加 `dynamic_shape_overrides`，由用户显式选择分支或给出动态维上界，并在报告中记录假设。
+
+## 8. 误差来源与校准
+
+### 8.1 首版可比较口径
+
+验收时真实 eager 基线必须使用“allocated tensor memory”而非 allocator reserved memory，并关闭 checkpoint/save/profile 等 dry-run 未执行功能。比较：
+
+```text
+relative_error = abs(dry_peak_bytes - eager_peak_allocated_bytes)
+                 / max(eager_peak_allocated_bytes, 1)
+```
+
+### 8.2 5% 验收条件
+
+在以下校准矩阵内，目标是峰值误差不超过 5%：
+
+- Torch 2.7/2.9；
+- dense decoder-only LM；
+- FSDP world size 1/2/4/8；
+- `reshard_after_forward` true/false；
+- fp32/bf16；
+- activation checkpoint off；
+- AdamW，`foreach=false` 作为确定性基线。
+
+`activation checkpoint=full` 已支持算子级 dry-run 和独立 recompute phase 记录，但尚不属于 5%
+误差验收矩阵；加入硬门槛前仍需补齐同配置的真实 eager allocated-memory 校准。`selective` 模式
+尚未进入 dry-run 支持范围并保持 fail-fast。
+
+不在 5% 硬门槛内的项目必须单独展示，不混入通过结论：allocator 碎片/reserved、fused kernel workspace、数据依赖 MoE、第三方自定义算子、PP、真实 checkpoint/callback 内存。报告中的 `limitations` 始终列出这些差异。
+
+## 9. 测试与验收计划
+
+### 9.1 单元测试（无设备）
+
+1. 配置解析：YAML/CLI、默认值、非法 rank/world size/depth/capacity；
+2. world size 推导和并行度不一致错误；
+3. 报告序列化：enum key、多个 device、模块深度/top-N、OOM/headroom；
+4. 原子写入与输出目录创建；
+5. `_post_parallelize()` 在 dry-run 时不调用 `_load_weights()`；
+6. runner 生命周期：异常时 tracker/mode/process group 均被清理；
+7. Torch 2.6、MindSpore、PP 的 fail-fast 信息。
+8. 算子 storage 生命周期峰值不超过 MemTracker 峰值，persistent 输出不超过 current，且 current
+   Activation 为 0 时不得残留 persistent Activation。
+9. 可视化行为合同直接执行 HTML 中的 `parseCsv`、`analyzeRows`、`buildSnapshot` 和时刻存活查询，
+   覆盖 fake pool、`stream_id`、INT64 sentinel、CSV 引号转义、free 事件和 `[start, end)` 边界。
+
+### 9.2 CPU 集成测试
+
+在安装 Torch >= 2.7 的 CPU 环境，用最小两层 LM 和 fake `world_size=2` 运行：
+
+- 确认无 CUDA/NPU 可用时仍能完成；
+- 确认输出包含 Parameter/Activation/Gradient/Optstate；
+- 确认 FSDP rank shard 小于未分片参数量，且 forward all-gather 使峰值高于常驻量；
+- 确认 AdamW step 后有 optimizer state；
+- 确认 `rank=0/1` 均能独立运行。
+
+### 9.3 真实设备校准测试
+
+同一 YAML 分别运行 dry-run 和单步真实 eager，采集 `memory_allocated/max_memory_allocated`，按 8.2 的矩阵生成误差表。该测试需要真实 NPU/GPU，不作为普通 UT 前置条件，但在发布首个稳定版本前必须完成。
+
+### 9.4 当前无卡验证基线
+
+2026-07-18 在 PyTorch 2.13 CPU-only 环境，以仓库 `examples/qwen3_5_0_8b_base/train.yaml`（4 层、bf16、FSDP4、`comm_fusion=true`）从 `scripts/train_lm.py` 完整执行成功：逻辑峰值为 2,530,471,526 bytes，报告含 Parameter、Activation、Gradient、Temp 和 step 后 337,299,644 bytes Optstate。相同最小 FSDP 集成用例已在 PyTorch 2.7.1、2.9.1 和 2.13.0 CPU wheel 通过。该结果验证了入口、版本兼容和逻辑生命周期，不替代 9.3 的真实 NPU/GPU 误差校准。
+
+同日在 8 × Ascend 910B3、`torch_npu 2.13.0` 环境，以相同 Qwen3.5 FSDP4 配置执行 NPU fake backend
+成功，`simulation_device_type=npu`，逻辑峰值仍为 2,530,471,526 bytes，生成 4,957 条算子输出
+storage 内存块 CSV（无 summary 行）。算子块生命周期峰值为 1,853,259,254 bytes，低于 MemTracker
+峰值；110 条 persistent Optstate 合计 337,299,424 bytes，与 current Optstate 一致，未残留 persistent
+Activation。该用例覆盖 torch_npu 注册、NPU device guard 与 NPU fake/meta kernel；它仍不执行数值
+计算，也不替代 9.3 的真实 eager `max_memory_allocated` 校准。
+
+2026-07-19 在相同 NPU 环境以 Qwen3.5 8 layers、FSDP4、bf16、micro batch 4、sequence 1024
+运行全层 `activation_checkpoint=full` 成功。报告包含 20,417 条算子输出 storage，其中 forward
+4,341 条、backward 11,458 条、recompute 4,186 条、optimizer 432 条；MemTracker 逻辑峰值为
+15,067,528,806 bytes，算子生命周期峰值为 14,348,742,662 bytes。5 秒间隔 `npu-smi` 监控显示
+NPU 0 无进程基线 HBM 为 3,423–3,424 MB，运行中为 3,487–3,488 MB，Python 进程口径为
+118 MB，退出后恢复到 3,423 MB；因此 FakeTensor 的十几 GB 逻辑 tensor 未在真实 HBM 分配，
+实际设备增量仅为 torch_npu runtime/context 带来的约 64–65 MB。
+
+## 10. 分阶段交付
+
+### Phase 1（本文实现）
+
+- Trainer 配置与 `train_lm.py` 一键入口；
+- Torch FakeProcessGroup/FakeTensorMode/MemTracker runner；
+- FSDP 无卡基线与 full activation checkpoint；HSDP/TP/CP/EP/selective AC 当前 fail-fast，按模型
+  逐项增加兼容性用例后转为正式支持；
+- JSON 峰值、分类、模块快照和 OOM 判断；
+- 无设备 UT/CPU fake integration test；
+- PP、MindSpore、动态 shape 明确 fail-fast。
+
+### Phase 2
+
+- 完整 gradient accumulation；
+- activation checkpoint full 的真实设备误差校准，以及 selective checkpoint 的 fake 集成与
+  生命周期验证；
+- PP rank/stage 分析与多 rank 批量报告聚合；
+- 动态 shape 上界/分支 override；
+- 自定义算子 fake/meta registration 清单。
+
+### Phase 3
+
+- allocator/碎片和 kernel workspace 校准系数；
+- 与 auto-parallel 搜索器联动，批量筛除 OOM 策略；
+- MindSpore 等价实现。
+
+## 11. 完成定义
+
+Phase 1 被认为可开发完成，需要同时满足：
+
+- 配置开启后不调用真实 device `set_device`，无可用 NPU/GPU 的 Torch 环境可运行最小集成用例；
+- 成功报告符合 schema，包含峰值、构成、模块热点、拓扑、限制和可选 OOM 判断；
+- 不支持路径返回描述性错误且不产生伪成功数据；
+- 所有新增 UT 通过，原有 Trainer 配置测试不回归；
+- 至少完成一组真实设备校准；若当前环境无设备，功能实现可进入评审，但必须把校准明确记录为稳定版发布阻塞项，不能宣称已满足 5% 精度验收。

--- a/hyper_parallel/core/dtensor/layout.py
+++ b/hyper_parallel/core/dtensor/layout.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Huawei Technologies Co., Ltd
+# Copyright 2025-2026 Huawei Technologies Co., Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -208,7 +208,10 @@ class Layout:
         result = cls.__new__(cls)
         memo[id(self)] = result
         for k, v in self.__dict__.items():
-            setattr(result, k, copy.deepcopy(v, memo))
+            # DeviceMesh topology/process groups are immutable for a Layout.
+            # Sharing the mesh also avoids copying its real CPU rank tensor
+            # while FakeTensorMode is active during dry-run materialization.
+            setattr(result, k, v if k == "_mesh" else copy.deepcopy(v, memo))
         return result
 
     @staticmethod

--- a/hyper_parallel/core/shard/ops/parallel_elementwise.py
+++ b/hyper_parallel/core/shard/ops/parallel_elementwise.py
@@ -23,7 +23,8 @@ from .parallel_ops import DistributedOp
 
 
 _INPLACE_ELEMENTWISE_OPS = frozenset({
-    "add_", "sub_", "InplaceAddExt", "InplaceSubExt",
+    "add_", "sub_", "lerp_", "addcmul_", "addcdiv_",
+    "InplaceAddExt", "InplaceSubExt",
 })
 
 

--- a/hyper_parallel/core/shard/ops/yaml/torch_element_wise.yaml
+++ b/hyper_parallel/core/shard/ops/yaml/torch_element_wise.yaml
@@ -13,6 +13,9 @@ clone:
   dist_op_name: _torch_clone_dist_op
   distributed_op_class: ElementWiseWithPartialDistributedOp
 
+detach:
+  dist_op_name: _torch_detach_dist_op
+
 __invert__:
   dist_op_name: _torch___invert___dist_op
 
@@ -33,6 +36,18 @@ float:
 
 rsqrt:
   dist_op_name: _torch_rsqrt_dist_op
+
+sqrt:
+  dist_op_name: _torch_sqrt_dist_op
+
+lerp_:
+  dist_op_name: _torch_lerp_inplace_dist_op
+
+addcmul_:
+  dist_op_name: _torch_addcmul_inplace_dist_op
+
+addcdiv_:
+  dist_op_name: _torch_addcdiv_inplace_dist_op
 
 sigmoid:
   dist_op_name: _torch_sigmoid_dist_op

--- a/hyper_parallel/platform/platform.py
+++ b/hyper_parallel/platform/platform.py
@@ -1195,6 +1195,22 @@ class Platform:
         raise NotImplementedError("Platform subclasses must implement init_process_group")
 
     @staticmethod
+    def init_dry_run_process_group(world_size: int, rank: int) -> None:
+        """Initialize a single-process fake distributed topology.
+
+        Args:
+            world_size: Logical number of ranks to simulate.
+            rank: Logical rank represented by the current process.
+
+        Raises:
+            NotImplementedError: When the selected backend has no fake process
+                group implementation.
+        """
+        raise NotImplementedError(
+            "Dry-run process groups are not supported by this platform"
+        )
+
+    @staticmethod
     def destroy_process_group(group=None) -> None:
         """
         Destroy a given process group.

--- a/hyper_parallel/platform/torch/dry_run.py
+++ b/hyper_parallel/platform/torch/dry_run.py
@@ -1,0 +1,969 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""No-accelerator memory analysis for the Torch Trainer path."""
+import copy
+import csv
+import json
+import logging
+import os
+import re
+import tempfile
+import traceback
+import weakref
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+_SCHEMA_VERSION = 2
+_GIB = 2 ** 30
+_PERSISTENT_END_INDEX = 2 ** 63 - 1
+_SMALL_ALLOCATION_BYTES = 2 ** 20
+_VIRTUAL_ADDRESS_BASE = 0xF00000000000
+_VIRTUAL_ADDRESS_ALIGNMENT = 512
+_CSV_FIELDS = (
+    "start_time_stamp",
+    "end_time_stamp",
+    "device_addr",
+    "stream_id",
+    "pool_type",
+    "size",
+    "actual_used_memory",
+    "actual_peak_memory",
+    "file_name",
+    "line_num",
+    "type",
+    "producer_task",
+    "task_name",
+    "node_name",
+    "graph_name",
+    "user_tasks",
+    "last_user_task",
+    "python_stack",
+    "is_persistent",
+    "is_small",
+)
+logger = logging.getLogger(__name__)
+_LIMITATIONS = [
+    "Reports logical live tensor bytes, not allocator reserved memory or fragmentation.",
+    "Kernel workspaces and opaque third-party fused-operator allocations are not tracked.",
+    "Checkpoint loading, dataloaders, callbacks, and gradient accumulation are not simulated.",
+    "Pipeline parallelism and data-dependent dynamic shapes are not supported in this version.",
+]
+
+
+def _report_limitations(metadata: Optional[Dict[str, Any]] = None) -> list[str]:
+    """Return static limitations plus run-specific simulation caveats."""
+    limitations = list(_LIMITATIONS)
+    metadata = metadata or {}
+    target = metadata.get("device_type")
+    simulation = metadata.get("simulation_device_type")
+    if target and simulation and target != simulation:
+        limitations.append(
+            f"The logical {target} run was simulated with {simulation} FakeTensors; "
+            "target-backend custom operators, device guards, and allocator behavior "
+            "were not exercised."
+        )
+    return limitations
+
+
+def _category_name(category: Any) -> str:
+    """Return a stable JSON key for a MemTracker category."""
+    if isinstance(category, str):
+        return category
+    value = getattr(category, "value", None)
+    return str(value if value is not None else category)
+
+
+def _normalize_snapshot(snapshot: Dict[Any, Dict[Any, int]]) -> Dict[str, Dict[str, int]]:
+    """Convert device/category objects in a MemTracker snapshot to JSON keys."""
+    normalized = {}
+    for device, categories in snapshot.items():
+        normalized[str(device)] = {
+            _category_name(category): int(value)
+            for category, value in categories.items()
+        }
+    return normalized
+
+
+def _snapshot_total(snapshot: Dict[str, Dict[str, int]], device_type: str) -> int:
+    """Sum total bytes for devices matching ``device_type``."""
+    return sum(
+        categories.get("Total", 0)
+        for device, categories in snapshot.items()
+        if device.split(":", maxsplit=1)[0] == device_type
+    )
+
+
+def _snapshot_breakdown(snapshot: Dict[str, Dict[str, int]], device_type: str) -> Dict[str, int]:
+    """Aggregate category bytes for devices matching ``device_type``."""
+    breakdown: Dict[str, int] = {}
+    for device, categories in snapshot.items():
+        if device.split(":", maxsplit=1)[0] != device_type:
+            continue
+        for category, value in categories.items():
+            if category == "Total":
+                continue
+            breakdown[category] = breakdown.get(category, 0) + int(value)
+    return dict(sorted(breakdown.items()))
+
+
+def _module_local_peak(module_stats: Any, device_type: str) -> int:
+    """Return a module's largest local peak on the target device type."""
+    peaks = [
+        int(value)
+        for device, value in getattr(module_stats, "local_peak", {}).items()
+        if str(device).split(":", maxsplit=1)[0] == device_type
+    ]
+    return max(peaks, default=0)
+
+
+def _serialize_module(module_stats: Any, device_type: str) -> Dict[str, Any]:
+    """Serialize one MemTracker module-stat object without private enum types."""
+    snapshots = {}
+    for state, snapshot_list in getattr(module_stats, "snapshots", {}).items():
+        snapshots[_category_name(state)] = [
+            _normalize_snapshot(snapshot)
+            for snapshot in snapshot_list
+        ]
+    return {
+        "fqn": str(module_stats.mod_fqn),
+        "parameter_bytes": int(getattr(module_stats, "parameter_mem", 0)),
+        "buffer_bytes": int(getattr(module_stats, "buffer_mem", 0)),
+        "input_bytes": int(getattr(module_stats, "input_mem", 0)),
+        "output_bytes": int(getattr(module_stats, "output_mem", 0)),
+        "local_peak_bytes": _module_local_peak(module_stats, device_type),
+        "snapshots": snapshots,
+    }
+
+
+def _capture_python_stack() -> Dict[str, Any]:
+    """Capture a formatted stack and its leaf caller location."""
+    frames = traceback.extract_stack(limit=64)
+    kept_frames = []
+    for frame in frames:
+        normalized_path = frame.filename.replace("\\", "/")
+        if normalized_path == __file__ and frame.name in (
+                "__torch_dispatch__", "_capture_python_stack"
+        ):
+            continue
+        if normalized_path.endswith(("/torch/_compile.py", "/torch/_dynamo/eval_frame.py")):
+            continue
+        kept_frames.append(frame)
+    python_stack = "|".join(
+        (
+            f"File:{frame.filename};Line:{frame.lineno};Function:{frame.name}"
+        )
+        for frame in kept_frames
+    )
+    leaf_frame = kept_frames[-1] if kept_frames else None
+    return {
+        "python_stack": python_stack,
+        "file_name": leaf_frame.filename if leaf_frame else "",
+        "line_num": leaf_frame.lineno if leaf_frame else 0,
+    }
+
+
+def _operator_phase(tracker: Any) -> str:
+    """Resolve the current training phase from MemTracker state."""
+    if getattr(tracker, "_in_opt", False):
+        return "optimizer"
+    from hyper_parallel.core.activation_checkpoint.recompute_state import (  # pylint: disable=C0415
+        is_recomputing,
+    )
+    if is_recomputing():
+        return "recompute"
+    module_tracker = getattr(tracker, "_mod_tracker", None)
+    if getattr(module_tracker, "is_bw", False):
+        return "backward"
+    return "forward"
+
+
+def _active_module_fqn(tracker: Any) -> str:
+    """Return the deepest active module as optional operator context."""
+    module_tracker = getattr(tracker, "_mod_tracker", None)
+    parents = getattr(module_tracker, "parents", ())
+    candidates = [str(parent) for parent in parents if str(parent) not in ("", "Global")]
+    return max(candidates, key=lambda fqn: (fqn.count("."), len(fqn)), default="")
+
+
+def _create_operator_trace_mode(tracker: Any, device_type: str) -> Any:
+    """Create a lazy TorchDispatchMode that records logical memory blocks."""
+    import torch  # pylint: disable=C0415
+    from torch.distributed._tools.mem_tracker import get_untyped_storages  # pylint: disable=C0415
+    from torch.utils._python_dispatch import TorchDispatchMode  # pylint: disable=C0415
+    from torch.utils._pytree import tree_flatten  # pylint: disable=C0415
+
+    def _storage_map(values: Any) -> Dict[int, Dict[str, Any]]:
+        """Return storage identifiers, logical devices, and byte sizes."""
+        flat_values, _ = tree_flatten(values)
+        storages = {}
+        for value in flat_values:
+            if not isinstance(value, torch.Tensor):
+                continue
+            try:
+                tensor_storages = get_untyped_storages(value)
+            except (RuntimeError, TypeError):
+                continue
+            for storage in tensor_storages:
+                storage_key = int(getattr(storage, "_cdata", id(storage)))
+                storages[storage_key] = {
+                    "device": str(value.device),
+                    "size": int(storage.size()),
+                    "storage": storage,
+                }
+        return storages
+
+    def _tracked_storage_info() -> Dict[int, Dict[str, Any]]:
+        """Read live category/device metadata from MemTracker storage refs."""
+        tracked = {}
+        for storage, (winfo, storage_ref) in tracker._WINFO.items():
+            storage_key = int(getattr(storage, "_cdata", id(storage)))
+            tracked[storage_key] = {
+                "device": str(winfo.device),
+                "size": int(winfo.mem_consumed),
+                "type": _category_name(winfo.reftype),
+                "storage_ref": storage_ref,
+            }
+        return tracked
+
+    class _OperatorTraceMode(TorchDispatchMode):
+        """Track producer, consumer, and lifetime data for fake storages."""
+
+        def __init__(self) -> None:
+            """Initialize ordered logical task and storage state."""
+            super().__init__()
+            self.memory_blocks: list[Dict[str, Any]] = []
+            self._active_blocks: Dict[int, Dict[str, Any]] = {}
+            self._active_storage_refs: Dict[int, Any] = {}
+            self._active_storage_sizes: Dict[int, int] = {}
+            self._memtracker_storage_keys: set[int] = set()
+            self._released_storage_keys: set[int] = set()
+            self._next_task_index = 0
+            self._next_virtual_address = _VIRTUAL_ADDRESS_BASE
+
+        def _close_blocks(self, storage_keys: set[int], end_index: int) -> None:
+            """Close active blocks and discard their lifetime bookkeeping."""
+            for storage_key in storage_keys & set(self._active_blocks):
+                block = self._active_blocks.pop(storage_key)
+                self._active_storage_refs.pop(storage_key)
+                self._active_storage_sizes.pop(storage_key)
+                self._memtracker_storage_keys.discard(storage_key)
+                self._released_storage_keys.discard(storage_key)
+                block["end_time_stamp"] = end_index
+
+        def _close_released_blocks(self, end_index: int) -> None:
+            """Close blocks whose storage weak refs disappeared."""
+            released_keys = self._released_storage_keys & set(self._active_blocks)
+            self._close_blocks(released_keys, end_index)
+
+        def _allocate_virtual_address(self, size: int) -> str:
+            """Return a deterministic aligned address in a reserved fake range."""
+            address = self._next_virtual_address
+            aligned_size = max(
+                _VIRTUAL_ADDRESS_ALIGNMENT,
+                (
+                    (size + _VIRTUAL_ADDRESS_ALIGNMENT - 1)
+                    // _VIRTUAL_ADDRESS_ALIGNMENT
+                ) * _VIRTUAL_ADDRESS_ALIGNMENT,
+            )
+            self._next_virtual_address += aligned_size
+            return f"0x{address:x}"
+
+        def finalize(self) -> None:
+            """Close released blocks and mark remaining storages persistent."""
+            self._close_released_blocks(self._next_task_index)
+            tracked_storages = _tracked_storage_info()
+            for storage_key, block in self._active_blocks.items():
+                tracked_storage = tracked_storages.get(storage_key)
+                if tracked_storage is None or tracked_storage["size"] <= 0:
+                    block["end_time_stamp"] = self._next_task_index
+                    continue
+                block["type"] = tracked_storage["type"]
+                block["end_time_stamp"] = _PERSISTENT_END_INDEX
+                block["is_persistent"] = 1
+            self._active_blocks.clear()
+            self._active_storage_refs.clear()
+            self._active_storage_sizes.clear()
+            self._memtracker_storage_keys.clear()
+            self._released_storage_keys.clear()
+
+        def _classify_output_keys(
+                self,
+                input_storages: Dict[int, Dict[str, Any]],
+                output_storages: Dict[int, Dict[str, Any]],
+                active_input_keys: set[int],
+        ) -> tuple[set[int], set[int]]:
+            """Return resized inputs and newly allocated target-device outputs."""
+            resized_output_keys = {
+                storage_key
+                for storage_key in active_input_keys & set(output_storages)
+                if output_storages[storage_key]["size"] != self._active_storage_sizes[storage_key]
+            }
+            new_output_keys = {
+                storage_key
+                for storage_key, storage in output_storages.items()
+                if (
+                    storage_key not in input_storages
+                    and storage_key not in self._active_blocks
+                    and storage["device"].split(":", maxsplit=1)[0] == device_type
+                    and storage["size"] > 0
+                )
+            }
+            new_output_keys.update(
+                storage_key
+                for storage_key in resized_output_keys
+                if (
+                    output_storages[storage_key]["device"].split(":", maxsplit=1)[0] == device_type
+                    and output_storages[storage_key]["size"] > 0
+                )
+            )
+            return resized_output_keys, new_output_keys
+
+        def _inactive_tracked_keys(
+                self,
+                tracked_storages: Dict[int, Dict[str, Any]],
+        ) -> set[int]:
+            """Return MemTracker storages that were removed or resized to zero."""
+            return {
+                storage_key
+                for storage_key in self._memtracker_storage_keys
+                if storage_key not in tracked_storages or tracked_storages[storage_key]["size"] <= 0
+            }
+
+        def _record_input_users(self, active_input_keys: set[int], task_index: int) -> None:
+            """Append the task index to every active input storage's user list."""
+            for storage_key in active_input_keys:
+                user_tasks = self._active_blocks[storage_key]["user_tasks"]
+                if not user_tasks or user_tasks[-1] != task_index:
+                    user_tasks.append(task_index)
+
+        def _track_new_outputs(
+                self,
+                output_keys: set[int],
+                output_storages: Dict[int, Dict[str, Any]],
+                tracked_storages: Dict[int, Dict[str, Any]],
+                context: Dict[str, Any],
+        ) -> None:
+            """Create logical memory blocks and weak lifetime refs for outputs."""
+            for storage_key in sorted(output_keys):
+                output_storage = output_storages[storage_key]
+                tracked_storage = tracked_storages.get(storage_key, {})
+                device = output_storage["device"]
+                size = int(tracked_storage.get("size", output_storage["size"]))
+                block = {
+                    "start_time_stamp": context["task_index"],
+                    "end_time_stamp": _PERSISTENT_END_INDEX,
+                    "device_addr": self._allocate_virtual_address(size),
+                    "stream_id": 0,
+                    "pool_type": "FakeTensorLogicalMemoryPool",
+                    "size": size,
+                    "actual_used_memory": context["after"].get(device, {}).get("Total", 0),
+                    "actual_peak_memory": context["running_peak"].get(device, {}).get("Total", 0),
+                    "file_name": context["stack"]["file_name"],
+                    "line_num": context["stack"]["line_num"],
+                    "type": tracked_storage.get("type", "Activation"),
+                    "producer_task": context["task_index"],
+                    "task_name": context["phase"],
+                    "node_name": context["operator_name"],
+                    "graph_name": context["module_fqn"],
+                    "user_tasks": [],
+                    "python_stack": context["stack"]["python_stack"],
+                    "is_persistent": 0,
+                    "is_small": int(size < _SMALL_ALLOCATION_BYTES),
+                }
+                self.memory_blocks.append(block)
+                self._active_blocks[storage_key] = block
+                self._active_storage_sizes[storage_key] = output_storage["size"]
+                storage_ref = tracked_storage.get("storage_ref")
+                if storage_ref is not None:
+                    self._memtracker_storage_keys.add(storage_key)
+                storage = storage_ref() if storage_ref is not None else None
+                if storage is None:
+                    storage = output_storage["storage"]
+                self._active_storage_refs[storage_key] = weakref.ref(
+                    storage,
+                    lambda _, key=storage_key: self._released_storage_keys.add(key),
+                )
+
+        def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+            del types
+            self._close_released_blocks(self._next_task_index)
+            input_storages = _storage_map((args, kwargs))
+            active_input_keys = set(input_storages) & set(self._active_blocks)
+            phase = _operator_phase(tracker)
+            module_fqn = _active_module_fqn(tracker)
+            result = func(*args, **(kwargs or {}))
+            after = _normalize_snapshot(tracker.get_tracker_snapshot("current"))
+            running_peak = _normalize_snapshot(tracker.get_tracker_snapshot("peak"))
+            output_storages = _storage_map(result)
+            resized_output_keys, new_output_keys = self._classify_output_keys(
+                input_storages,
+                output_storages,
+                active_input_keys,
+            )
+            tracked_storages = _tracked_storage_info()
+            inactive_tracked_keys = self._inactive_tracked_keys(tracked_storages)
+            if not active_input_keys and not new_output_keys and not resized_output_keys:
+                self._close_blocks(inactive_tracked_keys, self._next_task_index)
+                return result
+            task_index = self._next_task_index
+            self._next_task_index += 1
+            self._record_input_users(active_input_keys, task_index)
+            self._close_blocks(
+                resized_output_keys | inactive_tracked_keys,
+                task_index,
+            )
+            self._track_new_outputs(
+                new_output_keys,
+                output_storages,
+                tracked_storages,
+                {
+                    "task_index": task_index,
+                    "after": after,
+                    "running_peak": running_peak,
+                    "stack": _capture_python_stack(),
+                    "phase": phase,
+                    "operator_name": str(func),
+                    "module_fqn": module_fqn,
+                },
+            )
+            return result
+
+    return _OperatorTraceMode()
+
+
+def build_memory_report(
+        tracker: Any,
+        metadata: Dict[str, Any],
+        device_type: str,
+        module_depth: int,
+        top_modules: int,
+        device_memory_gib: Optional[float] = None,
+        memory_blocks: Optional[list[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Build the stable JSON report from a completed MemTracker run.
+
+    Args:
+        tracker: Completed memory-tracker instance.
+        metadata: Run metadata to include verbatim.
+        device_type: Device type used for FakeTensor simulation. This is the
+            logical accelerator type when its backend is available, otherwise
+            ``"cpu"`` for the no-backend fallback.
+        module_depth: Maximum module FQN depth, or zero for unlimited.
+        top_modules: Maximum number of hottest modules, or zero for all.
+        device_memory_gib: Optional target capacity for OOM-risk reporting.
+        memory_blocks: Optional logical output-storage lifetime records.
+
+    Returns:
+        JSON-serializable report dictionary.
+
+    Raises:
+        ValueError: If the tracker observed no memory on the simulation device.
+    """
+    peak = _normalize_snapshot(tracker.get_tracker_snapshot("peak"))
+    current = _normalize_snapshot(tracker.get_tracker_snapshot("current"))
+    peak_bytes = _snapshot_total(peak, device_type)
+    if peak_bytes <= 0:
+        raise ValueError(
+            f"MemTracker observed no {device_type!r} tensor memory; "
+            f"tracked devices are {sorted(peak)}"
+        )
+
+    modules = []
+    for module_stats in tracker.memory_tracking.values():
+        fqn = str(module_stats.mod_fqn)
+        depth = fqn.count(".") + 1
+        if module_depth and depth > module_depth:
+            continue
+        modules.append(_serialize_module(module_stats, device_type))
+    modules.sort(key=lambda item: (-item["local_peak_bytes"], item["fqn"]))
+    if top_modules:
+        modules = modules[:top_modules]
+
+    capacity_bytes = None
+    headroom_bytes = None
+    oom_risk = None
+    if device_memory_gib is not None:
+        capacity_bytes = int(device_memory_gib * _GIB)
+        headroom_bytes = capacity_bytes - peak_bytes
+        oom_risk = headroom_bytes < 0
+
+    devices = {}
+    for device in sorted(set(peak) | set(current)):
+        devices[device] = {
+            "peak": peak.get(device, {}),
+            "current": current.get(device, {}),
+        }
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "status": "ok",
+        "metadata": metadata,
+        "summary": {
+            "peak_bytes": peak_bytes,
+            "current_bytes": _snapshot_total(current, device_type),
+            "peak_gib": peak_bytes / _GIB,
+            "capacity_bytes": capacity_bytes,
+            "headroom_bytes": headroom_bytes,
+            "oom_risk": oom_risk,
+            "peak_breakdown_bytes": _snapshot_breakdown(peak, device_type),
+            "current_breakdown_bytes": _snapshot_breakdown(current, device_type),
+        },
+        "devices": devices,
+        "modules": modules,
+        "memory_blocks": memory_blocks or [],
+        "limitations": _report_limitations(metadata),
+    }
+
+
+def write_memory_report(report: Dict[str, Any], output_path: str) -> str:
+    """Atomically write a memory report.
+
+    Args:
+        report: JSON-serializable report dictionary.
+        output_path: Destination JSON path.
+
+    Returns:
+        Absolute destination path.
+    """
+    destination = Path(output_path).expanduser().resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_path = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=str(destination.parent),
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as report_file:
+            json.dump(report, report_file, ensure_ascii=False, indent=2, sort_keys=True)
+            report_file.write("\n")
+        os.replace(temporary_path, destination)
+    except Exception:
+        if os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+        raise
+    return str(destination)
+
+
+def build_memory_csv_rows(report: Dict[str, Any]) -> list[Dict[str, Any]]:
+    """Build MindSpore-compatible logical memory-block CSV rows.
+
+    Args:
+        report: Successful report returned by :func:`build_memory_report`.
+
+    Returns:
+        One row per new non-aliasing operator output storage. No summary rows.
+
+    Raises:
+        ValueError: If ``report`` does not describe a successful run.
+    """
+    if report.get("status") != "ok":
+        raise ValueError("CSV output requires a successful HyperDryRun report")
+    rows = []
+    for block in report.get("memory_blocks", []):
+        user_tasks = list(block.get("user_tasks", []))
+        row = {
+            field: block.get(field, "")
+            for field in _CSV_FIELDS
+        }
+        row["user_tasks"] = "{" + "-".join(str(task) for task in user_tasks) + "}"
+        row["last_user_task"] = user_tasks[-1] if user_tasks else ""
+        rows.append(row)
+    return rows
+
+
+def write_memory_csv(report: Dict[str, Any], output_path: str) -> str:
+    """Atomically write the tabular companion to a JSON memory report.
+
+    Args:
+        report: Successful JSON report dictionary.
+        output_path: Destination CSV path.
+
+    Returns:
+        Absolute destination path.
+    """
+    destination = Path(output_path).expanduser().resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    rows = build_memory_csv_rows(report)
+    descriptor, temporary_path = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=str(destination.parent),
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as report_file:
+            writer = csv.DictWriter(report_file, fieldnames=_CSV_FIELDS)
+            writer.writeheader()
+            writer.writerows(rows)
+        os.replace(temporary_path, destination)
+    except Exception:
+        if os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+        raise
+    return str(destination)
+
+
+class TorchDryRunRunner:
+    """Drive one fake Torch Trainer step and emit its memory report.
+
+    Args:
+        args: Parsed ``HyperTrainerConfig``.
+    """
+
+    def __init__(self, args: Any) -> None:
+        """Initialize the runner without touching distributed or device state."""
+        self.args = args
+        self._stage = "validation"
+
+    @staticmethod
+    def _check_torch_version(torch_module: Any) -> None:
+        """Require the MemTracker fake-collective integration from Torch 2.7."""
+        match = re.match(r"^(\d+)\.(\d+)", torch_module.__version__)
+        version = tuple(int(part) for part in match.groups()) if match else (0, 0)
+        if version < (2, 7):
+            raise RuntimeError(
+                "HyperDryRun requires PyTorch >= 2.7 because PyTorch 2.6 "
+                "MemTracker does not track fake collectives and DTensor dispatch; "
+                f"found {torch_module.__version__}"
+            )
+
+    @staticmethod
+    def _resolve_world_size(args: Any) -> int:
+        """Resolve the logical world size from dry-run and parallel config."""
+        dry_run_cfg = args.train.dry_run
+        accelerator = args.train.accelerator
+        if dry_run_cfg.world_size is not None:
+            return int(dry_run_cfg.world_size)
+        dp_shard = accelerator.dp_shard
+        if dp_shard in (None, -1):
+            dp_shard = accelerator.dp
+        if dp_shard in (None, -1):
+            raise ValueError(
+                "train.dry_run.world_size is required when dp_shard is automatic"
+            )
+        return int(
+            accelerator.dp_replicate
+            * dp_shard
+            * accelerator.cp
+            * accelerator.tp
+            * accelerator.pp
+            * accelerator.ep
+        )
+
+    def _prepare_args(self, torch_module: Any) -> Any:
+        """Validate user input and return an isolated dry-run config copy."""
+        from hyper_parallel.trainer.parallel_dims import ParallelDims  # pylint: disable=C0415
+
+        self._check_torch_version(torch_module)
+        if self.args.train.backend != "torch":
+            raise NotImplementedError(
+                "HyperDryRun currently supports train.backend='torch' only, "
+                f"got {self.args.train.backend!r}"
+            )
+        if self.args.train.accelerator.pp > 1:
+            raise NotImplementedError(
+                "HyperDryRun does not support pipeline parallelism in this version; "
+                f"got pp={self.args.train.accelerator.pp}"
+            )
+        unsupported_degrees = {
+            name: int(getattr(self.args.train.accelerator, name))
+            for name in ("dp_replicate", "tp", "cp", "ep", "etp")
+            if int(getattr(self.args.train.accelerator, name)) > 1
+        }
+        if unsupported_degrees:
+            raise NotImplementedError(
+                "HyperDryRun Phase 1 supports FSDP (dp_shard) only; "
+                f"unsupported parallel degrees are {unsupported_degrees}"
+            )
+        if self.args.train.accelerator.cpu_offload:
+            raise NotImplementedError(
+                "HyperDryRun Phase 1 does not support FSDP CPU offload"
+            )
+        activation_checkpoint = (
+            self.args.train.gradient_checkpointing.activation_checkpoint
+        )
+        if activation_checkpoint not in (
+                "off", "none", "full", None, False, ""
+        ):
+            raise NotImplementedError(
+                "HyperDryRun supports full activation checkpointing only; "
+                f"got {activation_checkpoint!r}"
+            )
+
+        prepared = copy.deepcopy(self.args)
+        world_size = self._resolve_world_size(prepared)
+        rank = int(prepared.train.dry_run.rank)
+        if rank >= world_size:
+            raise ValueError(
+                f"dry_run.rank ({rank}) must be smaller than world_size ({world_size})"
+            )
+        ParallelDims.from_config(prepared.train.accelerator, world_size=world_size)
+        prepared.train.dry_run.world_size = world_size
+        prepared.train.init_device = "meta"
+        prepared.train.local_rank = 0
+        return prepared
+
+    @staticmethod
+    def _build_fake_batch(torch_module: Any, base: Any) -> tuple[Dict[str, Any], int]:
+        """Build the fixed-shape LM batch used by the simulated step."""
+        micro_batch_size = int(base.args.train.micro_batch_size)
+        sequence_length = int(base.args.data.max_seq_len)
+        if micro_batch_size < 1:
+            raise ValueError(
+                f"train.micro_batch_size must be >= 1, got {micro_batch_size}"
+            )
+        if sequence_length < 2:
+            raise ValueError(
+                "data.max_seq_len must be >= 2 for causal-LM dry-run, "
+                f"got {sequence_length}"
+            )
+        shape = (micro_batch_size, sequence_length)
+        batch = {
+            "input_ids": torch_module.empty(shape, dtype=torch_module.int64, device=base.device),
+            "labels": torch_module.empty(shape, dtype=torch_module.int64, device=base.device),
+        }
+        prepare_batch_fn = getattr(base.spec, "prepare_batch_fn", None)
+        if prepare_batch_fn is not None:
+            batch = prepare_batch_fn(batch, base.model)
+        batch = base._shard_micro_batches_for_cp([batch])[0]
+        local_sequence = int(batch["input_ids"].shape[1])
+        token_count = micro_batch_size * max(local_sequence - 1, 1)
+        return batch, token_count
+
+    @staticmethod
+    def _metadata(
+            torch_module: Any,
+            base: Any,
+            original_init_device: str,
+            target_device_type: str,
+    ) -> Dict[str, Any]:
+        """Build reproducibility metadata for a successful report."""
+        dims = base.parallel_dims
+        parallel = {
+            name: int(getattr(dims, name))
+            for name in ("dp_replicate", "dp_shard", "tp", "cp", "ep", "pp", "etp")
+        }
+        return {
+            "model": base.args.model.name,
+            "torch_version": torch_module.__version__,
+            "rank": int(base.args.train.dry_run.rank),
+            "world_size": int(base.args.train.dry_run.world_size),
+            "device_type": target_device_type,
+            "simulation_device_type": base.device.type,
+            "original_init_device": original_init_device,
+            "weights_loaded": False,
+            "gradient_accumulation_simulated": False,
+            "parallel": parallel,
+            "reshard_after_forward": bool(base.args.train.accelerator.reshard_after_forward),
+            "comm_fusion": bool(base.args.train.accelerator.comm_fusion),
+        }
+
+    def _error_report(self, error: Exception) -> Dict[str, Any]:
+        """Build a minimal, explicitly unsuccessful report."""
+        dry_run_cfg = self.args.train.dry_run
+        return {
+            "schema_version": _SCHEMA_VERSION,
+            "status": "error",
+            "stage": self._stage,
+            "error": {
+                "type": type(error).__name__,
+                "message": str(error),
+            },
+            "metadata": {
+                "model": self.args.model.name,
+                "rank": dry_run_cfg.rank,
+                "world_size": dry_run_cfg.world_size,
+            },
+            "limitations": _report_limitations(),
+        }
+
+    @staticmethod
+    def _initialize_flat_buffers(base: Any) -> None:
+        """Materialize enabled FSDP flat shards before tracker registration."""
+        for hsdp_state in base._iter_hsdp_states():
+            param_group = getattr(hsdp_state, "param_group", None)
+            if param_group is not None and param_group.enable_zero_copy:
+                param_group._init_flat_param_buffer()
+
+    def _execute_fake_step(
+            self,
+            torch_module: Any,
+            fake_mode_type: Any,
+            mem_tracker_type: Any,
+            base: Any,
+            prepared: Any,
+            original_init_device: str,
+            target_device_type: str,
+    ) -> Dict[str, Any]:
+        """Materialize the fake model, execute one step, and build its report."""
+        fake_mode = fake_mode_type(allow_non_fake_inputs=True)
+        with fake_mode:
+            self._stage = "materialize"
+            base._post_parallelize()
+            base._build_optimizer()
+            base._build_training_context()
+            batch, token_count = self._build_fake_batch(torch_module, base)
+
+            # Register only after FSDP creates its long-lived flat shard, so
+            # MemTracker categorizes the storage as a Parameter.
+            self._initialize_flat_buffers(base)
+
+            self._stage = "memory_tracking"
+            tracker = mem_tracker_type()
+            tracker.track_external(base.model, base.optimizer, batch)
+            operator_trace = _create_operator_trace_mode(tracker, base.device.type)
+            with tracker, operator_trace:
+                if hasattr(base.model, "set_requires_gradient_sync"):
+                    base.model.set_requires_gradient_sync(True)
+                if hasattr(base.model, "set_is_last_backward"):
+                    base.model.set_is_last_backward(True)
+                global_tokens = token_count * base.parallel_dims.dp_size * base.parallel_dims.cp
+                base.forward_backward_step(batch, token_count, global_tokens)
+                base._run_post_fsdp_grad_reduce()
+                base.optimizer.step()
+                base.optimizer.zero_grad(set_to_none=True)
+            operator_trace.finalize()
+
+            self._stage = "report_generation"
+            return build_memory_report(
+                tracker=tracker,
+                metadata=self._metadata(
+                    torch_module,
+                    base,
+                    original_init_device,
+                    target_device_type,
+                ),
+                device_type=base.device.type,
+                module_depth=prepared.train.dry_run.module_depth,
+                top_modules=prepared.train.dry_run.top_modules,
+                device_memory_gib=prepared.train.dry_run.device_memory_gib,
+                memory_blocks=operator_trace.memory_blocks,
+            )
+
+    def run(self) -> str:
+        """Execute one fake training step and return the report path.
+
+        Returns:
+            Absolute JSON report path.
+
+        Raises:
+            RuntimeError: If validation, model construction, fake execution,
+                tracking, or report generation fails.
+        """
+        self._stage = "validation"
+        output_path = os.path.join(
+            self.args.train.dry_run.output_dir,
+            f"rank_{self.args.train.dry_run.rank}.json",
+        )
+        original_init_device = self.args.train.init_device
+        dist = None
+        had_existing_process_group = False
+        try:
+            if self.args.train.backend != "torch":
+                raise NotImplementedError(
+                    "HyperDryRun currently supports train.backend='torch' only, "
+                    f"got {self.args.train.backend!r}"
+                )
+
+            # pylint: disable=C0415
+            import torch
+            import torch.distributed as dist
+            from torch._subclasses.fake_tensor import FakeTensorMode
+            from torch.distributed._tools.mem_tracker import MemTracker
+            from hyper_parallel.trainer.base import BaseTrainer
+
+            had_existing_process_group = dist.is_initialized()
+            if had_existing_process_group:
+                raise RuntimeError(
+                    "HyperDryRun must start before a real or fake distributed "
+                    "process group is initialized"
+                )
+            prepared = self._prepare_args(torch)
+            output_path = os.path.join(
+                prepared.train.dry_run.output_dir,
+                f"rank_{prepared.train.dry_run.rank}.json",
+            )
+            base = BaseTrainer(prepared)
+            self._stage = "distributed_setup"
+            base._setup()
+            target_device_type = (
+                prepared.train.dry_run.device_type or base.device.type
+            )
+            device_handle = getattr(torch, target_device_type, None)
+            if device_handle is None or not device_handle.is_available():
+                # CPU FakeTensors preserve shape/dtype/lifecycle and avoid
+                # constructing a real CUDA/NPU autograd device guard in wheels
+                # compiled without that backend. The report records both the
+                # logical target and this simulation device.
+                base.device = torch.device("cpu")
+
+            self._stage = "model_build"
+            # Build real meta tensors before entering FakeTensorMode. The
+            # repository's init_empty_weights preserves arbitrary Parameter
+            # subclasses via ``type(param)(...)``; a FakeTensor Parameter has
+            # a private constructor and cannot be rebuilt that way. Real meta
+            # tensors allocate no storage and are safely converted when
+            # parallelization materializes them under the fake mode below.
+            base._build_model()
+            base._freeze_model()
+            # Apply storage dtype policy while parameters are ordinary meta
+            # tensors. Wrapper-subclass FakeTensors cannot change their outer
+            # dtype through ``Parameter.data`` after FSDP materialization, and
+            # casting here preserves the same configured dtype and byte count.
+            base._maybe_downcast_frozen_params()
+            base._maybe_cast_trainable_params()
+            self._stage = "parallelize"
+            # Build HyperParallel DTensor/FSDP metadata while parameters are
+            # ordinary meta tensors. DeviceMesh owns real CPU rank metadata;
+            # deepcopying that metadata inside FakeTensorMode would incorrectly
+            # mix fake meta storage with its real CPU storage.
+            if base.spec.parallelize_fn is None:
+                raise ValueError(
+                    f"Model spec {base.spec.name!r} must define parallelize_fn "
+                    "for HyperDryRun"
+                )
+            base.model = base.spec.parallelize_fn(base.model, base.mesh, base.args)
+            report = self._execute_fake_step(
+                torch,
+                FakeTensorMode,
+                MemTracker,
+                base,
+                prepared,
+                original_init_device,
+                target_device_type,
+            )
+            json_path = write_memory_report(report, output_path)
+            csv_path = os.path.splitext(json_path)[0] + "_memory.csv"
+            write_memory_csv(report, csv_path)
+            logger.info("HyperDryRun tabular report: %s", csv_path)
+            return json_path
+        except Exception as error:
+            try:
+                write_memory_report(self._error_report(error), output_path)
+            except Exception as report_error:
+                logger.warning(
+                    "Failed to write HyperDryRun error report %s: %s",
+                    output_path,
+                    report_error,
+                )
+            raise RuntimeError(
+                f"HyperDryRun failed during {self._stage}: {error}"
+            ) from error
+        finally:
+            if (
+                    dist is not None
+                    and not had_existing_process_group
+                    and dist.is_initialized()
+            ):
+                dist.destroy_process_group()

--- a/hyper_parallel/platform/torch/dtensor.py
+++ b/hyper_parallel/platform/torch/dtensor.py
@@ -34,6 +34,18 @@ class DTensorBase(Tensor):
         """
         if isinstance(local_tensor, DTensorBase):
             # Copy from existing DTensorBase — use alias_placements to preserve multi-axis ordering
+            if getattr(local_tensor, "_is_fake_wrapper", False):
+                copy_placements = (
+                    local_tensor.layout.alias_placements
+                    if local_tensor.layout
+                    else local_tensor.placements
+                )
+                return cls(
+                    local_tensor._local_tensor,
+                    local_tensor.device_mesh,
+                    copy_placements,
+                    local_tensor.layout,
+                )
             t = Tensor._make_subclass(cls, local_tensor._local_tensor, local_tensor._local_tensor.requires_grad)
             copy_placements = local_tensor.layout.alias_placements if local_tensor.layout else local_tensor.placements
             t.__init_data__(local_tensor._local_tensor, local_tensor.device_mesh, copy_placements)
@@ -44,8 +56,29 @@ class DTensorBase(Tensor):
         if placements is None:
             raise ValueError("placements is None, must provide placements")
 
-        # Create Tensor subclass instance, sharing local_tensor's underlying storage
-        t = Tensor._make_subclass(cls, local_tensor, local_tensor.requires_grad)
+        # FakeTensor is already a Python Tensor subclass, so PyTorch rejects
+        # nesting it inside another storage-owning subclass via
+        # ``_make_subclass``. Dry-run uses a traceable wrapper whose C++ device
+        # is meta (so CPU-only builds do not initialize a CUDA/NPU guard) while
+        # ``.device`` and all real work delegate to the local FakeTensor.
+        # Normal eager DTensors keep the original zero-overhead storage-sharing
+        # path below.
+        # pylint: disable=C0415
+        from torch._subclasses.fake_tensor import FakeTensor
+        if isinstance(local_tensor, FakeTensor):
+            t = Tensor._make_wrapper_subclass(
+                cls,
+                local_tensor.size(),
+                strides=local_tensor.stride(),
+                storage_offset=local_tensor.storage_offset(),
+                dtype=local_tensor.dtype,
+                layout=local_tensor.layout,
+                device=torch.device("meta"),
+                requires_grad=local_tensor.requires_grad,
+            )
+            t._is_fake_wrapper = True
+        else:
+            t = Tensor._make_subclass(cls, local_tensor, local_tensor.requires_grad)
         t.__init_data__(local_tensor, device_mesh, placements, layout)
         return t
 
@@ -75,9 +108,46 @@ class DTensorBase(Tensor):
         """
         kwargs = kwargs or {}
         # pylint: disable=C0415
+        from torch.utils._pytree import tree_flatten
+        flat_args, _ = tree_flatten((args, kwargs))
+        if any(
+                isinstance(arg, DTensorBase)
+                and getattr(arg, "_is_fake_wrapper", False)
+                for arg in flat_args
+        ):
+            # Wrapper subclasses must enter at TorchDispatch so autograd sees
+            # their meta C++ device. Calling the op on unwrapped FakeTensors
+            # here would make autograd inspect the outer wrapper's logical
+            # CUDA/NPU device on a CPU-only build.
+            return super().__torch_function__(func, types, args, kwargs)
+        # pylint: disable=C0415
         from hyper_parallel.core.shard._op_dispatch import _OP_DISPATCHER
         out = _OP_DISPATCHER.dispatch(func, args, kwargs)
         return out
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+        """Dispatch fake-wrapper DTensors through HyperParallel layout rules."""
+        # pylint: disable=C0415
+        from hyper_parallel.core.shard._op_dispatch import _OP_DISPATCHER
+        return _OP_DISPATCHER.dispatch(func, args, kwargs or {})
+
+    def __tensor_flatten__(self):
+        """Expose local storage so MemTracker can inspect wrapper DTensors."""
+        context = (self._device_mesh, self._alias_placements(), self._layout)
+        return ["_local_tensor"], context
+
+    @classmethod
+    def __tensor_unflatten__(cls, inner_tensors, context, outer_size, outer_stride):
+        """Rebuild a traceable wrapper DTensor from its local tensor."""
+        del outer_size, outer_stride
+        device_mesh, placements, layout = context
+        return cls(
+            inner_tensors["_local_tensor"],
+            device_mesh=device_mesh,
+            placements=placements,
+            layout=layout,
+        )
 
     @property
     def grad(self) -> Optional[Tensor]:
@@ -87,6 +157,8 @@ class DTensorBase(Tensor):
         Returns:
             Optional[Tensor]: The gradient tensor, or None if no gradient is set.
         """
+        if getattr(self, "_is_fake_wrapper", False):
+            return Tensor.grad.__get__(self, type(self))  # pylint: disable=C2801
         return self._local_tensor.grad
 
     @grad.setter
@@ -97,6 +169,9 @@ class DTensorBase(Tensor):
         Args:
             value (Optional[Tensor]): The gradient tensor to set, or None to clear.
         """
+        if getattr(self, "_is_fake_wrapper", False):
+            Tensor.grad.__set__(self, value)  # pylint: disable=C2801
+            return
         self._local_tensor.grad = value
 
     @property
@@ -232,15 +307,27 @@ class DTensorBase(Tensor):
 
     @property
     # pylint: disable=C2801
-    def data(self):
+    def data(self) -> Tensor:
         """Return the underlying Tensor's data view, bypassing DTensor wrappers."""
         return Tensor.data.__get__(self, type(self))
 
     @data.setter
     # pylint: disable=C2801
-    def data(self, value):
+    def data(self, value: Tensor) -> None:
         """Set the underlying tensor data, extracting the local shard if a DTensor is given."""
         local_value = value.to_local() if isinstance(value, DTensorBase) else value
+        if getattr(self, "_is_fake_wrapper", False):
+            if self.dtype != local_value.dtype:
+                raise ValueError(
+                    "Fake-wrapper DTensor data replacement must preserve dtype, "
+                    f"got {local_value.dtype} for {self.dtype}"
+                )
+            # Wrapper subclasses have no mutable storage of their own. Rebase
+            # the traceable inner FakeTensor, which is the storage exposed to
+            # dispatch and MemTracker. FSDP legitimately rebases a full-shape
+            # wrapper onto a local shard when it creates its flat buffer.
+            self._local_tensor = local_value
+            return
         # Tensor.data.__set__ on a Tensor subclass otherwise enters __torch_function__
         # and only rebinds _local_tensor through DTensor dispatch.
         with getattr(torch, "_C").DisableTorchFunctionSubclass():

--- a/hyper_parallel/platform/torch/fully_shard/param_group.py
+++ b/hyper_parallel/platform/torch/fully_shard/param_group.py
@@ -504,7 +504,12 @@ class HSDPParamGroup:
         """
         if self._flat_param_buffer is None or len(self.hsdp_params) == 0:
             return False
-        return self.hsdp_params[0]._sharded_param_data.data_ptr() == self._flat_param_buffer.data_ptr()
+        param_data = self.hsdp_params[0]._sharded_param_data
+        # pylint: disable=C0415
+        from torch._subclasses.fake_tensor import FakeTensor
+        if isinstance(param_data, FakeTensor):
+            return param_data.untyped_storage() is self._flat_param_buffer.untyped_storage()
+        return param_data.data_ptr() == self._flat_param_buffer.data_ptr()
 
     def unshard(self, async_op: bool = False):
         """Trigger fused all-gather to reconstruct full parameters from shards.

--- a/hyper_parallel/platform/torch/platform.py
+++ b/hyper_parallel/platform/torch/platform.py
@@ -491,8 +491,14 @@ class TorchPlatform(Platform):
         Returns:
             str: The device type string ("npu" for NPU, "cuda" for GPU).
         """
-        device_handle = self.get_device_handle()
-        if device_handle == torch.npu:
+        try:
+            device_handle = self.get_device_handle()
+        except RuntimeError:
+            # CUDA-only wheels do not expose ``torch.npu``. Keep the default
+            # NPU behavior when that backend exists, but allow shape-only
+            # dry-run (and normal CUDA selection) without the extension.
+            return "cuda"
+        if hasattr(torch, "npu") and device_handle == torch.npu:
             return "npu"
         return "cuda"
 
@@ -727,14 +733,15 @@ class TorchPlatform(Platform):
         Returns:
             str: The operation name.
         """
-        if hasattr(func, "__name__"):
-            return func.__name__
         if isinstance(func, OpOverload):
-            full_name = func.name
+            full_name = func.name() if callable(func.name) else func.name
             core_name = full_name.split("::")[-1].split(".")[0]
             return core_name
         if isinstance(func, OpOverloadPacket):
-            return func.name.split("::")[-1]
+            full_name = func.name() if callable(func.name) else func.name
+            return full_name.split("::")[-1]
+        if hasattr(func, "__name__"):
+            return func.__name__
         func_str = str(func)
         if "built-in function" in func_str:
             return func_str.split()[-1].strip(">")
@@ -1336,6 +1343,28 @@ class TorchPlatform(Platform):
                 backend = "hccl"
             dist.init_process_group(backend=backend, init_method=init_method, timeout=timeout, world_size=world_size,
                                     rank=rank, store=store, pg_options=pg_options, device_id=device_id)
+
+    @staticmethod
+    def init_dry_run_process_group(world_size: int, rank: int) -> None:
+        """Initialize PyTorch's fake process group without peer processes.
+
+        Args:
+            world_size: Logical number of ranks to simulate.
+            rank: Logical rank represented by the current process.
+        """
+        # pylint: disable=C0415
+        from torch.testing._internal.distributed import fake_pg
+
+        # Importing PyTorch's fake_pg module registers the version-matched
+        # factory. In particular, newer releases require a private internal
+        # constructor while 2.7/2.9 use the factory shipped with that release.
+        del fake_pg
+        dist.init_process_group(
+            backend=dist.Backend.FAKE,
+            store=dist.HashStore(),
+            world_size=world_size,
+            rank=rank,
+        )
 
     @staticmethod
     def destroy_process_group(group: Optional[ProcessGroup] = None) -> None:

--- a/hyper_parallel/trainer/base.py
+++ b/hyper_parallel/trainer/base.py
@@ -173,16 +173,26 @@ class BaseTrainer:
         Calls hyper's own ``init_process_group`` and ``init_device_mesh``.
         Mesh shape is derived from ``args.parallel`` (dp, tp, cp, pp, ep).
         """
-        self._apply_pre_init_deterministic_env()
-        backend = self.args.train.comm_backend
-        init_process_group(backend=backend)
+        dry_run_cfg = getattr(self.args.train, "dry_run", None)
+        dry_run_enabled = bool(dry_run_cfg and dry_run_cfg.enabled)
+        if not dry_run_enabled:
+            self._apply_pre_init_deterministic_env()
+        if dry_run_enabled:
+            platform.init_dry_run_process_group(
+                world_size=dry_run_cfg.world_size,
+                rank=dry_run_cfg.rank,
+            )
+        else:
+            backend = self.args.train.comm_backend
+            init_process_group(backend=backend)
 
         local_rank = self.args.train.local_rank
         device_type = platform.device_type()  # "npu" or "cuda"
         # Use platform.device(idx) — backend-agnostic.
         self.device = platform.device(local_rank)
-        device_handle = platform.get_device_handle(device_type)
-        device_handle.set_device(local_rank)
+        if not dry_run_enabled:
+            device_handle = platform.get_device_handle(device_type)
+            device_handle.set_device(local_rank)
 
         # Build & validate parallel dims in one place (fail-fast).
 
@@ -226,21 +236,22 @@ class BaseTrainer:
             group_name="trainer_dp", group=dp_group, rank_size=dp_size,
         )
 
-        seed = self.args.train.seed
-        platform.manual_seed(seed)
-        random.seed(seed)
-        np.random.seed(seed)
-        # ``platform.manual_seed`` only covers CPU; seed the device RNG too.
-        try:
-            handle = platform.get_device_handle(device_type)
-            if hasattr(handle, "manual_seed_all"):
-                handle.manual_seed_all(seed)
-            elif hasattr(handle, "manual_seed"):
-                handle.manual_seed(seed)
-        except Exception as exc:  # pylint: disable=W0718
-            logger.warning("Device-side seed init skipped: %s", exc)
+        if not dry_run_enabled:
+            seed = self.args.train.seed
+            platform.manual_seed(seed)
+            random.seed(seed)
+            np.random.seed(seed)
+            # ``platform.manual_seed`` only covers CPU; seed the device RNG too.
+            try:
+                handle = platform.get_device_handle(device_type)
+                if hasattr(handle, "manual_seed_all"):
+                    handle.manual_seed_all(seed)
+                elif hasattr(handle, "manual_seed"):
+                    handle.manual_seed(seed)
+            except Exception as exc:  # pylint: disable=W0718
+                logger.warning("Device-side seed init skipped: %s", exc)
 
-        if self._deterministic:
+        if self._deterministic and not dry_run_enabled:
             warn_only = self.args.train.debug.deterministic_warn_only
             torch.use_deterministic_algorithms(True, warn_only=warn_only)
             torch.backends.cudnn.deterministic = True
@@ -730,7 +741,11 @@ class BaseTrainer:
         random.
         """
         init_device = self.args.train.init_device
-        weights_path = self.args.model.weights_path
+        weights_path = (
+            None
+            if getattr(getattr(self.args.train, "dry_run", None), "enabled", False)
+            else self.args.model.weights_path
+        )
         if init_device == "meta":
             # Always materialize first (random init baseline) so no param
             # stays on meta — then overlay the checkpoint.
@@ -1004,7 +1019,7 @@ class BaseTrainer:
                 "Mixed precision via FSDP2 mp_policy: param=%s reduce=%s on %s",
                 mp_cfg.param_dtype,
                 mp_cfg.reduce_dtype,
-                platform.device_type(),
+                self.device.type,
             )
 
     def _init_callbacks(self):
@@ -1034,7 +1049,7 @@ class BaseTrainer:
         logger.info_rank0(
             "Callbacks initialized: logging, checkpoint, hf_export, eval, "
             "profiler, wandb, tensorboard, progress, moe_monitor, "
-            "training_state_monitor, " 
+            "training_state_monitor, "
             "gradient_health, memory_monitor, gc"
         )
 
@@ -2034,17 +2049,27 @@ class BaseTrainer:
         This is the meta-init path used after ``fully_shard`` has installed
         FSDP views.
         """
-        device_type = platform.device_type()
+        dry_run_enabled = bool(
+            getattr(getattr(self.args.train, "dry_run", None), "enabled", False)
+        )
+        device_type = self.device.type if dry_run_enabled else platform.device_type()
         # Step 1: meta → real storage, in-place (FSDP-views preserved).
         self.model.to_empty(device=device_type)
         self._materialize_replicate_params(device_type)
         # Step 2: init the local shard of every param (and zero every buffer).
-        param_count = self._init_local_shards()
+        if dry_run_enabled:
+            # Fake tensors carry shape/dtype/device only. Random initialization
+            # is unnecessary and may ask a CPU-only Torch build for a real
+            # CUDA/NPU generator before FakeTensorMode can intercept the op.
+            param_count = sum(1 for _ in self.model.parameters())
+        else:
+            param_count = self._init_local_shards()
         # Re-derive buffers wiped by ``to_empty`` (e.g. ``inv_freq``);
         # without this RoPE silently returns identity rotation.
-        for module in self.model.modules():
-            if hasattr(module, "reset_inv_freq"):
-                module.reset_inv_freq()
+        if not dry_run_enabled:
+            for module in self.model.modules():
+                if hasattr(module, "reset_inv_freq"):
+                    module.reset_inv_freq()
         # Re-tie weights — ``to_empty`` gives every nn.Parameter fresh
         # storage so ``__init__``-time ties are broken. Must happen before
         # ``lazy_init`` re-wraps params as DTensor (non-leaf), which would

--- a/hyper_parallel/trainer/config.py
+++ b/hyper_parallel/trainer/config.py
@@ -310,6 +310,53 @@ class MemoryMonitorConfig:
 
 
 @dataclass
+class DryRunConfig:
+    """``train.dry_run.*`` — no-accelerator logical memory analysis.
+
+    ``world_size`` may be omitted when every parallel degree is explicit. If
+    ``dp_shard`` is automatic, the runner requires an explicit world size.
+    ``device_memory_gib`` is optional and only controls the report's OOM-risk
+    calculation; it never changes the simulated allocation.
+    """
+    enabled: bool = False
+    world_size: Optional[int] = None
+    rank: int = 0
+    device_type: Optional[str] = None
+    output_dir: str = "outputs/dry_run"
+    module_depth: int = 3
+    top_modules: int = 20
+    device_memory_gib: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        if self.world_size is not None and self.world_size < 1:
+            raise ValueError(
+                f"dry_run.world_size must be >= 1, got {self.world_size}"
+            )
+        if self.rank < 0:
+            raise ValueError(f"dry_run.rank must be >= 0, got {self.rank}")
+        if self.device_type not in (None, "npu", "cuda"):
+            raise ValueError(
+                "dry_run.device_type must be 'npu', 'cuda', or null, "
+                f"got {self.device_type!r}"
+            )
+        if not isinstance(self.output_dir, str) or not self.output_dir.strip():
+            raise ValueError("dry_run.output_dir must not be empty")
+        if self.module_depth < 0:
+            raise ValueError(
+                f"dry_run.module_depth must be >= 0, got {self.module_depth}"
+            )
+        if self.top_modules < 0:
+            raise ValueError(
+                f"dry_run.top_modules must be >= 0, got {self.top_modules}"
+            )
+        if self.device_memory_gib is not None and self.device_memory_gib <= 0:
+            raise ValueError(
+                "dry_run.device_memory_gib must be > 0, "
+                f"got {self.device_memory_gib}"
+            )
+
+
+@dataclass
 class MonitorConfig:
     """``train.monitor.*`` — training-state monitor for loss / gradient scalars."""
     monitor_on: bool = False
@@ -405,6 +452,7 @@ class TrainConfig:
     wandb: WandbConfig = field(default_factory=WandbConfig)
     profile: ProfileConfig = field(default_factory=ProfileConfig)
     memory_monitor: MemoryMonitorConfig = field(default_factory=MemoryMonitorConfig)
+    dry_run: DryRunConfig = field(default_factory=DryRunConfig)
     monitor: MonitorConfig = field(default_factory=MonitorConfig)
     moe_monitor: MoEMonitorConfig = field(default_factory=MoEMonitorConfig)
     eval: EvalConfig = field(default_factory=EvalConfig)
@@ -577,6 +625,7 @@ def _validate_top_level(config: Dict[str, Any]) -> None:
         "wandb": "train.wandb",
         "profiler": "train.profile",
         "memory_monitor": "train.memory_monitor",
+        "dry_run": "train.dry_run",
         "moe_monitor": "train.moe_monitor",
         "eval": "train.eval",
         "runtime": "train (flatten init_device / backend / comm_backend)",

--- a/memory_analysis.html
+++ b/memory_analysis.html
@@ -1,0 +1,4977 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MS Runtime 显存分析</title>
+  <style data-main-page>
+    :root {
+      --bg: #f6f2e9;
+      --panel: rgba(255, 251, 245, 0.96);
+      --line: #dccfb9;
+      --text: #1f2937;
+      --muted: #6b7280;
+      --blue: #2563eb;
+      --red: #dc2626;
+      --amber: #d97706;
+      --teal: #0f766e;
+      --shadow: 0 18px 50px rgba(86, 64, 26, 0.12);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+      min-height: 100%;
+      overflow-x: hidden;
+      font-family: "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at top left, rgba(15, 118, 110, 0.16), transparent 30%),
+        radial-gradient(circle at top right, rgba(217, 119, 6, 0.14), transparent 26%),
+        linear-gradient(180deg, #faf7f0, var(--bg));
+    }
+
+    .app {
+      width: min(1600px, calc(100vw - 24px));
+      margin: 12px auto;
+      display: grid;
+      grid-template-columns: 320px minmax(0, 1fr);
+      gap: 16px;
+      align-items: start;
+    }
+
+    .card {
+      background: var(--panel);
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      border-radius: 20px;
+      box-shadow: var(--shadow);
+      backdrop-filter: blur(10px);
+      min-width: 0;
+    }
+
+    .sidebar {
+      padding: 18px;
+      position: sticky;
+      top: 12px;
+    }
+
+    .content {
+      min-width: 0;
+      display: grid;
+      gap: 16px;
+    }
+
+    h1,
+    h2 {
+      margin: 0;
+      line-height: 1.15;
+    }
+
+    h1 {
+      font-size: 28px;
+      margin-bottom: 10px;
+    }
+
+    h2 {
+      font-size: 18px;
+    }
+
+    .lead,
+    .muted,
+    .small {
+      color: var(--muted);
+    }
+
+    .lead {
+      font-size: 14px;
+      line-height: 1.6;
+      margin: 0 0 16px;
+    }
+
+    .block {
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.62);
+      padding: 14px;
+      margin-bottom: 14px;
+    }
+
+    .block-title {
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--teal);
+      margin-bottom: 10px;
+    }
+
+    label,
+    .small {
+      display: block;
+      font-size: 13px;
+      line-height: 1.5;
+    }
+
+    input[type="file"],
+    input[type="number"],
+    select {
+      width: 100%;
+      margin-top: 8px;
+      padding: 10px 12px;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.92);
+      color: var(--text);
+      font-size: 14px;
+    }
+
+    button {
+      width: 100%;
+      border: 0;
+      border-radius: 12px;
+      padding: 11px 14px;
+      font-size: 14px;
+      font-weight: 700;
+      color: #fff;
+      cursor: pointer;
+      background: linear-gradient(135deg, #0f766e, #2563eb);
+    }
+
+    button.secondary {
+      margin-top: 10px;
+      background: linear-gradient(135deg, #9a3412, #d97706);
+    }
+
+    button:disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
+    }
+
+    .checks {
+      display: grid;
+      gap: 10px;
+      margin-top: 10px;
+    }
+
+    .check {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 14px;
+      color: var(--text);
+    }
+
+    .check input {
+      margin: 0;
+      width: 16px;
+      height: 16px;
+    }
+
+    .stats {
+      display: grid;
+      gap: 10px;
+    }
+
+    .stat {
+      padding: 12px;
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.75);
+      border: 1px solid rgba(220, 207, 185, 0.95);
+    }
+
+    .stat-name {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .stat-value {
+      margin-top: 4px;
+      font-size: 17px;
+      font-weight: 700;
+      word-break: break-word;
+    }
+
+    .viewer {
+      padding: 16px;
+      min-width: 0;
+    }
+
+    .viewer-top {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 12px;
+      align-items: center;
+      margin-bottom: 12px;
+    }
+
+    .line-panel {
+      margin-bottom: 12px;
+      padding: 12px;
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.68);
+    }
+
+    .line-title {
+      font-size: 13px;
+      font-weight: 700;
+      color: var(--teal);
+      margin-bottom: 8px;
+    }
+
+    .line-form {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .line-form input,
+    .line-form select {
+      width: auto;
+      min-width: 120px;
+      margin: 0;
+    }
+
+    .line-form button {
+      width: auto;
+      min-width: 90px;
+    }
+
+    .line-form button.active {
+      background: linear-gradient(135deg, #7c3aed, #2563eb);
+    }
+
+    .line-list {
+      display: grid;
+      gap: 8px;
+      margin-top: 10px;
+    }
+
+    .line-item {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      padding: 8px 10px;
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      border-radius: 10px;
+      background: rgba(255, 255, 255, 0.78);
+      font-size: 13px;
+    }
+
+    .line-meta {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+      color: var(--text);
+    }
+
+    .line-color {
+      width: 12px;
+      height: 12px;
+      border-radius: 999px;
+      flex: 0 0 auto;
+    }
+
+    .line-remove {
+      width: auto;
+      min-width: 72px;
+      padding: 7px 10px;
+      background: linear-gradient(135deg, #9a3412, #d97706);
+      font-size: 12px;
+    }
+
+    .legend {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      font-size: 13px;
+      color: var(--muted);
+    }
+
+    .legend-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .swatch {
+      width: 12px;
+      height: 12px;
+      border-radius: 999px;
+    }
+
+    .chart-shell {
+      position: relative;
+      width: 100%;
+      min-width: 0;
+      overflow: hidden;
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      border-radius: 18px;
+      background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.78), rgba(250, 247, 241, 0.96)),
+        repeating-linear-gradient(
+          90deg,
+          rgba(15, 118, 110, 0.03) 0,
+          rgba(15, 118, 110, 0.03) 1px,
+          transparent 1px,
+          transparent 120px
+        );
+    }
+
+    canvas {
+      display: block;
+      width: 100%;
+      height: min(62vh, 640px);
+      min-height: 420px;
+      cursor: grab;
+    }
+
+    canvas.dragging {
+      cursor: grabbing;
+    }
+
+    canvas.line-adding {
+      cursor: crosshair;
+    }
+
+    canvas.line-hover {
+      cursor: ns-resize;
+    }
+
+    .status,
+    .tooltip {
+      position: absolute;
+      z-index: 2;
+      color: #f9fafb;
+      background: rgba(17, 24, 39, 0.88);
+      border-radius: 12px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+      white-space: pre-line;
+      font-size: 12px;
+      line-height: 1.5;
+    }
+
+    .tooltip {
+      pointer-events: none;
+    }
+
+    .status {
+      right: 14px;
+      top: 14px;
+      width: max-content;
+      max-width: min(32%, 320px);
+      padding: 10px 12px;
+      cursor: move;
+      user-select: none;
+    }
+
+    .status.hidden {
+      width: auto;
+      max-width: 120px;
+      padding: 7px 10px;
+      background: rgba(15, 118, 110, 0.92);
+      cursor: pointer;
+    }
+
+    .status.dragging-summary {
+      cursor: grabbing;
+    }
+
+    .tooltip {
+      display: none;
+      padding: 8px 10px;
+      transform: translate(12px, -12px);
+    }
+
+    .detail {
+      padding: 16px;
+      min-width: 0;
+    }
+
+    .detail-top {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      align-items: end;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+
+    .detail-controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      align-items: end;
+    }
+
+    .detail-controls > div {
+      min-width: 180px;
+    }
+
+    .detail-controls button {
+      width: auto;
+      min-width: 170px;
+    }
+
+    .pager {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      align-items: center;
+      gap: 10px;
+      margin-top: 12px;
+    }
+
+    .pager-info {
+      font-size: 13px;
+      color: var(--muted);
+    }
+
+    .pager-actions {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .pager-actions button {
+      width: auto;
+      min-width: 84px;
+      padding: 9px 12px;
+    }
+
+    .pager-actions input {
+      width: 96px;
+      margin: 0;
+      padding: 9px 10px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: rgba(255, 255, 255, 0.92);
+      color: var(--text);
+      font-size: 14px;
+    }
+
+    .column-panel {
+      margin-top: 12px;
+      padding: 12px;
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.68);
+    }
+
+    .column-title {
+      font-size: 13px;
+      font-weight: 700;
+      color: var(--teal);
+      margin-bottom: 8px;
+    }
+
+    .column-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 12px;
+    }
+
+    .column-chip {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 3px 6px;
+      border-radius: 8px;
+      font-size: 12px;
+      color: var(--text);
+      white-space: nowrap;
+      cursor: grab;
+      user-select: none;
+    }
+
+    .column-chip input {
+      margin: 0;
+    }
+
+    .column-chip.dragging-column {
+      opacity: 0.48;
+      cursor: grabbing;
+    }
+
+    .column-chip.drop-before {
+      box-shadow: inset 3px 0 0 var(--teal);
+      background: rgba(15, 118, 110, 0.08);
+    }
+
+    .column-chip.drop-after {
+      box-shadow: inset -3px 0 0 var(--teal);
+      background: rgba(15, 118, 110, 0.08);
+    }
+
+    .table-scroll {
+      width: 100%;
+      overflow-x: auto;
+      overflow-y: auto;
+      max-height: 480px;
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.75);
+    }
+
+    table {
+      width: max-content;
+      min-width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+
+    th,
+    td {
+      padding: 10px 12px;
+      border-bottom: 1px solid rgba(220, 207, 185, 0.65);
+      text-align: left;
+      vertical-align: top;
+      white-space: nowrap;
+    }
+
+    th {
+      position: sticky;
+      top: 0;
+      background: rgba(248, 244, 236, 0.98);
+      z-index: 1;
+      font-weight: 700;
+    }
+
+    .th-content {
+      display: grid;
+      gap: 7px;
+      min-width: max-content;
+    }
+
+    .th-top {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }
+
+    .header-tool-button,
+    .sort-button,
+    .clear-filter-button {
+      width: 28px;
+      min-width: 28px;
+      height: 26px;
+      padding: 0;
+      border-radius: 8px;
+      font-size: 12px;
+      line-height: 1;
+      background: rgba(15, 118, 110, 0.12);
+      color: var(--teal);
+    }
+
+    .header-tool-button {
+      position: relative;
+      display: inline-grid;
+      place-items: center;
+    }
+
+    .header-tool-button::before {
+      content: "";
+      width: 0;
+      height: 0;
+      border-left: 5px solid transparent;
+      border-right: 5px solid transparent;
+      border-top: 6px solid currentColor;
+      transform: translateY(1px);
+    }
+
+    .header-tool-button.active::after {
+      content: "";
+      position: absolute;
+      right: 5px;
+      top: 5px;
+      width: 5px;
+      height: 5px;
+      border-radius: 50%;
+      background: currentColor;
+    }
+
+    .header-tool-button.active,
+    .sort-button.active {
+      background: rgba(15, 118, 110, 0.9);
+      color: #fff;
+    }
+
+    .filter-panel {
+      display: grid;
+      gap: 7px;
+      min-width: 180px;
+      padding-top: 2px;
+    }
+
+    .filter-sort-row {
+      display: flex;
+      gap: 6px;
+      align-items: center;
+    }
+
+    .filter-input,
+    .filter-range input {
+      width: 100%;
+      min-width: 0;
+      margin: 0;
+      padding: 6px 7px;
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      border-radius: 8px;
+      background: rgba(255, 255, 255, 0.9);
+      color: var(--text);
+      font-size: 12px;
+    }
+
+    .filter-range {
+      display: grid;
+      grid-template-columns: minmax(76px, 1fr) minmax(76px, 1fr);
+      gap: 6px;
+    }
+
+    tr:hover td {
+      background: rgba(37, 99, 235, 0.05);
+    }
+
+    .cell-short {
+      display: inline-block;
+      max-width: 320px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      vertical-align: top;
+    }
+
+    .cell-wrap {
+      position: relative;
+      display: inline-grid;
+      grid-template-columns: minmax(0, 320px) auto;
+      align-items: start;
+      gap: 6px;
+      max-width: 360px;
+      vertical-align: top;
+    }
+
+    .cell-toggle {
+      border: 0;
+      background: transparent;
+      color: var(--blue);
+      cursor: pointer;
+      font-size: 12px;
+      padding: 0;
+      white-space: nowrap;
+      align-self: start;
+    }
+
+    .cell-full {
+      display: none;
+      position: absolute;
+      left: 0;
+      top: calc(100% + 6px);
+      z-index: 5;
+      width: min(720px, 70vw);
+      max-height: 320px;
+      overflow: auto;
+      padding: 10px 12px;
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      border-radius: 12px;
+      background: rgba(255, 251, 245, 0.99);
+      box-shadow: 0 16px 40px rgba(17, 24, 39, 0.16);
+      white-space: pre;
+      word-break: normal;
+      line-height: 1.5;
+      color: var(--text);
+    }
+
+    .cell-expanded .cell-full {
+      display: block;
+    }
+
+    .hint {
+      font-size: 12px;
+      line-height: 1.6;
+      color: var(--muted);
+      margin-top: 10px;
+    }
+
+    .detail-explain {
+      margin-top: 12px;
+      padding: 12px 14px;
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.62);
+      color: var(--muted);
+      font-size: 12px;
+      line-height: 1.7;
+    }
+
+    .detail-explain-title {
+      margin-bottom: 6px;
+      color: var(--teal);
+      font-size: 13px;
+      font-weight: 700;
+    }
+
+    .detail-explain ul {
+      margin: 0;
+      padding-left: 18px;
+    }
+
+    .detail-explain li {
+      margin: 4px 0;
+    }
+
+    /* ── View Switch Bar ── */
+    .view-switch-bar {
+      display: flex;
+      justify-content: center;
+      gap: 0;
+      padding: 8px 12px;
+      margin-bottom: 0;
+    }
+
+    .view-switch-btn {
+      padding: 9px 28px;
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      font-size: 14px;
+      font-weight: 700;
+      cursor: pointer;
+      background: rgba(255, 255, 255, 0.6);
+      color: var(--text);
+      text-align: center;
+      white-space: nowrap;
+    }
+
+    .view-switch-btn:first-child {
+      border-radius: 12px 0 0 12px;
+      border-right: 0;
+    }
+
+    .view-switch-btn:last-child {
+      border-radius: 0 12px 12px 0;
+    }
+
+    .view-switch-btn.active {
+      background: linear-gradient(135deg, #0f766e, #2563eb);
+      color: #fff;
+    }
+
+    .view-switch-btn:disabled {
+      opacity: 0.55;
+      cursor: not-allowed;
+    }
+
+    /* ── Detail Tab Bar ── */
+    .detail-tab-bar {
+      display: flex;
+      justify-content: center;
+      gap: 0;
+      padding: 0 12px;
+    }
+
+    .detail-tab-btn {
+      padding: 9px 24px;
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      border-bottom: 0;
+      font-size: 14px;
+      font-weight: 700;
+      cursor: pointer;
+      background: rgba(255, 255, 255, 0.45);
+      color: var(--text);
+      text-align: center;
+      white-space: nowrap;
+      transition: all 0.15s;
+    }
+
+    .detail-tab-btn:first-child {
+      border-radius: 12px 0 0 0;
+    }
+
+    .detail-tab-btn:last-child {
+      border-radius: 0 12px 0 0;
+    }
+
+    .detail-tab-btn.active {
+      background: linear-gradient(135deg, #0f766e, #2563eb);
+      color: #fff;
+      border-color: transparent;
+    }
+
+    #mvizStatus {
+      text-align: center;
+      padding: 4px 12px;
+      font-size: 13px;
+      color: var(--muted);
+    }
+    #mvizStatus.error { color: #dc2626; }
+    #mvizStatus.ok { color: #0f766e; }
+
+    /* Hide all MemoryViz body-level elements in line-chart mode
+       (uses !important to override MemoryViz inline styles like display:flex/grid) */
+    body.hide-mviz > div:not(.app):not(.view-switch-bar):not(#mvizStatus),
+    body.hide-mviz > label,
+    body.hide-mviz > input {
+      display: none !important;
+    }
+
+    /* In lifetime mode, reset global label rule so MemoryViz detail-bar stays on one line */
+    body:not(.hide-mviz) > label,
+    body:not(.hide-mviz) label {
+      display: inline;
+    }
+
+    /* ── Peak Interpreter ── */
+    .peak-interp-overview {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+      gap: 10px;
+      margin-bottom: 14px;
+    }
+
+    .peak-interp-stat {
+      padding: 10px 12px;
+      border-radius: 10px;
+      background: rgba(255, 255, 255, 0.75);
+      border: 1px solid rgba(220, 207, 185, 0.95);
+    }
+
+    .peak-interp-stat .label {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .peak-interp-stat .value {
+      margin-top: 2px;
+      font-size: 15px;
+      font-weight: 700;
+    }
+
+    .peak-interp-conclusions {
+      margin-bottom: 14px;
+      padding: 12px 14px;
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.68);
+    }
+
+    .peak-interp-conclusions-title {
+      font-size: 13px;
+      font-weight: 700;
+      color: var(--teal);
+      margin-bottom: 8px;
+    }
+
+    .peak-interp-conclusion-item {
+      font-size: 13px;
+      line-height: 1.6;
+      padding: 3px 0;
+      color: var(--text);
+    }
+
+    .peak-interp-conclusion-item.risk { color: #dc2626; }
+    .peak-interp-conclusion-item.warn { color: #d97706; }
+    .peak-interp-conclusion-item.info { color: #2563eb; }
+
+    .peak-agg-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      padding: 8px 10px;
+      border-bottom: 1px solid rgba(220, 207, 185, 0.5);
+      cursor: pointer;
+      font-size: 13px;
+      transition: background 0.1s;
+    }
+
+    .peak-agg-row:hover {
+      background: rgba(37, 99, 235, 0.05);
+    }
+
+    .peak-agg-row.selected {
+      background: rgba(37, 99, 235, 0.12);
+      border-left: 3px solid #2563eb;
+    }
+
+    .peak-agg-bar-wrap {
+      flex: 1;
+      min-width: 60px;
+      height: 8px;
+      border-radius: 4px;
+      background: rgba(220, 207, 185, 0.4);
+      overflow: hidden;
+    }
+
+    .peak-agg-bar-fill {
+      height: 100%;
+      border-radius: 4px;
+      background: linear-gradient(90deg, #2563eb, #7c3aed);
+    }
+
+    .peak-interp-export-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 10px;
+    }
+
+    .peak-interp-export-row button {
+      width: auto;
+      min-width: 120px;
+    }
+
+    @media (max-width: 1120px) {
+      .app {
+        grid-template-columns: 1fr;
+      }
+
+      .sidebar {
+        position: static;
+      }
+    }
+
+    /* ── Diff Analysis ── */
+    .diff-setup {
+      margin-top: 14px;
+      padding: 14px;
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      border-radius: 14px;
+      background: rgba(255, 255, 255, 0.62);
+    }
+
+    .diff-setup-title {
+      font-size: 13px;
+      font-weight: 700;
+      color: var(--teal);
+      margin-bottom: 10px;
+    }
+
+    .diff-point-row {
+      display: grid;
+      grid-template-columns: 1fr auto auto auto;
+      gap: 6px;
+      align-items: center;
+      margin-bottom: 8px;
+    }
+
+    .diff-point-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+    }
+
+    .diff-point-row input {
+      width: 100%;
+      min-width: 80px;
+      margin: 0;
+      padding: 8px 10px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: rgba(255, 255, 255, 0.92);
+      color: var(--text);
+      font-size: 13px;
+    }
+
+    .diff-point-row button {
+      width: auto;
+      min-width: 56px;
+      padding: 8px 10px;
+      font-size: 12px;
+    }
+
+    .diff-point-row select {
+      width: auto;
+      min-width: 80px;
+      margin: 0;
+      padding: 8px 10px;
+      font-size: 13px;
+    }
+
+    .diff-run-btn {
+      width: 100%;
+      margin-top: 4px;
+      background: linear-gradient(135deg, #7c3aed, #2563eb);
+    }
+
+    .diff-summary {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 10px;
+      margin-bottom: 14px;
+    }
+
+    .diff-summary-item {
+      padding: 10px 12px;
+      border-radius: 10px;
+      background: rgba(255, 255, 255, 0.75);
+      border: 1px solid rgba(220, 207, 185, 0.95);
+    }
+
+    .diff-summary-label {
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .diff-summary-value {
+      margin-top: 2px;
+      font-size: 15px;
+      font-weight: 700;
+    }
+
+    .diff-summary-value.added { color: #dc2626; }
+    .diff-summary-value.released { color: #0f766e; }
+    .diff-summary-value.common { color: #2563eb; }
+
+    .diff-tabs {
+      display: flex;
+      gap: 0;
+      margin-bottom: 12px;
+      border: 1px solid rgba(220, 207, 185, 0.95);
+      border-radius: 12px;
+      overflow: hidden;
+    }
+
+    .diff-tab {
+      flex: 1;
+      border: 0;
+      border-radius: 0;
+      padding: 10px 8px;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      background: rgba(255, 255, 255, 0.6);
+      color: var(--text);
+      text-align: center;
+    }
+
+    .diff-tab.active-add {
+      background: linear-gradient(135deg, #dc2626, #ef4444);
+      color: #fff;
+    }
+
+    .diff-tab.active-release {
+      background: linear-gradient(135deg, #0f766e, #14b8a6);
+      color: #fff;
+    }
+
+    .diff-tab.active-common {
+      background: linear-gradient(135deg, #2563eb, #60a5fa);
+      color: #fff;
+    }
+
+    .diff-agg-select {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+
+    .diff-agg-select label {
+      font-size: 13px;
+      color: var(--muted);
+      margin: 0;
+    }
+
+    .diff-agg-select select {
+      width: auto;
+      min-width: 140px;
+      margin: 0;
+      padding: 8px 10px;
+    }
+
+    .diff-export-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 10px;
+    }
+
+    .diff-export-row button {
+      width: auto;
+      min-width: 120px;
+    }
+
+    .diff-export-row button.json-btn {
+      background: linear-gradient(135deg, #7c3aed, #a78bfa);
+    }
+
+    .diff-highlight-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 10px;
+      align-items: center;
+    }
+
+    .diff-highlight-row span {
+      font-size: 13px;
+      color: var(--muted);
+    }
+
+    .diff-highlight-row button {
+      width: auto;
+      min-width: 80px;
+      padding: 8px 12px;
+      font-size: 12px;
+    }
+
+    .diff-highlight-row button.hl-added { background: linear-gradient(135deg, #dc2626, #ef4444); }
+    .diff-highlight-row button.hl-released { background: linear-gradient(135deg, #0f766e, #14b8a6); }
+    .diff-highlight-row button.hl-common { background: linear-gradient(135deg, #2563eb, #60a5fa); }
+    .diff-highlight-row button.hl-off { background: linear-gradient(135deg, #6b7280, #9ca3af); }
+
+    @media (max-width: 700px) {
+      .app {
+        width: calc(100vw - 12px);
+        margin: 6px auto;
+      }
+
+      .sidebar,
+      .viewer,
+      .detail {
+        padding: 14px;
+      }
+
+      canvas {
+        height: 460px;
+        min-height: 460px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="view-switch-bar" id="viewSwitchBar">
+    <button class="view-switch-btn active" id="btnLineChart" type="button">折线图</button>
+    <button class="view-switch-btn" id="btnLifetime" type="button" disabled>生命周期</button>
+  </div>
+  <div id="mvizStatus"></div>
+  <div class="app">
+    <aside class="sidebar card">
+      <h1>显存分析浏览器</h1>
+
+      <div class="block">
+        <div class="block-title">使用说明</div>
+        <div class="hint" style="margin-top:0;">
+          点击或拖拽 CSV 文件到页面即可加载，支持本地离线使用。
+        </div>
+        <div class="hint" style="margin-top:6px;">
+          <b>图表操作：</b>滚轮缩放时间轴，Shift + 滚轮缩放显存轴，拖拽平移，Alt + 拖拽框选放大。单击曲线上的点可查看该时刻的存活/后续明细。
+        </div>
+        <div class="hint" style="margin-top:6px;">
+          <b>折线图 / 生命周期：</b>顶部按钮切换。折线图适合查看全局趋势和峰值；生命周期适合查看内存块分配-释放时间线。大文件建议先用折线图。
+        </div>
+        <div class="hint" style="margin-top:6px;">
+          <b>明细表：</b>峰值明细查看峰值时刻存活块，差异分析对比两个时间点的分配变化，峰值解释器按维度聚合分析峰值构成。
+        </div>
+        <div class="hint" style="margin-top:6px;">
+          <b>横线标记：</b>点"点图加线"后点击图表添加参考线，用于标记关键时间点。
+        </div>
+      </div>
+
+      <div class="block">
+        <div class="block-title">文件</div>
+        <label>
+          选择 block CSV
+          <input id="fileInput" type="file" accept=".csv,text/csv">
+        </label>
+        <div class="small" id="fileName">尚未选择文件</div>
+      </div>
+
+      <div class="block">
+        <div class="block-title">显示项</div>
+        <div class="checks">
+          <label class="check"><input type="checkbox" id="showReal" checked> 无碎片显存</label>
+          <label class="check"><input type="checkbox" id="showTheory"> 理论显存</label>
+          <label class="check"><input type="checkbox" id="showActual" checked> 含碎片显存</label>
+        </div>
+      </div>
+
+      <div class="block">
+        <div class="block-title">采样</div>
+        <label>
+          每像素采样上限
+          <input id="samplesPerPixel" type="number" min="1" max="20" step="1" value="2">
+        </label>
+        <div class="hint">数据量很大时会自动降采样，避免图线太密或渲染太慢。</div>
+      </div>
+
+      <div class="block">
+        <button id="fitButton">适配全局视图</button>
+        <button id="resetYButton" class="secondary">重置纵轴</button>
+        <div class="hint">
+          滚轮：缩放时间轴
+          <br>Shift + 滚轮：缩放显存轴
+          <br>按住鼠标拖拽：在图里左右移动
+          <br>Alt + 拖拽：框选放大
+        </div>
+      </div>
+
+      <div class="block">
+        <div class="block-title">统计</div>
+        <div class="stats">
+          <div class="stat">
+            <div class="stat-name">总行数</div>
+            <div class="stat-value" id="statRows">-</div>
+          </div>
+          <div class="stat">
+            <div class="stat-name">时间范围</div>
+            <div class="stat-value" id="statTime">-</div>
+          </div>
+          <div class="stat">
+            <div class="stat-name">申请量峰值</div>
+            <div class="stat-value" id="statRealPeak">-</div>
+          </div>
+          <div class="stat">
+            <div class="stat-name">理论峰值</div>
+            <div class="stat-value" id="statTheoryPeak">-</div>
+          </div>
+          <div class="stat">
+            <div class="stat-name">内存池峰值</div>
+            <div class="stat-value" id="statActualPeak">-</div>
+          </div>
+        </div>
+      </div>
+
+    </aside>
+
+    <main class="content">
+      <section class="viewer card">
+        <div class="viewer-top">
+          <div class="legend" id="lineChartLegend">
+            <div class="legend-item"><span class="swatch" style="background: var(--blue);"></span>无碎片显存</div>
+            <div class="legend-item"><span class="swatch" style="background: var(--red);"></span>理论显存</div>
+            <div class="legend-item"><span class="swatch" style="background: var(--amber);"></span>含碎片显存</div>
+          </div>
+          <div class="small" id="viewportText">等待载入数据</div>
+        </div>
+
+        <div class="line-panel" id="linePanel">
+          <div class="line-title">横线标记</div>
+          <div class="line-form">
+            <select id="lineColorSelect">
+              <option value="#0f766e">青绿</option>
+              <option value="#7c3aed">紫色</option>
+              <option value="#db2777">玫红</option>
+              <option value="#ea580c">橙色</option>
+              <option value="#2563eb">蓝色</option>
+            </select>
+            <button id="addLineModeButton" type="button">点图加线</button>
+          </div>
+          <div class="line-list" id="lineList"></div>
+        </div>
+
+        <div class="chart-shell">
+          <canvas id="chartCanvas"></canvas>
+          <div class="tooltip" id="hoverTooltip"></div>
+          <div class="status" id="statusText">选择 CSV 文件后开始分析。</div>
+        </div>
+      </section>
+
+      <div class="detail-tab-bar" id="detailTabBar" style="display:none;">
+        <button class="detail-tab-btn active" data-tab="detail" type="button">峰值明细</button>
+        <button class="detail-tab-btn" data-tab="diff" type="button">激活点差异分析</button>
+        <button class="detail-tab-btn" data-tab="interp" type="button">峰值解释器</button>
+      </div>
+
+      <section class="detail card" id="detailCard" style="display:none;">
+        <div class="column-panel">
+          <div class="column-title">显示列</div>
+          <div class="column-list" id="columnList"></div>
+        </div>
+        <div class="detail-top">
+          <div>
+            <h2>峰值明细</h2>
+            <div class="small" id="detailSummary">载入数据后可查看全量申请、峰值时刻仍占用的内存块，以及点击/框选区域明细。</div>
+          </div>
+          <div class="detail-controls">
+            <div>
+              <label>
+                明细来源
+                <select id="detailMode">
+                  <option value="all_allocations">从头开始</option>
+                  <option value="real_peak">无碎片峰值时刻存活</option>
+                  <option value="actual_peak">含碎片峰值时刻存活</option>
+                  <option value="abnormal">异常 PyNative</option>
+                  <option value="clicked_alive">点击时刻存活</option>
+                  <option value="clicked_point">点击后续申请</option>
+                  <option value="selected_range">框选时间范围</option>
+                </select>
+              </label>
+            </div>
+            <div>
+              <button id="exportButton" disabled>导出当前明细 CSV</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="table-scroll">
+          <table>
+            <thead>
+              <tr id="detailHeadRow"></tr>
+            </thead>
+            <tbody id="detailBody"></tbody>
+          </table>
+        </div>
+        <div class="pager">
+          <div class="pager-info" id="pagerInfo">第 0 / 0 页</div>
+          <div class="pager-actions">
+            <button id="prevPageButton" type="button">上一页</button>
+            <button id="nextPageButton" type="button">下一页</button>
+            <input id="pageInput" type="number" min="1" step="1" placeholder="跳转页">
+            <button id="goPageButton" type="button">跳转</button>
+          </div>
+        </div>
+        <div class="hint">单击曲线附近的点会显示该时间点的明细。按住 Alt 拖拽框选后，会同时放大并显示该时间范围的明细。明细表使用自己的横向滚动条，不会把整个网页撑宽。</div>
+        <div class="detail-explain">
+          <div class="detail-explain-title">明细来源说明</div>
+          <ul>
+            <li>从头开始：显示所有有效申请记录，按 start_time_stamp 从小到大排列，用于从任务开始顺序排查内存申请。</li>
+            <li>无碎片峰值时刻存活：先用 size 按申请/释放时间累加出“无碎片显存”曲线，找到该曲线峰值时间点，再显示这个时间点仍存活的记录。</li>
+            <li>含碎片峰值时刻存活：先读取 actual_peak_memory 形成“含碎片显存”曲线，找到该曲线峰值时间点，再显示这个时间点仍存活的记录。</li>
+            <li>点击时刻存活：点击图上的某个时间点后，显示该时间点仍存活的记录；判定条件为 start_time_stamp &lt;= 点击时间 &lt; end_time_stamp。</li>
+            <li>点击后续申请：点击图上的某个时间点后，显示 start_time_stamp >= 点击时间 的后续申请记录，适合从某个阶段开始向后排查。</li>
+            <li>框选时间范围：按住 Alt 框选一段时间后，显示 start_time_stamp 落在该时间范围内的申请记录。</li>
+            <li>异常 PyNative：在无碎片峰值时刻存活的记录里，筛出 user_tasks 已早于峰值时间结束、但 PyNative 相关内存仍存活的记录，用于辅助排查疑似未及时释放的内存。</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="detail card" id="peakInterpCard" style="display:none;">
+        <div class="detail-top">
+          <div>
+            <h2>峰值解释器</h2>
+            <div class="small" id="peakInterpDesc">载入数据后可查看峰值来源分析。</div>
+          </div>
+          <div class="detail-controls">
+            <div>
+              <label>解释对象
+                <select id="peakInterpTarget">
+                  <option value="real_peak">无碎片峰值</option>
+                  <option value="theory_peak">理论峰值</option>
+                  <option value="actual_peak">含碎片峰值</option>
+                  <option value="clicked_time">当前点击时间点</option>
+                </select>
+              </label>
+            </div>
+            <div>
+              <button id="peakInterpRun">运行分析</button>
+            </div>
+          </div>
+        </div>
+
+        <div id="peakInterpContent" style="display:none;">
+          <div class="peak-interp-overview" id="peakInterpOverview"></div>
+
+          <div class="peak-interp-conclusions" id="peakInterpConclusions">
+            <div class="peak-interp-conclusions-title">解释结论</div>
+            <div id="peakInterpConclusionList"></div>
+          </div>
+
+          <div style="margin-bottom:12px;">
+            <label style="font-size:13px;color:var(--muted);">聚合维度</label>
+            <select id="peakInterpDim" style="width:auto;min-width:160px;margin:0;padding:7px 10px;">
+              <option value="type">type</option>
+              <option value="task_name">task_name</option>
+              <option value="node_name">node_name</option>
+              <option value="graph_name">graph_name</option>
+              <option value="producer_task">producer_task</option>
+              <option value="pool_type">pool_type</option>
+              <option value="python_stack_frame">python_stack 顶层帧</option>
+              <option value="is_persistent">is_persistent</option>
+              <option value="is_small">is_small</option>
+            </select>
+          </div>
+
+          <div style="max-height:360px;overflow-y:auto;border:1px solid rgba(220,207,185,0.95);border-radius:12px;background:rgba(255,255,255,0.75);" id="peakInterpAggList"></div>
+          <div class="small" style="margin-top:8px;color:var(--muted)" id="peakInterpAggNote"></div>
+
+          <div class="peak-interp-export-row">
+            <button id="peakInterpExportCSV">导出解释 CSV</button>
+            <button id="peakInterpExportJSON" class="json-btn">导出解释 JSON</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="detail card" id="diffCard" style="display:none;">
+        <div class="detail-top">
+          <div>
+            <h2>激活点差异分析</h2>
+            <div class="small" id="diffSummary">设置 A/B 时间点并运行分析后，这里会显示差异结果。</div>
+          </div>
+        </div>
+
+        <div class="diff-setup">
+          <div class="diff-setup-title">分析点 A</div>
+          <div class="diff-point-row">
+            <span class="diff-point-label">时间戳</span>
+            <input id="diffATime" type="number" placeholder="输入时间或点击曲线">
+            <button id="diffASetClick" type="button" title="从点击的曲线点设置">点击</button>
+            <select id="diffARefLine">
+              <option value="">-- 参考线 --</option>
+            </select>
+          </div>
+          <div class="diff-setup-title" style="margin-top:8px;">分析点 B</div>
+          <div class="diff-point-row">
+            <span class="diff-point-label">时间戳</span>
+            <input id="diffBTime" type="number" placeholder="输入时间或点击曲线">
+            <button id="diffBSetClick" type="button" title="从点击的曲线点设置">点击</button>
+            <select id="diffBRefLine">
+              <option value="">-- 参考线 --</option>
+            </select>
+          </div>
+          <button id="diffRunBtn" class="diff-run-btn" disabled>运行差异分析</button>
+        </div>
+        <div class="hint">设置 A/B 两个时间点后，比较两个时刻的存活显存分配差异。</div>
+
+        <div class="diff-summary" id="diffSummaryGrid" style="display:none;"></div>
+
+        <div id="diffContent" style="display:none;">
+          <div class="diff-agg-select">
+            <label>聚合维度</label>
+            <select id="diffAggDimension">
+              <option value="type">type</option>
+              <option value="task_name">task_name</option>
+              <option value="node_name">node_name</option>
+              <option value="graph_name">graph_name</option>
+              <option value="python_stack">python_stack</option>
+            </select>
+          </div>
+
+          <div class="diff-tabs" id="diffTabs">
+            <button class="diff-tab active-add" data-category="added" type="button">新增</button>
+            <button class="diff-tab" data-category="released" type="button">释放</button>
+            <button class="diff-tab" data-category="common" type="button">共同存活</button>
+          </div>
+
+          <div class="table-scroll" style="max-height:300px;">
+            <table>
+              <thead id="diffAggHead"></thead>
+              <tbody id="diffAggBody"></tbody>
+            </table>
+          </div>
+
+          <div class="small" style="margin-top:10px;color:var(--muted)" id="diffAggNote"></div>
+
+          <div style="margin-top:12px;">
+            <div class="small" id="diffDetailSummary" style="margin-bottom:8px;"></div>
+            <div class="table-scroll">
+              <table>
+                <thead id="diffDetailHead"></thead>
+                <tbody id="diffDetailBody"></tbody>
+              </table>
+            </div>
+            <div class="pager">
+              <div class="pager-info" id="diffPagerInfo">第 0 / 0 页</div>
+              <div class="pager-actions">
+                <button id="diffPrevPage" type="button">上一页</button>
+                <button id="diffNextPage" type="button">下一页</button>
+                <input id="diffPageInput" type="number" min="1" step="1" placeholder="跳转页">
+                <button id="diffGoPage" type="button">跳转</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="diff-export-row">
+            <button id="diffExportCSV">导出差异 CSV</button>
+            <button id="diffExportJSON" class="json-btn">导出差异 JSON</button>
+          </div>
+
+          <div class="diff-highlight-row">
+            <span>图表联动:</span>
+            <button id="diffHighlightAdded" class="hl-added" type="button">高亮新增</button>
+            <button id="diffHighlightReleased" class="hl-released" type="button">高亮释放</button>
+            <button id="diffHighlightCommon" class="hl-common" type="button">高亮共同</button>
+            <button id="diffHighlightOff" class="hl-off" type="button">关闭高亮</button>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script>
+    const colors = {
+      real: "#2563eb",
+      theory: "#dc2626",
+      actual: "#d97706",
+      axis: "#374151",
+      grid: "rgba(31, 41, 55, 0.10)",
+      hover: "#111827",
+      select: "rgba(37, 99, 235, 0.12)"
+    };
+
+    const elements = {
+      fileInput: document.getElementById("fileInput"),
+      fileName: document.getElementById("fileName"),
+      showReal: document.getElementById("showReal"),
+      showTheory: document.getElementById("showTheory"),
+      showActual: document.getElementById("showActual"),
+      samplesPerPixel: document.getElementById("samplesPerPixel"),
+      lineColorSelect: document.getElementById("lineColorSelect"),
+      addLineModeButton: document.getElementById("addLineModeButton"),
+      lineList: document.getElementById("lineList"),
+      fitButton: document.getElementById("fitButton"),
+      resetYButton: document.getElementById("resetYButton"),
+      viewportText: document.getElementById("viewportText"),
+      statusText: document.getElementById("statusText"),
+      hoverTooltip: document.getElementById("hoverTooltip"),
+      statRows: document.getElementById("statRows"),
+      statTime: document.getElementById("statTime"),
+      statRealPeak: document.getElementById("statRealPeak"),
+      statTheoryPeak: document.getElementById("statTheoryPeak"),
+      statActualPeak: document.getElementById("statActualPeak"),
+      detailMode: document.getElementById("detailMode"),
+      detailSummary: document.getElementById("detailSummary"),
+      detailCard: document.getElementById("detailCard"),
+      detailTabBar: document.getElementById("detailTabBar"),
+      detailHeadRow: document.getElementById("detailHeadRow"),
+      detailBody: document.getElementById("detailBody"),
+      columnList: document.getElementById("columnList"),
+      exportButton: document.getElementById("exportButton"),
+      pagerInfo: document.getElementById("pagerInfo"),
+      prevPageButton: document.getElementById("prevPageButton"),
+      nextPageButton: document.getElementById("nextPageButton"),
+      pageInput: document.getElementById("pageInput"),
+      goPageButton: document.getElementById("goPageButton"),
+      canvas: document.getElementById("chartCanvas"),
+      diffATime: document.getElementById("diffATime"),
+      diffBTime: document.getElementById("diffBTime"),
+      diffASetClick: document.getElementById("diffASetClick"),
+      diffBSetClick: document.getElementById("diffBSetClick"),
+      diffARefLine: document.getElementById("diffARefLine"),
+      diffBRefLine: document.getElementById("diffBRefLine"),
+      diffRunBtn: document.getElementById("diffRunBtn"),
+      diffCard: document.getElementById("diffCard"),
+      diffSummary: document.getElementById("diffSummary"),
+      diffSummaryGrid: document.getElementById("diffSummaryGrid"),
+      diffContent: document.getElementById("diffContent"),
+      diffAggDimension: document.getElementById("diffAggDimension"),
+      diffTabs: document.getElementById("diffTabs"),
+      diffAggHead: document.getElementById("diffAggHead"),
+      diffAggBody: document.getElementById("diffAggBody"),
+      diffAggNote: document.getElementById("diffAggNote"),
+      diffDetailSummary: document.getElementById("diffDetailSummary"),
+      diffDetailHead: document.getElementById("diffDetailHead"),
+      diffDetailBody: document.getElementById("diffDetailBody"),
+      diffPagerInfo: document.getElementById("diffPagerInfo"),
+      diffPrevPage: document.getElementById("diffPrevPage"),
+      diffNextPage: document.getElementById("diffNextPage"),
+      diffPageInput: document.getElementById("diffPageInput"),
+      diffGoPage: document.getElementById("diffGoPage"),
+      diffExportCSV: document.getElementById("diffExportCSV"),
+      diffExportJSON: document.getElementById("diffExportJSON"),
+      diffHighlightAdded: document.getElementById("diffHighlightAdded"),
+      diffHighlightReleased: document.getElementById("diffHighlightReleased"),
+      diffHighlightCommon: document.getElementById("diffHighlightCommon"),
+      diffHighlightOff: document.getElementById("diffHighlightOff"),
+      lineChartLegend: document.getElementById("lineChartLegend"),
+      linePanel: document.getElementById("linePanel"),
+      peakInterpCard: document.getElementById("peakInterpCard"),
+      peakInterpDesc: document.getElementById("peakInterpDesc"),
+      peakInterpTarget: document.getElementById("peakInterpTarget"),
+      peakInterpRun: document.getElementById("peakInterpRun"),
+      peakInterpContent: document.getElementById("peakInterpContent"),
+      peakInterpOverview: document.getElementById("peakInterpOverview"),
+      peakInterpConclusions: document.getElementById("peakInterpConclusions"),
+      peakInterpConclusionList: document.getElementById("peakInterpConclusionList"),
+      peakInterpDim: document.getElementById("peakInterpDim"),
+      peakInterpAggList: document.getElementById("peakInterpAggList"),
+      peakInterpAggNote: document.getElementById("peakInterpAggNote"),
+      peakInterpExportCSV: document.getElementById("peakInterpExportCSV"),
+      peakInterpExportJSON: document.getElementById("peakInterpExportJSON")
+    };
+
+    const ctx = elements.canvas.getContext("2d");
+
+    const state = {
+      dpr: Math.max(1, window.devicePixelRatio || 1),
+      headers: [],
+      visibleHeaders: [],
+      columnOrder: [],
+      rows: [],
+      detailPageSize: 100,
+      detailCurrentPage: 1,
+      detailRows: [],
+      detailSourceRows: [],
+      detailFilteredRows: [],
+      detailFilters: {},
+      detailSort: { header: null, direction: null },
+      detailToolsOpen: {},
+      detailModeUserLocked: false,
+      clickedPointRows: [],
+      clickedAliveRows: [],
+      selectedRangeRows: [],
+      clickedPointTime: null,
+      selectedPoint: null,
+      selectedRange: null,
+      allRowsFromStart: [],
+      detailModes: { real_peak: [], actual_peak: [], abnormal: [] },
+        referenceLines: [],
+        lineAddMode: false,
+        draggingReferenceLineId: null,
+        hoverReferenceLineId: null,
+        series: {},
+      fullRangeX: [0, 1],
+      fullRangeY: [0, 1],
+      viewX: [0, 1],
+      viewY: [0, 1],
+      dragging: false,
+      selecting: false,
+      dragStart: null,
+      selection: null,
+      hoverPoint: null,
+      draggingColumn: null,
+      statusSummaryText: "选择 CSV 文件后开始分析。",
+      statusHidden: false,
+      statusDrag: null,
+      diffPointA: null,
+      diffPointB: null,
+      diffActiveA: [],
+      diffActiveB: [],
+      diffResults: null,
+      diffCategory: "added",
+      diffAggDimension: "type",
+      diffCurrentPage: 1,
+      diffPageSize: 50,
+      diffHighlight: null,
+      viewMode: "line",
+      memoryVizReady: false,
+      memoryVizBase64: null,
+      memoryVizLoaded: false,
+      peakInterpTarget: "real_peak",
+      peakInterpResults: null,
+      peakInterpDim: "type",
+      peakInterpSelected: null
+    };
+
+    window.state = state;
+
+    const PERSISTENT_END_TIMESTAMP = "9223372036854775807";
+    const END_SENTINEL_THRESHOLD = Number(PERSISTENT_END_TIMESTAMP);
+    const TRACKED_MEMORY_POOLS = new Set([
+      "DefaultEnhancedAscendMemoryPool",
+      "FakeTensorLogicalMemoryPool"
+    ]);
+    const DEFAULT_VISIBLE_HEADERS = [
+      "start_time_stamp",
+      "end_time_stamp",
+      "size",
+      "actual_peak_memory",
+      "type",
+      "producer_task",
+      "task_name",
+      "node_name",
+      "user_tasks",
+      "python_stack"
+    ];
+
+    function setStatus(text) {
+      state.statusSummaryText = text;
+      if (!state.statusHidden) {
+        elements.statusText.textContent = text;
+      }
+    }
+
+    function isTrackedMemoryPool(poolType) {
+      return TRACKED_MEMORY_POOLS.has(poolType);
+    }
+
+    function setStatusHidden(hidden) {
+      state.statusHidden = hidden;
+      elements.statusText.classList.toggle("hidden", hidden);
+      elements.statusText.textContent = hidden ? "显示摘要" : state.statusSummaryText;
+      if (hidden) {
+        elements.statusText.style.bottom = "";
+        const currentLeft = Number.parseFloat(elements.statusText.style.left);
+        const currentTop = Number.parseFloat(elements.statusText.style.top);
+        if (!Number.isFinite(currentLeft) || !Number.isFinite(currentTop)) {
+          requestAnimationFrame(() => {
+            const shell = elements.statusText.parentElement.getBoundingClientRect();
+            const status = elements.statusText.getBoundingClientRect();
+            setStatusPosition(shell.width - status.width - 14, 14);
+          });
+        } else {
+          requestAnimationFrame(() => setStatusPosition(currentLeft, currentTop));
+        }
+      }
+    }
+
+    function setStatusPosition(left, top) {
+      const shell = elements.statusText.parentElement;
+      const shellRect = shell.getBoundingClientRect();
+      const statusRect = elements.statusText.getBoundingClientRect();
+      const maxLeft = Math.max(0, shellRect.width - statusRect.width - 8);
+      const maxTop = Math.max(0, shellRect.height - statusRect.height - 8);
+      const nextLeft = Math.max(8, Math.min(maxLeft, left));
+      const nextTop = Math.max(8, Math.min(maxTop, top));
+      elements.statusText.style.left = `${nextLeft}px`;
+      elements.statusText.style.top = `${nextTop}px`;
+      elements.statusText.style.right = "";
+      elements.statusText.style.bottom = "";
+    }
+
+    function formatNumber(n) {
+      return Number.isFinite(n) ? new Intl.NumberFormat("zh-CN").format(Math.round(n)) : "-";
+    }
+
+    function formatAxisTime(n) {
+      return Number.isFinite(n) ? new Intl.NumberFormat("zh-CN").format(Math.round(n)) : "-";
+    }
+
+    function formatBytes(bytes) {
+      if (!Number.isFinite(bytes)) return "-";
+      const units = ["B", "KB", "MB", "GB", "TB"];
+      let value = Math.abs(bytes);
+      let unit = 0;
+      while (value >= 1024 && unit < units.length - 1) {
+        value /= 1024;
+        unit += 1;
+      }
+      const signed = bytes < 0 ? -value : value;
+      return `${signed.toFixed(unit === 0 ? 0 : 2)} ${units[unit]}`;
+    }
+
+    function formatAxisBytes(bytes) {
+      if (!Number.isFinite(bytes)) return "-";
+      const units = ["B", "KB", "MB", "GB", "TB"];
+      let value = Math.abs(bytes);
+      let unit = 0;
+      while (value >= 1024 && unit < units.length - 1) {
+        value /= 1024;
+        unit += 1;
+      }
+      const signed = bytes < 0 ? -value : value;
+      return `${signed.toFixed(value >= 100 || unit === 0 ? 0 : 1)} ${units[unit]}`;
+    }
+
+    function parseCsvLine(line) {
+      if (!line.includes('"')) {
+        return line.split(",");
+      }
+
+      const fields = [];
+      let current = "";
+      let inQuotes = false;
+      for (let i = 0; i < line.length; i++) {
+        const ch = line[i];
+        if (ch === '"') {
+          if (inQuotes && line[i + 1] === '"') {
+            current += '"';
+            i += 1;
+          } else {
+            inQuotes = !inQuotes;
+          }
+        } else if (ch === "," && !inQuotes) {
+          fields.push(current);
+          current = "";
+        } else {
+          current += ch;
+        }
+      }
+      fields.push(current);
+      return fields;
+    }
+
+    function parseCsv(text) {
+      const lines = text.replace(/^\uFEFF/, "").replace(/\r/g, "").split("\n").filter(Boolean);
+      if (lines.length < 2) {
+        throw new Error("CSV 内容为空或缺少表头");
+      }
+
+      const headers = parseCsvLine(lines[0]);
+      const index = Object.fromEntries(headers.map((name, i) => [name, i]));
+      const required = ["start_time_stamp", "end_time_stamp", "size", "producer_task", "user_tasks", "type"];
+      for (const key of required) {
+        if (!(key in index)) {
+          throw new Error(`CSV 缺少字段: ${key}`);
+        }
+      }
+
+      const rows = [];
+      for (let i = 1; i < lines.length; i++) {
+        const values = parseCsvLine(lines[i]);
+        if (values.length === 1 && values[0] === "") continue;
+        const row = {};
+        for (let j = 0; j < headers.length; j++) {
+          row[headers[j]] = values[j] === undefined ? "" : values[j];
+        }
+        rows.push(row);
+      }
+      return { headers, rows };
+    }
+
+    function detectTextEncoding(bytes) {
+      if (bytes.length >= 2 && bytes[0] === 0xFF && bytes[1] === 0xFE) return "utf-16le";
+      if (bytes.length >= 2 && bytes[0] === 0xFE && bytes[1] === 0xFF) return "utf-16be";
+      if (bytes.length >= 3 && bytes[0] === 0xEF && bytes[1] === 0xBB && bytes[2] === 0xBF) return "utf-8";
+
+      const sampleSize = Math.min(bytes.length, 4096);
+      let evenNulls = 0;
+      let oddNulls = 0;
+      for (let i = 0; i < sampleSize; i++) {
+        if (bytes[i] !== 0) continue;
+        if (i % 2 === 0) {
+          evenNulls += 1;
+        } else {
+          oddNulls += 1;
+        }
+      }
+
+      if (oddNulls > sampleSize / 8 && evenNulls < sampleSize / 32) return "utf-16le";
+      if (evenNulls > sampleSize / 8 && oddNulls < sampleSize / 32) return "utf-16be";
+      return "utf-8";
+    }
+
+    async function parseCsvFile(file, onProgress) {
+      if (!window.TextDecoder) {
+        return parseCsv(await file.text());
+      }
+      if (!file.stream) {
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const text = new TextDecoder(detectTextEncoding(bytes)).decode(bytes);
+        if (onProgress) onProgress(file.size, file.size, 0);
+        return parseCsv(text);
+      }
+
+      const reader = file.stream().getReader();
+      let pending = "";
+      let headers = null;
+      let index = null;
+      let loaded = 0;
+      let lastProgressBytes = 0;
+      let lastProgressTime = 0;
+      const rows = [];
+      const required = ["start_time_stamp", "end_time_stamp", "size", "producer_task", "user_tasks", "type"];
+      let decoder = null;
+
+      const consumeLine = (rawLine) => {
+        const line = (rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine).replace(/^\uFEFF/, "");
+        if (!line) return;
+
+        if (!headers) {
+          headers = parseCsvLine(line);
+          index = Object.fromEntries(headers.map((name, i) => [name, i]));
+          for (const key of required) {
+            if (!(key in index)) {
+              throw new Error(`CSV 缺少字段: ${key}`);
+            }
+          }
+          return;
+        }
+
+        const values = parseCsvLine(line);
+        if (values.length === 1 && values[0] === "") return;
+        const row = {};
+        for (let j = 0; j < headers.length; j++) {
+          row[headers[j]] = values[j] === undefined ? "" : values[j];
+        }
+        rows.push(row);
+      };
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+
+        loaded += value.byteLength;
+        if (!decoder) {
+          decoder = new TextDecoder(detectTextEncoding(value));
+        }
+        pending += decoder.decode(value, { stream: true });
+        const lines = pending.split("\n");
+        pending = lines.pop() ?? "";
+        for (const line of lines) {
+          consumeLine(line);
+        }
+
+        const now = performance.now();
+        if (onProgress && (loaded - lastProgressBytes >= 16 * 1024 * 1024 || now - lastProgressTime > 250)) {
+          onProgress(loaded, file.size, rows.length);
+          lastProgressBytes = loaded;
+          lastProgressTime = now;
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+      }
+
+      if (decoder) pending += decoder.decode();
+      if (pending) consumeLine(pending);
+      if (!headers || rows.length === 0) {
+        throw new Error("CSV 内容为空或缺少表头");
+      }
+      return { headers, rows };
+    }
+
+    function extractUsers(str) {
+      const matches = str.match(/\d+/g);
+      return matches ? matches.map(Number) : [];
+    }
+
+    function arrayMax(values) {
+      let max = -Infinity;
+      for (const value of values) {
+        if (value > max) max = value;
+      }
+      return max;
+    }
+
+    function parsePythonStack(raw) {
+      if (!raw) return [];
+      const STACK_RE = /File:(.+?);Line:(\d+);Function:(.+)/;
+      const frames = [];
+      for (const seg of raw.split("|")) {
+        const s = seg.trim();
+        if (!s) continue;
+        const m = STACK_RE.exec(s);
+        if (m) {
+          frames.push({ name: m[3], filename: m[1], line: parseInt(m[2], 10) });
+        }
+      }
+      frames.reverse();
+      return frames;
+    }
+
+    function buildSnapshot(rows) {
+      let eventCount = 0;
+      const estEvents = rows.length * 3;
+      const events = new Array(estEvents);
+      const stillAlive = [];
+
+      for (const row of rows) {
+        const start = parseInt(row.start_time_stamp, 10);
+        const endStr = row.end_time_stamp;
+        const addr = parseInt((row.device_addr || "0x0").replace(/^0x/i, ""), 16);
+        const size = parseInt(row.size, 10);
+        const streamValue = row.stream_id || row.stream;
+        const stream = streamValue ? parseInt(streamValue, 10) : 0;
+
+        events[eventCount++] = {
+          action: "alloc",
+          addr,
+          size,
+          stream,
+          time_us: start,
+        };
+
+        if (
+          endStr === PERSISTENT_END_TIMESTAMP
+          || !endStr
+          || Number(endStr) >= END_SENTINEL_THRESHOLD
+        ) {
+          const frames = parsePythonStack(row.python_stack || "");
+          stillAlive.push({ addr, size, frames });
+        } else {
+          const endTime = parseInt(endStr, 10);
+          for (const action of ["free_requested", "free_completed"]) {
+            events[eventCount++] = {
+              action,
+              addr,
+              size,
+              stream,
+              time_us: endTime,
+            };
+          }
+        }
+      }
+
+      events.length = eventCount;
+      events.sort((a, b) => {
+        if (a.time_us !== b.time_us) return a.time_us - b.time_us;
+        const aIsFree = a.action !== "alloc";
+        const bIsFree = b.action !== "alloc";
+        return aIsFree === bIsFree ? 0 : aIsFree ? -1 : 1;
+      });
+
+      stillAlive.sort((a, b) => a.addr - b.addr);
+      const blocks = [];
+      let lastAddr = null;
+      const segStart = stillAlive.length > 0 ? stillAlive[0].addr : 0;
+
+      for (const { addr, size, frames } of stillAlive) {
+        if (lastAddr !== null && addr > lastAddr) {
+          blocks.push({
+            address: lastAddr,
+            size: addr - lastAddr,
+            requested_size: addr - lastAddr,
+            state: "inactive",
+            frames: [],
+          });
+        }
+        blocks.push({
+          address: addr,
+          size,
+          requested_size: size,
+          state: "active_allocated",
+          frames,
+        });
+        lastAddr = addr + size;
+      }
+
+      const segTotalSize = lastAddr !== null ? lastAddr - segStart : 0;
+      const segments = [];
+      if (blocks.length > 0) {
+        const activeSize = blocks
+          .filter((b) => b.state === "active_allocated")
+          .reduce((s, b) => s + b.size, 0);
+        segments.push({
+          device: 0,
+          address: segStart,
+          total_size: segTotalSize,
+          allocated_size: activeSize,
+          active_size: activeSize,
+          requested_size: activeSize,
+          stream: 0,
+          segment_type: "large",
+          segment_pool_id: [0, 0],
+          is_expandable: false,
+          frames: [],
+          blocks,
+        });
+      }
+
+      return {
+        device_traces: [events],
+        segments,
+      };
+    }
+
+    function jsonToBase64(obj) {
+      const json = JSON.stringify(obj);
+      let bytes = new TextEncoder().encode(json);
+      const pad = (3 - (bytes.length % 3)) % 3;
+      if (pad > 0) {
+        const padded = new Uint8Array(bytes.length + pad);
+        padded.set(bytes);
+        padded.fill(0x20, bytes.length);
+        bytes = padded;
+      }
+      const CHUNK = 8192;
+      const parts = [];
+      for (let i = 0; i < bytes.length; i += CHUNK) {
+        const chunk = bytes.subarray(i, Math.min(i + CHUNK, bytes.length));
+        parts.push(String.fromCharCode.apply(null, chunk));
+      }
+      return btoa(parts.join(""));
+    }
+
+    function buildSeries(memoryChanges, cumulative) {
+      const times = Array.from(memoryChanges.keys()).sort((a, b) => a - b);
+      const points = [];
+      let current = 0;
+      let peak = null;
+
+      for (const time of times) {
+        const delta = memoryChanges.get(time);
+        const value = cumulative ? (current += delta) : delta;
+        points.push([time, value]);
+        if (!peak || value > peak.value) {
+          peak = { time, value };
+        }
+      }
+
+      return { points, peak };
+    }
+
+    function computeBounds(seriesList) {
+      let minX = Infinity;
+      let maxX = -Infinity;
+      let minY = Infinity;
+      let maxY = -Infinity;
+      let hasPoint = false;
+
+      for (const series of seriesList) {
+        for (const [x, y] of series.points) {
+          hasPoint = true;
+          if (x < minX) minX = x;
+          if (x > maxX) maxX = x;
+          if (y < minY) minY = y;
+          if (y > maxY) maxY = y;
+        }
+      }
+
+      if (!hasPoint) {
+        throw new Error("没有生成任何曲线点，请检查 CSV 内容");
+      }
+
+      return {
+        minX,
+        maxX,
+        minY: Math.min(0, minY),
+        maxY
+      };
+    }
+
+    function computeBoundsFromActive() {
+      const active = getActiveSeries();
+      return active.length ? computeBounds(active) : {
+        minX: state.fullRangeX[0],
+        maxX: state.fullRangeX[1],
+        minY: state.fullRangeY[0],
+        maxY: state.fullRangeY[1]
+      };
+    }
+
+    function analyzeRows(rows) {
+      const realChanges = new Map();
+      const theoryChanges = new Map();
+      const actualMemory = new Map();
+      let maxObservedTime = 0;
+
+      function add(map, key, value) {
+        map.set(key, (map.get(key) || 0) + value);
+      }
+
+      for (const row of rows) {
+        const start = Number(row.start_time_stamp);
+        const end = Number(row.end_time_stamp);
+        if (Number.isFinite(start) && start >= 0) {
+          if (start > maxObservedTime) maxObservedTime = start;
+        }
+        if (Number.isFinite(end) && end >= 0 && end < END_SENTINEL_THRESHOLD) {
+          if (end > maxObservedTime) maxObservedTime = end;
+        }
+      }
+
+      for (const row of rows) {
+        const start = Number(row.start_time_stamp);
+        const end = Number(row.end_time_stamp);
+        const size = Number(row.size);
+        const effectiveEnd = (Number.isFinite(end) && end >= 0 && end < END_SENTINEL_THRESHOLD)
+          ? end
+          : maxObservedTime + 1;
+
+        if (row.actual_peak_memory !== undefined && row.actual_peak_memory !== "") {
+          actualMemory.set(start, Number(row.actual_peak_memory));
+        }
+
+        if (start === -1 || !isTrackedMemoryPool(row.pool_type)) continue;
+
+        add(realChanges, start, size);
+        add(realChanges, effectiveEnd - 1, 0);
+        add(realChanges, effectiveEnd, -size);
+      }
+
+      for (const row of rows) {
+        const producer = row.producer_task;
+        if (!producer) continue;
+
+        const producerId = Number(producer);
+        const type = row.type;
+        const start = Number(row.start_time_stamp);
+        const end = Number(row.end_time_stamp);
+        const userTasks = extractUsers(row.user_tasks || "");
+        if (!userTasks.length) continue;
+        if (type === "SomasOutput" && start === -1) continue;
+
+        const maxUserId = arrayMax(userTasks);
+        const size = Number(row.size);
+        add(theoryChanges, producerId, size);
+        add(theoryChanges, maxUserId, 0);
+        add(theoryChanges, maxUserId + 1, -size);
+      }
+
+      const real = buildSeries(realChanges, true);
+      const theory = buildSeries(theoryChanges, true);
+      const actual = buildSeries(actualMemory, false);
+      const bounds = computeBounds([real, theory, actual]);
+
+      const detailModes = {
+        real_peak: [],
+        actual_peak: [],
+        abnormal: []
+      };
+
+      const realPeakTime = real.peak ? real.peak.time : null;
+      const actualPeakTime = actual.peak ? actual.peak.time : null;
+
+      for (const row of rows) {
+        const start = Number(row.start_time_stamp);
+        const end = Number(row.end_time_stamp);
+        const effectiveEnd = (Number.isFinite(end) && end >= 0 && end < END_SENTINEL_THRESHOLD)
+          ? end
+          : maxObservedTime + 1;
+        if (start === -1) continue;
+
+        if (realPeakTime !== null && start <= realPeakTime && realPeakTime < effectiveEnd) {
+          detailModes.real_peak.push(row);
+
+          const userTasks = extractUsers(row.user_tasks || "");
+          if (userTasks.length) {
+            const maxUserId = arrayMax(userTasks);
+            if (maxUserId < realPeakTime && (row.type || "").startsWith("PyNative")) {
+              detailModes.abnormal.push(row);
+            }
+          }
+        }
+
+        if (actualPeakTime !== null && start <= actualPeakTime && actualPeakTime < effectiveEnd) {
+          detailModes.actual_peak.push(row);
+        }
+      }
+
+      return {
+        real,
+        theory,
+        actual,
+        xRange: [bounds.minX, bounds.maxX],
+        yRange: [bounds.minY, bounds.maxY],
+        detailModes
+      };
+    }
+
+    function rowsForTimePoint(timePoint) {
+      if (!Number.isFinite(timePoint)) return [];
+      const matched = [];
+      for (const row of state.rows) {
+        const start = Number(row.start_time_stamp);
+        if (start !== -1 && Number.isFinite(start) && start >= timePoint) {
+          matched.push(row);
+        }
+      }
+      matched.sort((a, b) => {
+        const aStart = Number(a.start_time_stamp);
+        const bStart = Number(b.start_time_stamp);
+        if (aStart !== bStart) return aStart - bStart;
+        return Number(b.size) - Number(a.size);
+      });
+      return matched;
+    }
+
+    function rowsAliveAtTimePoint(timePoint) {
+      if (!Number.isFinite(timePoint)) return [];
+      const matched = [];
+      const fallbackEnd = Number.isFinite(state.fullRangeX[1]) ? state.fullRangeX[1] + 1 : timePoint + 1;
+      for (const row of state.rows) {
+        const start = Number(row.start_time_stamp);
+        const end = Number(row.end_time_stamp);
+        const effectiveEnd = (Number.isFinite(end) && end >= 0 && end < END_SENTINEL_THRESHOLD)
+          ? end
+          : fallbackEnd;
+        if (start !== -1 && Number.isFinite(start) && start <= timePoint && timePoint < effectiveEnd) {
+          matched.push(row);
+        }
+      }
+      matched.sort((a, b) => {
+        const aSize = Number(a.size || 0);
+        const bSize = Number(b.size || 0);
+        if (aSize !== bSize) return bSize - aSize;
+        return Number(a.start_time_stamp) - Number(b.start_time_stamp);
+      });
+      return matched;
+    }
+
+    function buildRowsFromStart(rows) {
+      const matched = [];
+      for (const row of rows) {
+        const start = Number(row.start_time_stamp);
+        if (start !== -1 && Number.isFinite(start)) {
+          matched.push(row);
+        }
+      }
+      matched.sort((a, b) => {
+        const aStart = Number(a.start_time_stamp);
+        const bStart = Number(b.start_time_stamp);
+        if (aStart !== bStart) return aStart - bStart;
+        return Number(b.size || 0) - Number(a.size || 0);
+      });
+      return matched;
+    }
+
+    function rowsForTimeRange(startTime, endTime) {
+      if (!Number.isFinite(startTime) || !Number.isFinite(endTime)) return [];
+      const rangeStart = Math.min(startTime, endTime);
+      const rangeEnd = Math.max(startTime, endTime);
+      const matched = [];
+      for (const row of state.rows) {
+        const start = Number(row.start_time_stamp);
+        if (start === -1) continue;
+        // For selected ranges, default to allocations that start within the range.
+        if (start >= rangeStart && start <= rangeEnd) {
+          matched.push(row);
+        }
+      }
+      matched.sort((a, b) => {
+        const aStart = Number(a.start_time_stamp);
+        const bStart = Number(b.start_time_stamp);
+        const aDistance = Math.abs(aStart - rangeStart);
+        const bDistance = Math.abs(bStart - rangeStart);
+        if (aDistance !== bDistance) return aDistance - bDistance;
+        if (aStart !== bStart) return aStart - bStart;
+        return Number(b.size || 0) - Number(a.size || 0);
+      });
+      return matched;
+    }
+
+    /* ── Diff Analysis ── */
+
+    function getRowIdentityKey(row) {
+      const addr = (row.device_addr || "").trim();
+      if (addr && addr !== "0x0" && addr !== "0") {
+        return `addr:${addr}`;
+      }
+      const start = row.start_time_stamp || "";
+      const end = row.end_time_stamp || "";
+      const size = row.size || "";
+      const producer = row.producer_task || "";
+      const taskName = row.task_name || "";
+      return `key:${start}|${end}|${size}|${producer}|${taskName}`;
+    }
+
+    function computeActiveSetAt(timePoint) {
+      if (!Number.isFinite(timePoint)) return new Map();
+      const active = new Map();
+      const fallbackEnd = Number.isFinite(state.fullRangeX[1]) ? state.fullRangeX[1] + 1 : timePoint + 1;
+      for (const row of state.rows) {
+        const start = Number(row.start_time_stamp);
+        if (start === -1) continue;
+        if (!Number.isFinite(start)) continue;
+        const end = Number(row.end_time_stamp);
+        const effectiveEnd = (Number.isFinite(end) && end >= 0 && end < END_SENTINEL_THRESHOLD)
+          ? end
+          : fallbackEnd;
+        if (start <= timePoint && timePoint < effectiveEnd) {
+          const key = getRowIdentityKey(row);
+          const existing = active.get(key);
+          if (!existing || Number(row.size || 0) > Number(existing.size || 0)) {
+            active.set(key, row);
+          }
+        }
+      }
+      return active;
+    }
+
+    function computeActiveSetNoFragment(timePoint) {
+      if (!Number.isFinite(timePoint)) return new Map();
+      const active = new Map();
+      const fallbackEnd = Number.isFinite(state.fullRangeX[1]) ? state.fullRangeX[1] + 1 : timePoint + 1;
+      for (const row of state.rows) {
+        const start = Number(row.start_time_stamp);
+        if (start === -1) continue;
+        if (!Number.isFinite(start)) continue;
+        if (!isTrackedMemoryPool(row.pool_type)) continue;
+        const end = Number(row.end_time_stamp);
+        const effectiveEnd = (Number.isFinite(end) && end >= 0 && end < END_SENTINEL_THRESHOLD)
+          ? end
+          : fallbackEnd;
+        if (start <= timePoint && timePoint < effectiveEnd) {
+          const key = getRowIdentityKey(row);
+          const existing = active.get(key);
+          if (!existing || Number(row.size || 0) > Number(existing.size || 0)) {
+            active.set(key, row);
+          }
+        }
+      }
+      return active;
+    }
+
+    function computeDiff(timeA, timeB) {
+      const activeA = computeActiveSetNoFragment(timeA);
+      const activeB = computeActiveSetNoFragment(timeB);
+      const keysA = new Set(activeA.keys());
+      const keysB = new Set(activeB.keys());
+
+      const added = [];
+      const released = [];
+      const common = [];
+
+      for (const key of keysB) {
+        if (!keysA.has(key)) {
+          added.push(activeB.get(key));
+        }
+      }
+      for (const key of keysA) {
+        if (!keysB.has(key)) {
+          released.push(activeA.get(key));
+        }
+      }
+      for (const key of keysA) {
+        if (keysB.has(key)) {
+          common.push(activeA.get(key));
+        }
+      }
+
+      const sumSize = (rows) => rows.reduce((s, r) => s + Number(r.size || 0), 0);
+      const countA = activeA.size;
+      const countB = activeB.size;
+      const totalSizeA = sumSize(Array.from(activeA.values()));
+      const totalSizeB = sumSize(Array.from(activeB.values()));
+      const addedSize = sumSize(added);
+      const releasedSize = sumSize(released);
+      const commonSize = sumSize(common);
+      const netSize = totalSizeB - totalSizeA;
+
+      return {
+        timeA,
+        timeB,
+        activeA,
+        activeB,
+        countA,
+        countB,
+        totalSizeA,
+        totalSizeB,
+        netCount: countB - countA,
+        netSize,
+        added,
+        released,
+        common,
+        addedSize,
+        releasedSize,
+        commonSize,
+        addedCount: added.length,
+        releasedCount: released.length,
+        commonCount: common.length
+      };
+    }
+
+    function aggregateByDimension(rows, dimension) {
+      const buckets = new Map();
+      for (const row of rows) {
+        const raw = row[dimension] == null ? "" : String(row[dimension]);
+        const val = raw.trim() || "(empty)";
+        const entry = buckets.get(val);
+        if (entry) {
+          entry.count += 1;
+          entry.size += Number(row.size || 0);
+        } else {
+          buckets.set(val, { value: val, count: 1, size: Number(row.size || 0) });
+        }
+      }
+      const results = Array.from(buckets.values());
+      results.sort((a, b) => b.size - a.size);
+      return results;
+    }
+
+    function getDiffDetailRows() {
+      if (!state.diffResults) return [];
+      const category = state.diffCategory;
+      if (category === "added") return state.diffResults.added;
+      if (category === "released") return state.diffResults.released;
+      if (category === "common") return state.diffResults.common;
+      return [];
+    }
+
+    function updateDiffUI() {
+      const results = state.diffResults;
+      if (!results) return;
+      switchDetailTab("diff");
+
+      elements.diffSummary.textContent =
+        `A 点（${formatNumber(results.timeA)}）：${formatNumber(results.countA)} blocks, ${formatBytes(results.totalSizeA)} → B 点（${formatNumber(results.timeB)}）：${formatNumber(results.countB)} blocks, ${formatBytes(results.totalSizeB)}`;
+
+      elements.diffSummaryGrid.style.display = "";
+      elements.diffSummaryGrid.innerHTML = `
+        <div class="diff-summary-item">
+          <div class="diff-summary-label">A 总 size</div>
+          <div class="diff-summary-value">${formatBytes(results.totalSizeA)} (${formatNumber(results.countA)} blocks)</div>
+        </div>
+        <div class="diff-summary-item">
+          <div class="diff-summary-label">B 总 size</div>
+          <div class="diff-summary-value">${formatBytes(results.totalSizeB)} (${formatNumber(results.countB)} blocks)</div>
+        </div>
+        <div class="diff-summary-item">
+          <div class="diff-summary-label">净增</div>
+          <div class="diff-summary-value" style="color:${results.netSize >= 0 ? '#dc2626' : '#0f766e'}">${results.netSize >= 0 ? '+' : ''}${formatBytes(results.netSize)}</div>
+        </div>
+        <div class="diff-summary-item">
+          <div class="diff-summary-label">新增 (B有A无)</div>
+          <div class="diff-summary-value added">+${formatBytes(results.addedSize)} (${formatNumber(results.addedCount)} blocks)</div>
+        </div>
+        <div class="diff-summary-item">
+          <div class="diff-summary-label">释放 (A有B无)</div>
+          <div class="diff-summary-value released">-${formatBytes(results.releasedSize)} (${formatNumber(results.releasedCount)} blocks)</div>
+        </div>
+        <div class="diff-summary-item">
+          <div class="diff-summary-label">共同存活</div>
+          <div class="diff-summary-value common">${formatBytes(results.commonSize)} (${formatNumber(results.commonCount)} blocks)</div>
+        </div>
+      `;
+
+      elements.diffContent.style.display = "";
+
+      updateDiffTabs();
+      updateDiffAggTable();
+      updateDiffDetailTable();
+    }
+
+    function updateDiffTabs() {
+      const tabs = elements.diffTabs.querySelectorAll(".diff-tab");
+      tabs.forEach((tab) => {
+        tab.classList.remove("active-add", "active-release", "active-common");
+        const cat = tab.dataset.category;
+
+        const activeClass = state.diffCategory === cat
+          ? (cat === "added" ? "active-add" : cat === "released" ? "active-release" : "active-common")
+          : "";
+        if (activeClass) tab.classList.add(activeClass);
+
+        const countKey = cat === "added" ? "addedCount" : cat === "released" ? "releasedCount" : "commonCount";
+        const sizeKey = cat === "added" ? "addedSize" : cat === "released" ? "releasedSize" : "commonSize";
+        const result = state.diffResults;
+        const catLabel = cat === "added" ? "新增" : cat === "released" ? "释放" : "共同存活";
+        tab.textContent = `${catLabel} (${formatNumber(result ? result[countKey] : 0)})`;
+      });
+    }
+
+    function updateDiffAggTable() {
+      if (!state.diffResults) return;
+      const rows = getDiffDetailRows();
+      const dimension = elements.diffAggDimension.value;
+      const agg = aggregateByDimension(rows, dimension);
+
+      elements.diffAggHead.innerHTML = "";
+      elements.diffAggBody.innerHTML = "";
+
+      const headers = [dimension, "count", "total_size"];
+      const tr = document.createElement("tr");
+      for (const h of headers) {
+        const th = document.createElement("th");
+        th.textContent = h;
+        tr.appendChild(th);
+      }
+      elements.diffAggHead.appendChild(tr);
+
+      if (!agg.length) {
+        const emptyTr = document.createElement("tr");
+        const emptyTd = document.createElement("td");
+        emptyTd.colSpan = 3;
+        emptyTd.className = "muted";
+        emptyTd.textContent = "无数据";
+        emptyTr.appendChild(emptyTd);
+        elements.diffAggBody.appendChild(emptyTr);
+        return;
+      }
+
+      const topN = Math.min(agg.length, 30);
+      let shownCount = 0;
+      let shownSize = 0;
+      for (let i = 0; i < topN; i++) {
+        const item = agg[i];
+        shownCount += item.count;
+        shownSize += item.size;
+        const rowTr = document.createElement("tr");
+        const tdDim = document.createElement("td");
+        tdDim.textContent = item.value;
+        const tdCount = document.createElement("td");
+        tdCount.textContent = formatNumber(item.count);
+        const tdSize = document.createElement("td");
+        tdSize.textContent = formatBytes(item.size);
+        rowTr.appendChild(tdDim);
+        rowTr.appendChild(tdCount);
+        rowTr.appendChild(tdSize);
+        elements.diffAggBody.appendChild(rowTr);
+      }
+
+      const totalCount = rows.length;
+      const totalSize = rows.reduce((s, r) => s + Number(r.size || 0), 0);
+      if (topN < agg.length) {
+        elements.diffAggNote.textContent =
+          `显示 top ${topN}/${agg.length} 聚合项（覆盖 ${formatNumber(shownCount)}/${formatNumber(totalCount)} blocks, ${formatBytes(shownSize)}/${formatBytes(totalSize)}）。`;
+      } else {
+        elements.diffAggNote.textContent =
+          `${agg.length} 个聚合项，共 ${formatNumber(totalCount)} blocks, ${formatBytes(totalSize)}。`;
+      }
+    }
+
+    function updateDiffDetailTable() {
+      if (!state.diffResults) return;
+      const rows = getDiffDetailRows();
+      const totalPages = Math.max(1, Math.ceil(rows.length / state.diffPageSize));
+      state.diffCurrentPage = Math.min(Math.max(1, state.diffCurrentPage), totalPages);
+      const pageStart = (state.diffCurrentPage - 1) * state.diffPageSize;
+      const pageEnd = Math.min(rows.length, pageStart + state.diffPageSize);
+      const renderRows = rows.slice(pageStart, pageEnd);
+
+      elements.diffDetailSummary.textContent =
+        `明细列表：共 ${formatNumber(rows.length)} 行，显示第 ${formatNumber(pageStart + 1)} - ${formatNumber(pageEnd)} 行`;
+      elements.diffPagerInfo.textContent =
+        `第 ${formatNumber(state.diffCurrentPage)} / ${formatNumber(totalPages)} 页`;
+      elements.diffPrevPage.disabled = state.diffCurrentPage <= 1;
+      elements.diffNextPage.disabled = state.diffCurrentPage >= totalPages;
+      elements.diffPageInput.disabled = rows.length === 0;
+      elements.diffGoPage.disabled = rows.length === 0;
+      elements.diffPageInput.max = String(totalPages);
+
+      const activeHeaders = getActiveHeaders();
+      elements.diffDetailHead.innerHTML = "";
+      elements.diffDetailBody.innerHTML = "";
+
+      const headTr = document.createElement("tr");
+      for (const header of activeHeaders) {
+        const th = document.createElement("th");
+        th.textContent = header;
+        headTr.appendChild(th);
+      }
+      elements.diffDetailHead.appendChild(headTr);
+
+      if (!renderRows.length) {
+        const emptyTr = document.createElement("tr");
+        const td = document.createElement("td");
+        td.colSpan = Math.max(1, activeHeaders.length);
+        td.className = "muted";
+        td.textContent = "无数据";
+        emptyTr.appendChild(td);
+        elements.diffDetailBody.appendChild(emptyTr);
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+      for (const row of renderRows) {
+        const tr = document.createElement("tr");
+        for (const header of activeHeaders) {
+          const td = document.createElement("td");
+          renderTableCell(td, row[header] ?? "", header);
+          tr.appendChild(td);
+        }
+        fragment.appendChild(tr);
+      }
+      elements.diffDetailBody.appendChild(fragment);
+    }
+
+    function runDiffAnalysis() {
+      const timeA = Number(elements.diffATime.value);
+      const timeB = Number(elements.diffBTime.value);
+      if (!Number.isFinite(timeA) || !Number.isFinite(timeB)) {
+        setStatus("请为 A、B 两点设置有效的时间戳。");
+        return;
+      }
+
+      state.diffPointA = { time: timeA, label: `A: ${formatNumber(timeA)}` };
+      state.diffPointB = { time: timeB, label: `B: ${formatNumber(timeB)}` };
+
+      setStatus(`正在计算 ${formatNumber(timeA)} vs ${formatNumber(timeB)} 的差异...`);
+      setTimeout(() => {
+        try {
+          state.diffResults = computeDiff(timeA, timeB);
+          state.diffCurrentPage = 1;
+          state.diffCategory = "added";
+          updateDiffUI();
+          draw();
+          setStatus(
+            `差异分析完成\n` +
+            `A: ${formatBytes(state.diffResults.totalSizeA)} (${formatNumber(state.diffResults.countA)} blocks)\n` +
+            `B: ${formatBytes(state.diffResults.totalSizeB)} (${formatNumber(state.diffResults.countB)} blocks)\n` +
+            `新增: +${formatBytes(state.diffResults.addedSize)} | 释放: -${formatBytes(state.diffResults.releasedSize)} | 共同: ${formatBytes(state.diffResults.commonSize)}`
+          );
+        } catch (err) {
+          console.error(err);
+          setStatus(`差异分析失败: ${err.message}`);
+        }
+      }, 0);
+    }
+
+    function updateDiffRefLineSelects() {
+      [elements.diffARefLine, elements.diffBRefLine].forEach((select) => {
+        const currentValue = select.value;
+        select.innerHTML = '<option value="">-- 参考线 --</option>';
+        for (const line of state.referenceLines) {
+          const option = document.createElement("option");
+          option.value = String(line.value);
+          option.textContent = `${formatBytes(line.value)} (${formatNumber(line.value)})`;
+          select.appendChild(option);
+        }
+        if (Array.from(select.options).some((o) => o.value === currentValue)) {
+          select.value = currentValue;
+        }
+      });
+    }
+
+    function setDiffPointFromClick(target) {
+      const element = target === "A" ? elements.diffATime : elements.diffBTime;
+      const currentTime = state.clickedPointTime;
+      if (currentTime !== null && Number.isFinite(currentTime)) {
+        element.value = String(Math.round(currentTime));
+        updateDiffRunButton();
+      } else {
+        setStatus("请先在曲线上点击一个时间点。");
+      }
+    }
+
+    function updateDiffRunButton() {
+      const a = Number(elements.diffATime.value);
+      const b = Number(elements.diffBTime.value);
+      const hasData = state.rows && state.rows.length > 0;
+      elements.diffRunBtn.disabled = !Number.isFinite(a) || !Number.isFinite(b) || !hasData;
+    }
+
+    function exportDiffCSV() {
+      if (!state.diffResults) return;
+      const rows = getDiffDetailRows();
+      if (!rows.length) return;
+      const activeHeaders = getActiveHeaders();
+      const lines = [activeHeaders.map(escapeCsv).join(",")];
+      for (const row of rows) {
+        const values = [];
+        for (const header of activeHeaders) {
+          values.push(escapeCsv(row[header] ?? ""));
+        }
+        lines.push(values.join(","));
+      }
+      const category = state.diffCategory;
+      const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `diff_${category}_A${Math.round(state.diffResults.timeA)}_B${Math.round(state.diffResults.timeB)}.csv`;
+      link.click();
+      URL.revokeObjectURL(url);
+    }
+
+    function exportDiffJSON() {
+      if (!state.diffResults) return;
+      const rows = getDiffDetailRows();
+      const exportData = {
+        pointA: state.diffResults.timeA,
+        pointB: state.diffResults.timeB,
+        summary: {
+          aTotalSize: state.diffResults.totalSizeA,
+          aBlockCount: state.diffResults.countA,
+          bTotalSize: state.diffResults.totalSizeB,
+          bBlockCount: state.diffResults.countB,
+          netSize: state.diffResults.netSize,
+          addedSize: state.diffResults.addedSize,
+          addedCount: state.diffResults.addedCount,
+          releasedSize: state.diffResults.releasedSize,
+          releasedCount: state.diffResults.releasedCount,
+          commonSize: state.diffResults.commonSize,
+          commonCount: state.diffResults.commonCount
+        },
+        category: state.diffCategory,
+        aggregationDimension: elements.diffAggDimension.value,
+        aggregation: aggregateByDimension(rows, elements.diffAggDimension.value),
+        rows: rows
+      };
+      const json = JSON.stringify(exportData, null, 2);
+      const blob = new Blob([json], { type: "application/json;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `diff_${state.diffCategory}_A${Math.round(state.diffResults.timeA)}_B${Math.round(state.diffResults.timeB)}.json`;
+      link.click();
+      URL.revokeObjectURL(url);
+    }
+
+    /* ── Peak Interpreter ── */
+
+    function getTopPythonFrame(stack) {
+      if (!stack) return "(empty)";
+      const parts = stack.split("|");
+      for (let i = parts.length - 1; i >= 0; i--) {
+        const frame = parts[i].trim();
+        if (!frame) continue;
+        if (frame.includes("/mindspore/") || frame.includes("/site-packages/mindspore/")) continue;
+        return frame;
+      }
+      return parts[parts.length - 1].trim() || "(empty)";
+    }
+
+    function getPeakTimeAndRows(target) {
+      let peakTime = null;
+      if (target === "real_peak" && state.series.real && state.series.real.peak) {
+        peakTime = state.series.real.peak.time;
+      } else if (target === "theory_peak" && state.series.theory && state.series.theory.peak) {
+        peakTime = state.series.theory.peak.time;
+      } else if (target === "actual_peak" && state.series.actual && state.series.actual.peak) {
+        peakTime = state.series.actual.peak.time;
+      } else if (target === "clicked_time" && state.clickedPointTime !== null) {
+        peakTime = state.clickedPointTime;
+      }
+      if (peakTime === null) return { peakTime: null, rows: [] };
+
+      const rows = rowsAliveAtTimePoint(peakTime);
+      return { peakTime, rows };
+    }
+
+    function isPyNativeAbnormalAt(row, peakTime) {
+      const userTasks = extractUsers(row.user_tasks || "");
+      if (!userTasks.length) return false;
+      const maxUserId = arrayMax(userTasks);
+      return maxUserId < peakTime && (row.type || "").startsWith("PyNative");
+    }
+
+    function computePeakBreakdown(target) {
+      const { peakTime, rows } = getPeakTimeAndRows(target);
+      if (peakTime === null) return null;
+      if (!rows.length) return { peakTime, rows: [], totalSize: 0, blockCount: 0, breakdowns: {}, conclusions: [] };
+
+      const totalSize = rows.reduce((s, r) => s + Number(r.size || 0), 0);
+      const blockCount = rows.length;
+
+      const dimensions = ["type", "task_name", "node_name", "graph_name", "producer_task", "pool_type"];
+
+      const breakdowns = {};
+      for (const dim of dimensions) {
+        const buckets = new Map();
+        for (const row of rows) {
+          const raw = row[dim] == null ? "" : String(row[dim]);
+          const val = raw.trim() || "(empty)";
+          const entry = buckets.get(val);
+          if (entry) {
+            entry.count += 1;
+            entry.size += Number(row.size || 0);
+            if (Number(row.size || 0) > entry.maxBlockSize) {
+              entry.maxBlockSize = Number(row.size || 0);
+              entry.repRow = row;
+            }
+            const lifetime = (Number.isFinite(Number(row.end_time_stamp)) && Number(row.end_time_stamp) < END_SENTINEL_THRESHOLD)
+              ? Number(row.end_time_stamp) - Number(row.start_time_stamp)
+              : (state.fullRangeX[1] + 1 - Number(row.start_time_stamp));
+            if (lifetime > entry.maxLifetime) entry.maxLifetime = lifetime;
+          } else {
+            const lifetime = (Number.isFinite(Number(row.end_time_stamp)) && Number(row.end_time_stamp) < END_SENTINEL_THRESHOLD)
+              ? Number(row.end_time_stamp) - Number(row.start_time_stamp)
+              : (state.fullRangeX[1] + 1 - Number(row.start_time_stamp));
+            buckets.set(val, {
+              value: val,
+              count: 1,
+              size: Number(row.size || 0),
+              maxBlockSize: Number(row.size || 0),
+              maxLifetime: lifetime,
+              repRow: row
+            });
+          }
+        }
+        const arr = Array.from(buckets.values());
+        arr.sort((a, b) => b.size - a.size);
+        for (const item of arr) {
+          item.pct = totalSize > 0 ? (item.size / totalSize * 100) : 0;
+        }
+        breakdowns[dim] = arr;
+      }
+
+      // python_stack top frame
+      const frameBuckets = new Map();
+      for (const row of rows) {
+        const frame = getTopPythonFrame(row.python_stack || "");
+        const entry = frameBuckets.get(frame);
+        if (entry) {
+          entry.count += 1;
+          entry.size += Number(row.size || 0);
+        } else {
+          frameBuckets.set(frame, { value: frame, count: 1, size: Number(row.size || 0), maxBlockSize: Number(row.size || 0), maxLifetime: 0, repRow: row });
+        }
+        if (Number(row.size || 0) > frameBuckets.get(frame).maxBlockSize) {
+          frameBuckets.get(frame).maxBlockSize = Number(row.size || 0);
+          frameBuckets.get(frame).repRow = row;
+        }
+      }
+      const frameArr = Array.from(frameBuckets.values());
+      frameArr.sort((a, b) => b.size - a.size);
+      for (const item of frameArr) {
+        item.pct = totalSize > 0 ? (item.size / totalSize * 100) : 0;
+      }
+      breakdowns["python_stack_frame"] = frameArr;
+
+      // is_persistent
+      const persistentBuckets = new Map();
+      persistentBuckets.set("persistent", { value: "persistent", count: 0, size: 0, maxBlockSize: 0, maxLifetime: 0, repRow: null });
+      persistentBuckets.set("non_persistent", { value: "non_persistent", count: 0, size: 0, maxBlockSize: 0, maxLifetime: 0, repRow: null });
+      for (const row of rows) {
+        const isPersistent = (row.is_persistent === "1" || row.is_persistent === "true" || row.is_persistent === "True");
+        const key = isPersistent ? "persistent" : "non_persistent";
+        const entry = persistentBuckets.get(key);
+        entry.count += 1;
+        entry.size += Number(row.size || 0);
+        if (Number(row.size || 0) > entry.maxBlockSize) {
+          entry.maxBlockSize = Number(row.size || 0);
+          entry.repRow = row;
+        }
+      }
+      for (const item of persistentBuckets.values()) {
+        item.pct = totalSize > 0 ? (item.size / totalSize * 100) : 0;
+      }
+      breakdowns["is_persistent"] = Array.from(persistentBuckets.values()).filter((x) => x.count > 0).sort((a, b) => b.size - a.size);
+
+      // is_small
+      const smallBuckets = new Map();
+      smallBuckets.set("small", { value: "small (<1MB)", count: 0, size: 0, maxBlockSize: 0, maxLifetime: 0, repRow: null });
+      smallBuckets.set("medium", { value: "medium (1-10MB)", count: 0, size: 0, maxBlockSize: 0, maxLifetime: 0, repRow: null });
+      smallBuckets.set("large", { value: "large (>10MB)", count: 0, size: 0, maxBlockSize: 0, maxLifetime: 0, repRow: null });
+      for (const row of rows) {
+        const sz = Number(row.size || 0);
+        let key = "large";
+        if (sz < 1048576) key = "small";
+        else if (sz <= 10485760) key = "medium";
+        const entry = smallBuckets.get(key);
+        entry.count += 1;
+        entry.size += sz;
+        if (sz > entry.maxBlockSize) { entry.maxBlockSize = sz; entry.repRow = row; }
+      }
+      for (const item of smallBuckets.values()) {
+        item.pct = totalSize > 0 ? (item.size / totalSize * 100) : 0;
+      }
+      breakdowns["is_small"] = Array.from(smallBuckets.values()).filter((x) => x.count > 0).sort((a, b) => b.size - a.size);
+
+      // Conclusions
+      const conclusions = [];
+      const topItem = breakdowns["type"][0];
+      if (topItem) {
+        conclusions.push({ text: `最大 type 贡献: "${escapeHtml(topItem.value)}" 占 ${topItem.pct.toFixed(1)}%（${formatBytes(topItem.size)}），共 ${formatNumber(topItem.count)} 个 block。`, cls: "info" });
+      }
+
+      const topFrame = breakdowns["python_stack_frame"][0];
+      if (topFrame && topFrame.pct > 20) {
+        conclusions.push({ text: `主要调用来源: ${escapeHtml(topFrame.value).slice(0, 80)} 贡献 ${topFrame.pct.toFixed(1)}%。`, cls: "info" });
+      }
+
+      const persistentItem = breakdowns["is_persistent"].find((x) => x.value === "persistent");
+      const persistentPct = persistentItem ? persistentItem.pct : 0;
+      if (persistentPct > 10) {
+        conclusions.push({ text: `持久内存占比 ${persistentPct.toFixed(1)}%（${formatBytes(persistentItem.size)}），可能为静态权重或常驻 buffer。`, cls: persistentPct > 30 ? "risk" : "warn" });
+      } else {
+        conclusions.push({ text: `持久内存占比 ${persistentPct.toFixed(1)}%，大部分峰值内存可在计算结束后释放。`, cls: "info" });
+      }
+
+      const smallItem = breakdowns["is_small"].find((x) => x.value === "small (<1MB)");
+      const smallPct = smallItem ? smallItem.pct : 0;
+      const smallCount = smallItem ? smallItem.count : 0;
+      if (smallPct > 20 && smallCount > 100) {
+        conclusions.push({ text: `小块碎片风险: <1MB 的 block 占 ${smallPct.toFixed(1)}%（${formatNumber(smallCount)} 个），可能因大量小块导致显存碎片。`, cls: smallPct > 40 ? "risk" : "warn" });
+      }
+
+      const largeItem = breakdowns["is_small"].find((x) => x.value === "large (>10MB)");
+      if (largeItem && largeItem.count > 0) {
+        conclusions.push({ text: `大块内存: >10MB 的 block 共 ${formatNumber(largeItem.count)} 个，总 ${formatBytes(largeItem.size)}，占峰值 ${largeItem.pct.toFixed(1)}%。`, cls: largeItem.pct > 50 ? "warn" : "info" });
+      }
+
+      const abnormalCount = rows.filter((r) => isPyNativeAbnormalAt(r, peakTime)).length;
+      if (abnormalCount > 0) {
+        conclusions.push({ text: `异常 PyNative: ${formatNumber(abnormalCount)} 个 PyNative 相关 block 在 user_task 结束后仍存活，疑似未及时释放。`, cls: abnormalCount > 10 ? "risk" : "warn" });
+      }
+
+      // Check for blocks that live far beyond peak
+      const longAfterPeak = rows.filter((r) => {
+        const end = Number(r.end_time_stamp);
+        return Number.isFinite(end) && end < END_SENTINEL_THRESHOLD && end > peakTime + 1e8;
+      });
+      if (longAfterPeak.length > 0) {
+        conclusions.push({ text: `峰值后长留对象: ${formatNumber(longAfterPeak.length)} 个 block 的 end_time 超出峰值 >1e8，可能在后续阶段仍占用显存。`, cls: "warn" });
+      }
+
+      return { peakTime, rows, totalSize, blockCount, breakdowns, conclusions };
+    }
+
+    function renderPeakInterpreter() {
+      const results = state.peakInterpResults;
+      if (!results) {
+        elements.peakInterpCard.style.display = "none";
+        return;
+      }
+      switchDetailTab("interp");
+      elements.peakInterpCard.style.display = "";
+      elements.peakInterpContent.style.display = "";
+      elements.peakInterpDesc.textContent =
+        `峰值时间: ${formatNumber(results.peakTime)} — 解释维度: ${state.peakInterpDim}`;
+
+      // Overview
+      elements.peakInterpOverview.innerHTML = `
+        <div class="peak-interp-stat">
+          <div class="label">峰值时间</div>
+          <div class="value">${formatNumber(results.peakTime)}</div>
+        </div>
+        <div class="peak-interp-stat">
+          <div class="label">峰值总 size</div>
+          <div class="value">${formatBytes(results.totalSize)}</div>
+        </div>
+        <div class="peak-interp-stat">
+          <div class="label">活跃 block 数</div>
+          <div class="value">${formatNumber(results.blockCount)}</div>
+        </div>
+      `;
+
+      // Conclusions
+      elements.peakInterpConclusionList.innerHTML = results.conclusions.map((c) =>
+        `<div class="peak-interp-conclusion-item ${c.cls}">• ${c.text}</div>`
+      ).join("");
+
+      // Aggregation list
+      const dim = state.peakInterpDim;
+      const agg = results.breakdowns[dim] || [];
+      const topN = Math.min(agg.length, 40);
+      let html = "";
+      for (let i = 0; i < topN; i++) {
+        const item = agg[i];
+        const selected = state.peakInterpSelected && state.peakInterpSelected.dim === dim && state.peakInterpSelected.value === item.value;
+        html += `<div class="peak-agg-row${selected ? " selected" : ""}" data-dim="${escapeHtml(dim)}" data-value="${escapeHtml(item.value)}">
+          <span style="min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:0 1 220px;" title="${escapeHtml(item.value)}">${escapeHtml(item.value)}</span>
+          <span style="width:70px;text-align:right;flex-shrink:0;">${formatBytes(item.size)}</span>
+          <span style="width:48px;text-align:right;flex-shrink:0;color:var(--muted);">${item.pct.toFixed(1)}%</span>
+          <div class="peak-agg-bar-wrap"><div class="peak-agg-bar-fill" style="width:${Math.min(100, item.pct)}%;"></div></div>
+          <span style="width:48px;text-align:right;flex-shrink:0;color:var(--muted);">${formatNumber(item.count)}</span>
+        </div>`;
+      }
+      elements.peakInterpAggList.innerHTML = html || '<div class="small" style="padding:12px;">无聚合数据</div>';
+      if (topN < agg.length) {
+        elements.peakInterpAggNote.textContent = `显示 top ${topN}/${agg.length} 项。`;
+      } else {
+        elements.peakInterpAggNote.textContent = `${agg.length} 项，共 ${formatBytes(results.totalSize)}。`;
+      }
+
+      // Click handlers on agg rows
+      elements.peakInterpAggList.querySelectorAll(".peak-agg-row").forEach((el) => {
+        el.addEventListener("click", () => {
+          const dim = el.dataset.dim;
+          const value = el.dataset.value;
+          onPeakInterpItemClick(dim, value);
+        });
+      });
+    }
+
+    function escapeHtml(str) {
+      return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+    }
+
+    function onPeakInterpItemClick(dim, value) {
+      if (state.peakInterpSelected && state.peakInterpSelected.dim === dim && state.peakInterpSelected.value === value) {
+        state.peakInterpSelected = null;
+        // Reset detail filter for this dimension
+        delete state.detailFilters[dim];
+        updateDetailTable();
+      } else {
+        state.peakInterpSelected = { dim, value };
+        // Apply filter to detail table
+        const header = mapPeakDimToHeader(dim);
+        if (header) {
+          commitDetailFilter(header, { text: value, min: "", max: "" });
+        }
+        // Also filter other dimensions
+        if (dim === "is_persistent") {
+          const isPersistent = value === "persistent";
+          const filterVal = isPersistent ? "1" : "";
+          if (isPersistent) {
+            commitDetailFilter("is_persistent", { text: "1", min: "", max: "" });
+          } else {
+            delete state.detailFilters["is_persistent"];
+          }
+        } else if (dim === "is_small") {
+          delete state.detailFilters["size"];
+          if (value.includes("<1MB")) {
+            commitDetailFilter("size", { text: "", min: "0", max: "1048575" });
+          } else if (value.includes("1-10MB")) {
+            commitDetailFilter("size", { text: "", min: "1048576", max: "10485760" });
+          } else {
+            commitDetailFilter("size", { text: "", min: "10485761", max: "" });
+          }
+        } else {
+          commitDetailFilter(header, { text: value, min: "", max: "" });
+        }
+      }
+      renderPeakInterpreter();
+    }
+
+    function mapPeakDimToHeader(dim) {
+      if (dim === "python_stack_frame") return "python_stack";
+      if (dim === "is_persistent") return "is_persistent";
+      if (dim === "is_small") return "size";
+      return dim;
+    }
+
+    function runPeakInterpreter() {
+      const target = elements.peakInterpTarget.value;
+      state.peakInterpTarget = target;
+      state.peakInterpSelected = null;
+
+      setStatus("正在分析峰值...");
+      setTimeout(() => {
+        try {
+          state.peakInterpResults = computePeakBreakdown(target);
+          if (!state.peakInterpResults) {
+            setStatus("无法获取峰值时间。请确认 CSV 已加载且峰值数据可用。");
+            return;
+          }
+          state.detailFilters = {};
+          state.detailCurrentPage = 1;
+          renderPeakInterpreter();
+          elements.detailMode.value = "clicked_alive";
+          state.clickedAliveRows = state.peakInterpResults.rows;
+          state.clickedPointTime = state.peakInterpResults.peakTime;
+          updateDetailTable();
+          setStatus(
+            `峰值解释完成\n` +
+            `峰值时间: ${formatNumber(state.peakInterpResults.peakTime)}\n` +
+            `总 size: ${formatBytes(state.peakInterpResults.totalSize)}\n` +
+            `活跃 block: ${formatNumber(state.peakInterpResults.blockCount)}`
+          );
+        } catch (err) {
+          console.error(err);
+          setStatus(`峰值解释失败: ${err.message}`);
+        }
+      }, 0);
+    }
+
+    function exportPeakInterpCSV() {
+      if (!state.peakInterpResults) return;
+      const dim = state.peakInterpDim;
+      const agg = state.peakInterpResults.breakdowns[dim] || [];
+      const lines = ["dimension,value,count,size,pct"];
+      for (const item of agg) {
+        lines.push(`${escapeCsv(dim)},${escapeCsv(item.value)},${item.count},${item.size},${item.pct.toFixed(2)}`);
+      }
+      const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `peak_interp_${state.peakInterpTarget}_${dim}.csv`;
+      link.click();
+      URL.revokeObjectURL(url);
+    }
+
+    function exportPeakInterpJSON() {
+      if (!state.peakInterpResults) return;
+      const exportData = {
+        target: state.peakInterpTarget,
+        peakTime: state.peakInterpResults.peakTime,
+        totalSize: state.peakInterpResults.totalSize,
+        blockCount: state.peakInterpResults.blockCount,
+        conclusions: state.peakInterpResults.conclusions.map((c) => c.text),
+        breakdowns: state.peakInterpResults.breakdowns
+      };
+      const json = JSON.stringify(exportData, null, 2);
+      const blob = new Blob([json], { type: "application/json;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `peak_interp_${state.peakInterpTarget}.json`;
+      link.click();
+      URL.revokeObjectURL(url);
+    }
+
+    function getActiveSeries() {
+      const active = [];
+      if (elements.showReal.checked && state.series.real) {
+        active.push({
+          key: "real",
+          points: state.series.real.points,
+          peak: state.series.real.peak,
+          color: colors.real,
+          label: "无碎片显存"
+        });
+      }
+      if (elements.showTheory.checked && state.series.theory) {
+        active.push({
+          key: "theory",
+          points: state.series.theory.points,
+          peak: state.series.theory.peak,
+          color: colors.theory,
+          label: "理论显存"
+        });
+      }
+      if (elements.showActual.checked && state.series.actual) {
+        active.push({
+          key: "actual",
+          points: state.series.actual.points,
+          peak: state.series.actual.peak,
+          color: colors.actual,
+          label: "含碎片显存"
+        });
+      }
+      return active;
+    }
+
+    function resizeCanvas() {
+      const rect = elements.canvas.getBoundingClientRect();
+      state.dpr = Math.max(1, window.devicePixelRatio || 1);
+      elements.canvas.width = Math.max(1, Math.floor(rect.width * state.dpr));
+      elements.canvas.height = Math.max(1, Math.floor(rect.height * state.dpr));
+      draw();
+    }
+
+    function getPlotRect() {
+      const width = elements.canvas.width;
+      const height = elements.canvas.height;
+      return {
+        left: 96 * state.dpr,
+        top: 24 * state.dpr,
+        right: width - 28 * state.dpr,
+        bottom: height - 62 * state.dpr,
+        width: width - 124 * state.dpr,
+        height: height - 86 * state.dpr
+      };
+    }
+
+    function clampView() {
+      const [fullMinX, fullMaxX] = state.fullRangeX;
+      const [fullMinY, fullMaxY] = state.fullRangeY;
+      let [minX, maxX] = state.viewX;
+      let [minY, maxY] = state.viewY;
+      const minWidth = Math.max(10, (fullMaxX - fullMinX) / 1e6);
+      const minHeight = Math.max(1, (fullMaxY - fullMinY) / 1e6);
+
+      if (maxX - minX < minWidth) {
+        const mid = (minX + maxX) / 2;
+        minX = mid - minWidth / 2;
+        maxX = mid + minWidth / 2;
+      }
+      if (maxY - minY < minHeight) {
+        const mid = (minY + maxY) / 2;
+        minY = mid - minHeight / 2;
+        maxY = mid + minHeight / 2;
+      }
+
+      if (minX < fullMinX) {
+        maxX += fullMinX - minX;
+        minX = fullMinX;
+      }
+      if (maxX > fullMaxX) {
+        minX -= maxX - fullMaxX;
+        maxX = fullMaxX;
+      }
+      if (minY < fullMinY) {
+        maxY += fullMinY - minY;
+        minY = fullMinY;
+      }
+      if (maxY > fullMaxY) {
+        minY -= maxY - fullMaxY;
+        maxY = fullMaxY;
+      }
+
+      state.viewX = [Math.max(fullMinX, minX), Math.min(fullMaxX, maxX)];
+      state.viewY = [Math.max(fullMinY, minY), Math.min(fullMaxY, maxY)];
+    }
+
+    function visiblePoints(points) {
+      const minX = state.viewX[0];
+      const maxX = state.viewX[1];
+      let start = 0;
+      let end = points.length - 1;
+
+      while (start < points.length && points[start][0] < minX) start++;
+      while (end >= 0 && points[end][0] > maxX) end--;
+      start = Math.max(0, start - 1);
+      end = Math.min(points.length - 1, end + 1);
+      return points.slice(start, end + 1);
+    }
+
+    function downsample(points, pixelWidth, samplesPerPixel) {
+      if (points.length <= pixelWidth * samplesPerPixel) {
+        return points;
+      }
+
+      const bucketCount = Math.max(1, Math.floor(pixelWidth * samplesPerPixel));
+      const bucketWidth = (state.viewX[1] - state.viewX[0]) / bucketCount;
+      const out = [];
+      let pointIndex = 0;
+
+      for (let bucket = 0; bucket < bucketCount; bucket++) {
+        const startX = state.viewX[0] + bucket * bucketWidth;
+        const endX = startX + bucketWidth;
+        let firstPoint = null;
+        let minPoint = null;
+        let maxPoint = null;
+        let lastPoint = null;
+
+        while (pointIndex < points.length && points[pointIndex][0] < endX) {
+          const point = points[pointIndex];
+          if (point[0] >= startX) {
+            if (!firstPoint) firstPoint = point;
+            lastPoint = point;
+            if (!minPoint || point[1] < minPoint[1]) minPoint = point;
+            if (!maxPoint || point[1] > maxPoint[1]) maxPoint = point;
+          }
+          pointIndex += 1;
+        }
+
+        if (firstPoint) out.push(firstPoint);
+        if (minPoint && minPoint !== firstPoint && minPoint !== lastPoint) out.push(minPoint);
+        if (maxPoint && maxPoint !== firstPoint && maxPoint !== lastPoint && maxPoint !== minPoint) out.push(maxPoint);
+        if (lastPoint && lastPoint !== firstPoint) out.push(lastPoint);
+      }
+
+      out.sort((a, b) => a[0] - b[0]);
+      return out.length ? out : points;
+    }
+
+    function dataToScreen(x, y, plot) {
+      return {
+        px: plot.left + ((x - state.viewX[0]) / (state.viewX[1] - state.viewX[0])) * plot.width,
+        py: plot.bottom - ((y - state.viewY[0]) / (state.viewY[1] - state.viewY[0])) * plot.height
+      };
+    }
+
+    function screenToData(clientX, clientY) {
+      const rect = elements.canvas.getBoundingClientRect();
+      const px = (clientX - rect.left) * state.dpr;
+      const py = (clientY - rect.top) * state.dpr;
+      const plot = getPlotRect();
+      const dataX = state.viewX[0] + ((px - plot.left) / plot.width) * (state.viewX[1] - state.viewX[0]);
+      const dataY = state.viewY[1] - ((py - plot.top) / plot.height) * (state.viewY[1] - state.viewY[0]);
+      return { px, py, dataX, dataY, rect, plot };
+    }
+
+    function drawAxes(plot) {
+      ctx.save();
+      ctx.strokeStyle = colors.grid;
+      ctx.fillStyle = colors.axis;
+      ctx.lineWidth = 1;
+      ctx.font = `${12 * state.dpr}px Segoe UI`;
+
+      const tickCountX = Math.max(4, Math.min(7, Math.floor(plot.width / (160 * state.dpr))));
+      const tickCountY = Math.max(4, Math.min(6, Math.floor(plot.height / (110 * state.dpr))));
+
+      for (let i = 0; i <= tickCountX; i++) {
+        const x = plot.left + (plot.width * i) / tickCountX;
+        ctx.beginPath();
+        ctx.moveTo(x, plot.top);
+        ctx.lineTo(x, plot.bottom);
+        ctx.stroke();
+
+        const value = state.viewX[0] + ((state.viewX[1] - state.viewX[0]) * i) / tickCountX;
+        const label = formatAxisTime(value);
+        const width = ctx.measureText(label).width;
+        ctx.fillText(label, x - width / 2, plot.bottom + 24 * state.dpr);
+      }
+
+      for (let i = 0; i <= tickCountY; i++) {
+        const y = plot.top + (plot.height * i) / tickCountY;
+        ctx.beginPath();
+        ctx.moveTo(plot.left, y);
+        ctx.lineTo(plot.right, y);
+        ctx.stroke();
+
+        const value = state.viewY[1] - ((state.viewY[1] - state.viewY[0]) * i) / tickCountY;
+        ctx.fillText(formatAxisBytes(value), 10 * state.dpr, y + 4 * state.dpr);
+      }
+
+      ctx.strokeStyle = colors.axis;
+      ctx.lineWidth = 1.5 * state.dpr;
+      ctx.beginPath();
+      ctx.moveTo(plot.left, plot.top);
+      ctx.lineTo(plot.left, plot.bottom);
+      ctx.lineTo(plot.right, plot.bottom);
+      ctx.stroke();
+
+      ctx.font = `${13 * state.dpr}px Segoe UI`;
+      ctx.fillText("Time", plot.right - 20 * state.dpr, plot.bottom + 46 * state.dpr);
+      ctx.save();
+      ctx.translate(18 * state.dpr, plot.top + plot.height / 2);
+      ctx.rotate(-Math.PI / 2);
+      ctx.fillText("Memory", 0, 0);
+      ctx.restore();
+      ctx.restore();
+    }
+
+    function drawSeries(plot, item) {
+      const rawPoints = visiblePoints(item.points);
+      if (rawPoints.length < 2) return;
+
+      const samplesPerPixel = Math.max(1, Number(elements.samplesPerPixel.value) || 2);
+      const points = downsample(rawPoints, plot.width / state.dpr, samplesPerPixel);
+      if (points.length < 2) return;
+
+      ctx.save();
+      ctx.strokeStyle = item.color;
+      ctx.lineWidth = 2 * state.dpr;
+      ctx.lineJoin = "round";
+      ctx.lineCap = "round";
+      ctx.beginPath();
+
+      let started = false;
+      for (const [x, y] of points) {
+        const { px, py } = dataToScreen(x, y, plot);
+        if (!started) {
+          ctx.moveTo(px, py);
+          started = true;
+        } else {
+          ctx.lineTo(px, py);
+        }
+      }
+      ctx.stroke();
+
+      if (item.peak && item.peak.time >= state.viewX[0] && item.peak.time <= state.viewX[1]) {
+        const { px, py } = dataToScreen(item.peak.time, item.peak.value, plot);
+        ctx.fillStyle = item.color;
+        ctx.beginPath();
+        ctx.arc(px, py, 4 * state.dpr, 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      ctx.restore();
+    }
+
+    function drawSelection() {
+      if (!state.selection) return;
+      ctx.save();
+      ctx.fillStyle = colors.select;
+      ctx.strokeStyle = colors.real;
+      ctx.lineWidth = 1.2 * state.dpr;
+      ctx.fillRect(state.selection.x, state.selection.y, state.selection.w, state.selection.h);
+      ctx.strokeRect(state.selection.x, state.selection.y, state.selection.w, state.selection.h);
+      ctx.restore();
+    }
+
+    function drawHoverMarker(plot) {
+      if (!state.hoverPoint) return;
+      ctx.save();
+      ctx.strokeStyle = state.hoverPoint.color;
+      ctx.fillStyle = "#ffffff";
+      ctx.lineWidth = 1.6 * state.dpr;
+      ctx.beginPath();
+      ctx.arc(state.hoverPoint.px, state.hoverPoint.py, 4.4 * state.dpr, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+
+      ctx.strokeStyle = "rgba(17, 24, 39, 0.18)";
+      ctx.setLineDash([4 * state.dpr, 4 * state.dpr]);
+      ctx.beginPath();
+      ctx.moveTo(state.hoverPoint.px, plot.top);
+      ctx.lineTo(state.hoverPoint.px, plot.bottom);
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    function drawSelectedPointMarker(plot) {
+      if (!state.selectedPoint || !Number.isFinite(state.selectedPoint.x)) return;
+      if (state.selectedPoint.x < state.viewX[0] || state.selectedPoint.x > state.viewX[1]) return;
+
+      const y = Number.isFinite(state.selectedPoint.y)
+        ? Math.max(state.viewY[0], Math.min(state.viewY[1], state.selectedPoint.y))
+        : state.viewY[0];
+      const { px, py } = dataToScreen(state.selectedPoint.x, y, plot);
+      const color = state.selectedPoint.color || colors.hover;
+
+      ctx.save();
+      ctx.strokeStyle = "rgba(17, 24, 39, 0.32)";
+      ctx.lineWidth = 1.2 * state.dpr;
+      ctx.setLineDash([5 * state.dpr, 5 * state.dpr]);
+      ctx.beginPath();
+      ctx.moveTo(px, plot.top);
+      ctx.lineTo(px, plot.bottom);
+      ctx.stroke();
+
+      if (Number.isFinite(state.selectedPoint.y) && state.selectedPoint.y >= state.viewY[0] && state.selectedPoint.y <= state.viewY[1]) {
+        ctx.setLineDash([]);
+        ctx.fillStyle = "#ffffff";
+        ctx.strokeStyle = color;
+        ctx.lineWidth = 2.4 * state.dpr;
+        ctx.beginPath();
+        ctx.arc(px, py, 6.5 * state.dpr, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+
+        ctx.fillStyle = color;
+        ctx.beginPath();
+        ctx.arc(px, py, 2.6 * state.dpr, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.restore();
+    }
+
+    function drawReferenceLines(plot) {
+      for (const line of state.referenceLines) {
+        if (!Number.isFinite(line.value)) continue;
+        if (line.value < state.viewY[0] || line.value > state.viewY[1]) continue;
+
+        const { py } = dataToScreen(state.viewX[0], line.value, plot);
+        ctx.save();
+        ctx.strokeStyle = line.color;
+        ctx.lineWidth = 1.5 * state.dpr;
+        ctx.setLineDash([8 * state.dpr, 6 * state.dpr]);
+        ctx.beginPath();
+        ctx.moveTo(plot.left, py);
+        ctx.lineTo(plot.right, py);
+        ctx.stroke();
+
+        const label = `${formatBytes(line.value)} (${formatNumber(line.value)})`;
+        ctx.setLineDash([]);
+        ctx.font = `${12 * state.dpr}px Segoe UI`;
+        const paddingX = 8 * state.dpr;
+        const textWidth = ctx.measureText(label).width;
+        const boxWidth = textWidth + paddingX * 2;
+        const boxHeight = 20 * state.dpr;
+        const boxX = Math.min(plot.right - boxWidth, plot.left + 8 * state.dpr);
+        const boxY = Math.max(plot.top + 4 * state.dpr, py - boxHeight - 4 * state.dpr);
+
+        ctx.fillStyle = "rgba(255, 251, 245, 0.95)";
+        ctx.strokeStyle = line.color;
+        ctx.lineWidth = 1 * state.dpr;
+        ctx.beginPath();
+        ctx.roundRect(boxX, boxY, boxWidth, boxHeight, 8 * state.dpr);
+        ctx.fill();
+        ctx.stroke();
+
+        ctx.fillStyle = line.color;
+        ctx.fillText(label, boxX + paddingX, boxY + 14 * state.dpr);
+        ctx.restore();
+      }
+    }
+
+    function drawDiffMarkers(plot) {
+      function drawTimeMarker(time, color, label) {
+        if (!Number.isFinite(time)) return;
+        if (time < state.viewX[0] || time > state.viewX[1]) return;
+        const { px } = dataToScreen(time, state.viewY[0], plot);
+
+        ctx.save();
+        ctx.strokeStyle = color;
+        ctx.lineWidth = 2 * state.dpr;
+        ctx.setLineDash([6 * state.dpr, 4 * state.dpr]);
+        ctx.beginPath();
+        ctx.moveTo(px, plot.top);
+        ctx.lineTo(px, plot.bottom);
+        ctx.stroke();
+
+        ctx.setLineDash([]);
+        ctx.font = `bold ${13 * state.dpr}px Segoe UI`;
+        const textWidth = ctx.measureText(label).width;
+        const boxPad = 6 * state.dpr;
+        const boxWidth = textWidth + boxPad * 2;
+        const boxHeight = 22 * state.dpr;
+        const boxX = Math.min(plot.right - boxWidth, Math.max(plot.left, px - boxWidth / 2));
+        const boxY = plot.top + 4 * state.dpr;
+
+        ctx.fillStyle = "rgba(255, 251, 245, 0.95)";
+        ctx.strokeStyle = color;
+        ctx.lineWidth = 1.2 * state.dpr;
+        ctx.beginPath();
+        ctx.roundRect(boxX, boxY, boxWidth, boxHeight, 6 * state.dpr);
+        ctx.fill();
+        ctx.stroke();
+
+        ctx.fillStyle = color;
+        ctx.fillText(label, boxX + boxPad, boxY + 16 * state.dpr);
+
+        ctx.restore();
+      }
+
+      if (state.diffPointA) {
+        drawTimeMarker(state.diffPointA.time, "#2563eb", state.diffPointA.label);
+      }
+      if (state.diffPointB) {
+        drawTimeMarker(state.diffPointB.time, "#dc2626", state.diffPointB.label);
+      }
+
+      if (state.diffHighlight && state.diffResults) {
+        let highlightRows = [];
+        if (state.diffHighlight === "added") highlightRows = state.diffResults.added;
+        else if (state.diffHighlight === "released") highlightRows = state.diffResults.released;
+        else if (state.diffHighlight === "common") highlightRows = state.diffResults.common;
+
+        if (highlightRows.length) {
+          ctx.save();
+          const hlColor = state.diffHighlight === "added" ? "rgba(220,38,38,0.14)"
+            : state.diffHighlight === "released" ? "rgba(15,118,110,0.14)"
+            : "rgba(37,99,235,0.12)";
+          ctx.fillStyle = hlColor;
+
+          const MAX_HL_ROWS = 1000;
+          const rows = highlightRows.length > MAX_HL_ROWS
+            ? highlightRows.slice(0, MAX_HL_ROWS)
+            : highlightRows;
+
+          for (const row of rows) {
+            const start = Number(row.start_time_stamp);
+            const end = Number(row.end_time_stamp);
+            if (!Number.isFinite(start)) continue;
+            const effectiveEnd = (Number.isFinite(end) && end >= 0 && end < END_SENTINEL_THRESHOLD)
+              ? end
+              : state.fullRangeX[1] + 1;
+            if (effectiveEnd < state.viewX[0] || start > state.viewX[1]) continue;
+            const x1 = Math.max(plot.left + ((start - state.viewX[0]) / (state.viewX[1] - state.viewX[0])) * plot.width, plot.left);
+            const x2 = Math.min(plot.left + ((effectiveEnd - state.viewX[0]) / (state.viewX[1] - state.viewX[0])) * plot.width, plot.right);
+            if (x2 - x1 < 0.5) continue;
+            ctx.fillRect(x1, plot.top, x2 - x1, plot.height);
+          }
+          ctx.restore();
+        }
+      }
+    }
+
+
+    function findReferenceLineAt(clientX, clientY) {
+      if (!state.referenceLines.length) return null;
+      const current = screenToData(clientX, clientY);
+      const threshold = 8 * state.dpr;
+
+      let best = null;
+      for (const line of state.referenceLines) {
+        if (!Number.isFinite(line.value)) continue;
+        if (line.value < state.viewY[0] || line.value > state.viewY[1]) continue;
+        const screen = dataToScreen(state.viewX[0], line.value, current.plot);
+        const dist = Math.abs(screen.py - current.py);
+        if (dist <= threshold && (!best || dist < best.dist)) {
+          best = { id: line.id, dist };
+        }
+      }
+      return best ? best.id : null;
+    }
+
+    function updateCanvasCursor() {
+      elements.canvas.classList.toggle(
+        "line-adding",
+        state.lineAddMode && !state.dragging && !state.selecting && !state.draggingReferenceLineId
+      );
+      elements.canvas.classList.toggle("line-hover", !!state.hoverReferenceLineId || !!state.draggingReferenceLineId);
+    }
+
+    function draw() {
+      const width = elements.canvas.width;
+      const height = elements.canvas.height;
+      ctx.clearRect(0, 0, width, height);
+
+      if (!state.series.real && !state.series.theory && !state.series.actual) {
+        ctx.save();
+        ctx.fillStyle = colors.axis;
+        ctx.font = `${18 * state.dpr}px Segoe UI`;
+        ctx.fillText("请先选择一个 CSV 文件", 36 * state.dpr, 80 * state.dpr);
+        ctx.restore();
+        return;
+      }
+
+      clampView();
+      const plot = getPlotRect();
+
+      drawAxes(plot);
+
+      const active = getActiveSeries();
+      for (const item of active) {
+        drawSeries(plot, item);
+      }
+
+      drawReferenceLines(plot);
+      drawSelection();
+      drawSelectedPointMarker(plot);
+      drawHoverMarker(plot);
+      drawDiffMarkers(plot);
+
+      elements.viewportText.textContent =
+        `时间: ${formatNumber(state.viewX[0])} - ${formatNumber(state.viewX[1])} | 显存: ${formatBytes(state.viewY[0])} - ${formatBytes(state.viewY[1])}`;
+    }
+
+    function fitView() {
+      const bounds = computeBoundsFromActive();
+      state.viewX = [bounds.minX, bounds.maxX];
+      state.viewY = [bounds.minY, bounds.maxY === bounds.minY ? bounds.minY + 1 : bounds.maxY];
+      draw();
+    }
+
+    function resetY() {
+      const bounds = computeBoundsFromActive();
+      state.viewY = [bounds.minY, bounds.maxY === bounds.minY ? bounds.minY + 1 : bounds.maxY];
+      draw();
+    }
+
+    function getActiveHeaders() {
+      const ordered = state.columnOrder.length ? state.columnOrder : state.headers;
+      if (!state.visibleHeaders.length) return ordered;
+      return ordered.filter((header) => state.visibleHeaders.includes(header));
+    }
+
+    function isNumericHeader(header, rows) {
+      let checked = 0;
+      let numeric = 0;
+      for (const row of rows) {
+        const value = row[header];
+        if (value === undefined || value === "") continue;
+        checked++;
+        if (Number.isFinite(Number(value))) numeric++;
+        if (checked >= 80) break;
+      }
+      return checked > 0 && numeric / checked >= 0.9;
+    }
+
+    function getDetailSourceRows() {
+      const mode = elements.detailMode.value;
+      if (mode === "all_allocations") return state.allRowsFromStart;
+      if (mode === "clicked_alive") return state.clickedAliveRows;
+      if (mode === "clicked_point") return state.clickedPointRows;
+      if (mode === "selected_range") return state.selectedRangeRows;
+      return state.detailModes[mode] || [];
+    }
+
+    function normalizeFilter(filter) {
+      return filter || { text: "", min: "", max: "" };
+    }
+
+    function applyDetailFilters(rows) {
+      const filters = Object.entries(state.detailFilters).filter(([, filter]) => {
+        const current = normalizeFilter(filter);
+        return current.text || current.min !== "" || current.max !== "";
+      });
+      if (!filters.length) return rows.slice();
+
+      return rows.filter((row) => {
+        for (const [header, filter] of filters) {
+          const current = normalizeFilter(filter);
+          const raw = row[header] == null ? "" : String(row[header]);
+          if (current.text && !raw.toLowerCase().includes(current.text.toLowerCase())) {
+            return false;
+          }
+          if (current.min !== "" || current.max !== "") {
+            const value = Number(raw);
+            if (!Number.isFinite(value)) return false;
+            const min = current.min === "" ? -Infinity : Number(current.min);
+            const max = current.max === "" ? Infinity : Number(current.max);
+            if (Number.isFinite(min) && value < min) return false;
+            if (Number.isFinite(max) && value > max) return false;
+          }
+        }
+        return true;
+      });
+    }
+
+    function compareDetailRows(a, b, header) {
+      const av = a[header] == null ? "" : String(a[header]);
+      const bv = b[header] == null ? "" : String(b[header]);
+      const an = Number(av);
+      const bn = Number(bv);
+      if (Number.isFinite(an) && Number.isFinite(bn)) {
+        return an - bn;
+      }
+      return av.localeCompare(bv, "zh-CN", { numeric: true });
+    }
+
+    function applyDetailSort(rows) {
+      if (!state.detailSort.header || !state.detailSort.direction) return rows;
+      const direction = state.detailSort.direction === "desc" ? -1 : 1;
+      return rows.slice().sort((a, b) => compareDetailRows(a, b, state.detailSort.header) * direction);
+    }
+
+    function getTransformedDetailRows(rows) {
+      return applyDetailSort(applyDetailFilters(rows));
+    }
+
+    function commitDetailFilter(header, patch) {
+      const next = { ...normalizeFilter(state.detailFilters[header]), ...patch };
+      if (!next.text && next.min === "" && next.max === "") {
+        delete state.detailFilters[header];
+      } else {
+        state.detailFilters[header] = next;
+      }
+      state.detailCurrentPage = 1;
+      updateDetailTable();
+    }
+
+    function toggleDetailSort(header) {
+      if (state.detailSort.header !== header) {
+        state.detailSort = { header, direction: "asc" };
+      } else if (state.detailSort.direction === "asc") {
+        state.detailSort = { header, direction: "desc" };
+      } else {
+        state.detailSort = { header: null, direction: null };
+      }
+      state.detailCurrentPage = 1;
+      updateDetailTable();
+    }
+
+    function setDetailSort(header, direction) {
+      state.detailSort = direction ? { header, direction } : { header: null, direction: null };
+      state.detailCurrentPage = 1;
+      updateDetailTable();
+    }
+
+    function hasActiveColumnTool(header) {
+      const filter = normalizeFilter(state.detailFilters[header]);
+      return Boolean(filter.text || filter.min !== "" || filter.max !== "" || state.detailSort.header === header);
+    }
+
+    function toggleDetailTools(header) {
+      state.detailToolsOpen[header] = !state.detailToolsOpen[header];
+      updateDetailTable();
+    }
+
+    function clearDetailColumnTools(header) {
+      delete state.detailFilters[header];
+      if (state.detailSort.header === header) {
+        state.detailSort = { header: null, direction: null };
+      }
+      state.detailCurrentPage = 1;
+      updateDetailTable();
+    }
+
+    function applyZoom(factor, centerX, centerY, zoomX, zoomY) {
+      if (zoomX) {
+        const [minX, maxX] = state.viewX;
+        const ratio = (centerX - minX) / Math.max(1, maxX - minX);
+        const newSpan = (maxX - minX) * factor;
+        state.viewX = [centerX - newSpan * ratio, centerX + newSpan * (1 - ratio)];
+      }
+      if (zoomY) {
+        const [minY, maxY] = state.viewY;
+        const ratio = (centerY - minY) / Math.max(1, maxY - minY);
+        const newSpan = (maxY - minY) * factor;
+        state.viewY = [centerY - newSpan * ratio, centerY + newSpan * (1 - ratio)];
+      }
+      draw();
+    }
+
+    function updateDetailTable() {
+      const mode = elements.detailMode.value;
+      state.detailSourceRows = getDetailSourceRows();
+      state.detailFilteredRows = getTransformedDetailRows(state.detailSourceRows);
+      state.detailRows = state.detailFilteredRows;
+      elements.exportButton.disabled = state.detailRows.length === 0;
+
+      const labelMap = {
+        all_allocations: "从头开始",
+        real_peak: "无碎片峰值时刻存活",
+        actual_peak: "含碎片峰值时刻存活",
+        abnormal: "异常 PyNative",
+        clicked_alive: "点击时刻存活",
+        clicked_point: "点击后续申请",
+        selected_range: "框选时间范围"
+      };
+
+      const sourceRows = state.detailSourceRows.length;
+      const totalRows = state.detailRows.length;
+      const totalPages = Math.max(1, Math.ceil(totalRows / state.detailPageSize));
+      state.detailCurrentPage = Math.min(Math.max(1, state.detailCurrentPage), totalPages);
+      const pageStart = (state.detailCurrentPage - 1) * state.detailPageSize;
+      const pageEnd = Math.min(totalRows, pageStart + state.detailPageSize);
+      const renderRows = state.detailRows.slice(pageStart, pageEnd);
+      const filteredText = sourceRows !== totalRows ? `，筛选后 ${formatNumber(totalRows)} / ${formatNumber(sourceRows)} 行` : "";
+      const suffix = totalRows > 0 ? `${filteredText}，当前显示第 ${formatNumber(pageStart + 1)} - ${formatNumber(pageEnd)} 行` : filteredText;
+      let prefix = `${labelMap[mode]}：${formatNumber(sourceRows)} 行`;
+      if ((mode === "clicked_point" || mode === "clicked_alive") && state.clickedPointTime !== null) {
+        prefix = `${labelMap[mode]}（start_time_stamp >= ${formatNumber(state.clickedPointTime)}）：${formatNumber(sourceRows)} 行`;
+      }
+      if (mode === "clicked_alive" && state.clickedPointTime !== null) {
+        prefix = `${labelMap[mode]}（${formatNumber(state.clickedPointTime)} 时刻仍存活）：${formatNumber(sourceRows)} 行`;
+      }
+      if (mode === "selected_range" && state.selectedRange) {
+        prefix = `${labelMap[mode]}（${formatNumber(state.selectedRange[0])} - ${formatNumber(state.selectedRange[1])}）：${formatNumber(sourceRows)} 行`;
+      }
+      elements.detailSummary.textContent = `${prefix}${suffix}`;
+      elements.pagerInfo.textContent = `第 ${formatNumber(state.detailCurrentPage)} / ${formatNumber(totalPages)} 页，共 ${formatNumber(totalRows)} 行`;
+      elements.prevPageButton.disabled = totalRows === 0 || state.detailCurrentPage <= 1;
+      elements.nextPageButton.disabled = totalRows === 0 || state.detailCurrentPage >= totalPages;
+      elements.pageInput.disabled = totalRows === 0;
+      elements.goPageButton.disabled = totalRows === 0;
+      elements.pageInput.max = String(totalPages);
+
+      elements.detailHeadRow.innerHTML = "";
+      elements.detailBody.innerHTML = "";
+
+      const activeHeaders = getActiveHeaders();
+
+      if (state.headers.length) {
+        for (const header of activeHeaders) {
+          elements.detailHeadRow.appendChild(renderHeaderCell(header, state.detailSourceRows));
+        }
+      }
+
+      if (!state.headers.length || !state.detailRows.length) {
+        const th = document.createElement("th");
+        th.textContent = "暂无数据";
+        if (!state.headers.length) elements.detailHeadRow.appendChild(th);
+
+        const tr = document.createElement("tr");
+        const td = document.createElement("td");
+        td.colSpan = Math.max(1, activeHeaders.length);
+        td.className = "muted";
+        td.textContent = state.detailSourceRows.length ? "当前筛选条件下没有匹配行。" : "载入 CSV 后，这里会显示与峰值相关的原始行。";
+        tr.appendChild(td);
+        elements.detailBody.appendChild(tr);
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+      for (const row of renderRows) {
+        const tr = document.createElement("tr");
+        for (const header of activeHeaders) {
+          const td = document.createElement("td");
+          renderTableCell(td, row[header] ?? "", header);
+          tr.appendChild(td);
+        }
+        fragment.appendChild(tr);
+      }
+      elements.detailBody.appendChild(fragment);
+    }
+
+    function renderHeaderCell(header, sourceRows) {
+      const th = document.createElement("th");
+      const wrapper = document.createElement("div");
+      wrapper.className = "th-content";
+      const filter = normalizeFilter(state.detailFilters[header]);
+      const isOpen = Boolean(state.detailToolsOpen[header]);
+      const isNumeric = isNumericHeader(header, sourceRows);
+
+      const top = document.createElement("div");
+      top.className = "th-top";
+
+      const title = document.createElement("span");
+      title.textContent = header;
+
+      const toolButton = document.createElement("button");
+      toolButton.type = "button";
+      toolButton.className = "header-tool-button";
+      toolButton.classList.toggle("active", isOpen || hasActiveColumnTool(header));
+      toolButton.title = "筛选和排序";
+      toolButton.setAttribute("aria-label", `${header} 筛选和排序`);
+      toolButton.addEventListener("click", () => toggleDetailTools(header));
+
+      top.appendChild(title);
+      top.appendChild(toolButton);
+      wrapper.appendChild(top);
+
+      if (!isOpen) {
+        th.appendChild(wrapper);
+        return th;
+      }
+
+      const panel = document.createElement("div");
+      panel.className = "filter-panel";
+
+      const sortRow = document.createElement("div");
+      sortRow.className = "filter-sort-row";
+      const ascButton = document.createElement("button");
+      ascButton.type = "button";
+      ascButton.className = "sort-button";
+      ascButton.classList.toggle("active", state.detailSort.header === header && state.detailSort.direction === "asc");
+      ascButton.title = "升序";
+      ascButton.textContent = "↑";
+      ascButton.addEventListener("click", () => setDetailSort(header, "asc"));
+
+      const descButton = document.createElement("button");
+      descButton.type = "button";
+      descButton.className = "sort-button";
+      descButton.classList.toggle("active", state.detailSort.header === header && state.detailSort.direction === "desc");
+      descButton.title = "降序";
+      descButton.textContent = "↓";
+      descButton.addEventListener("click", () => setDetailSort(header, "desc"));
+
+      const clearButton = document.createElement("button");
+      clearButton.type = "button";
+      clearButton.className = "clear-filter-button";
+      clearButton.title = "清除本列筛选和排序";
+      clearButton.textContent = "×";
+      clearButton.addEventListener("click", () => clearDetailColumnTools(header));
+
+      sortRow.appendChild(ascButton);
+      sortRow.appendChild(descButton);
+      sortRow.appendChild(clearButton);
+      panel.appendChild(sortRow);
+
+      if (isNumeric) {
+        const range = document.createElement("div");
+        range.className = "filter-range";
+
+        const minInput = document.createElement("input");
+        minInput.type = "number";
+        minInput.placeholder = "最小";
+        minInput.value = filter.min;
+
+        const maxInput = document.createElement("input");
+        maxInput.type = "number";
+        maxInput.placeholder = "最大";
+        maxInput.value = filter.max;
+
+        const commitRange = () => {
+          commitDetailFilter(header, { min: minInput.value.trim(), max: maxInput.value.trim(), text: "" });
+        };
+        minInput.addEventListener("change", commitRange);
+        maxInput.addEventListener("change", commitRange);
+        minInput.addEventListener("keydown", (event) => {
+          if (event.key === "Enter") commitRange();
+        });
+        maxInput.addEventListener("keydown", (event) => {
+          if (event.key === "Enter") commitRange();
+        });
+
+        range.appendChild(minInput);
+        range.appendChild(maxInput);
+        panel.appendChild(range);
+      } else {
+        const input = document.createElement("input");
+        input.type = "search";
+        input.className = "filter-input";
+        input.placeholder = "包含文本";
+        input.value = filter.text;
+        const commitText = () => {
+          commitDetailFilter(header, { text: input.value.trim(), min: "", max: "" });
+        };
+        input.addEventListener("change", commitText);
+        input.addEventListener("keydown", (event) => {
+          if (event.key === "Enter") commitText();
+        });
+        panel.appendChild(input);
+      }
+
+      wrapper.appendChild(panel);
+      th.appendChild(wrapper);
+      return th;
+    }
+
+    function renderTableCell(td, value, header) {
+      const text = value == null ? "" : String(value);
+      const shouldCollapse = text.length > 80 || header === "python_stack" || header === "user_tasks";
+      const shortText = formatCellDisplayText(text, header, false);
+      const fullText = formatCellDisplayText(text, header, true);
+
+      if (!shouldCollapse) {
+        td.textContent = shortText;
+        return;
+      }
+
+      const wrapper = document.createElement("div");
+      wrapper.className = "cell-wrap";
+      const short = document.createElement("span");
+      short.className = "cell-short";
+      short.textContent = shortText;
+
+      const full = document.createElement("span");
+      full.className = "cell-full";
+      full.textContent = fullText;
+
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "cell-toggle";
+      button.textContent = "展开";
+      button.addEventListener("mousedown", (event) => {
+        event.preventDefault();
+      });
+      button.addEventListener("click", () => {
+        const expanded = wrapper.classList.toggle("cell-expanded");
+        button.textContent = expanded ? "收起" : "展开";
+      });
+
+      wrapper.appendChild(short);
+      wrapper.appendChild(full);
+      wrapper.appendChild(button);
+      td.appendChild(wrapper);
+    }
+
+    function formatCellDisplayText(text, header, expanded) {
+      if (header === "python_stack") {
+        return expanded ? text.replace(/\|/g, "\n") : text.replace(/\|/g, " | ");
+      }
+      return text;
+    }
+
+    function clearColumnDropHints() {
+      elements.columnList.querySelectorAll(".drop-before, .drop-after").forEach((item) => {
+        item.classList.remove("drop-before", "drop-after");
+      });
+    }
+
+    function moveColumn(sourceHeader, targetHeader, insertAfter) {
+      if (!sourceHeader || !targetHeader || sourceHeader === targetHeader) return;
+      const nextOrder = state.columnOrder.filter((header) => header !== sourceHeader);
+      const targetIndex = nextOrder.indexOf(targetHeader);
+      if (targetIndex === -1) return;
+      nextOrder.splice(targetIndex + (insertAfter ? 1 : 0), 0, sourceHeader);
+      state.columnOrder = nextOrder;
+      renderColumnSelector();
+      updateDetailTable();
+    }
+
+    function renderColumnSelector() {
+      elements.columnList.innerHTML = "";
+      if (!state.headers.length) return;
+
+      const orderedHeaders = state.columnOrder.length ? state.columnOrder : state.headers;
+      for (const header of orderedHeaders) {
+        const label = document.createElement("label");
+        label.className = "column-chip";
+        label.draggable = true;
+        label.dataset.header = header;
+
+        const input = document.createElement("input");
+        input.type = "checkbox";
+        input.checked = state.visibleHeaders.includes(header);
+        input.addEventListener("change", () => {
+          if (input.checked) {
+            if (!state.visibleHeaders.includes(header)) state.visibleHeaders.push(header);
+          } else {
+            state.visibleHeaders = state.visibleHeaders.filter((item) => item !== header);
+          }
+          updateDetailTable();
+        });
+
+        const text = document.createElement("span");
+        text.textContent = header;
+
+        label.addEventListener("dragstart", (event) => {
+          state.draggingColumn = header;
+          label.classList.add("dragging-column");
+          event.dataTransfer.effectAllowed = "move";
+          event.dataTransfer.setData("text/plain", header);
+        });
+        label.addEventListener("dragend", () => {
+          state.draggingColumn = null;
+          label.classList.remove("dragging-column");
+          clearColumnDropHints();
+        });
+        label.addEventListener("dragover", (event) => {
+          if (!state.draggingColumn || state.draggingColumn === header) return;
+          event.preventDefault();
+          const rect = label.getBoundingClientRect();
+          const insertAfter = event.clientX > rect.left + rect.width / 2;
+          clearColumnDropHints();
+          label.classList.add(insertAfter ? "drop-after" : "drop-before");
+          event.dataTransfer.dropEffect = "move";
+        });
+        label.addEventListener("drop", (event) => {
+          event.preventDefault();
+          const sourceHeader = event.dataTransfer.getData("text/plain") || state.draggingColumn;
+          const rect = label.getBoundingClientRect();
+          moveColumn(sourceHeader, header, event.clientX > rect.left + rect.width / 2);
+          clearColumnDropHints();
+        });
+
+        label.appendChild(input);
+        label.appendChild(text);
+        elements.columnList.appendChild(label);
+      }
+    }
+
+    function escapeCsv(value) {
+      const text = value == null ? "" : String(value);
+      return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+    }
+
+    function exportCurrentDetail() {
+      if (!state.detailRows.length || !state.headers.length) return;
+      const activeHeaders = getActiveHeaders();
+      const lines = [activeHeaders.map(escapeCsv).join(",")];
+      for (const row of state.detailRows) {
+        const values = [];
+        for (const header of activeHeaders) {
+          values.push(escapeCsv(row[header] ?? ""));
+        }
+        lines.push(values.join(","));
+      }
+
+      const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8;" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `memory_detail_${elements.detailMode.value}.csv`;
+      link.click();
+      URL.revokeObjectURL(url);
+    }
+
+    function findNearestPoint(clientX, clientY) {
+      const active = getActiveSeries();
+      if (!active.length) return null;
+
+      const { dataX, rect, plot } = screenToData(clientX, clientY);
+      if (dataX < state.viewX[0] || dataX > state.viewX[1]) return null;
+
+      let best = null;
+      const targetX = (clientX - rect.left) * state.dpr;
+      const targetY = (clientY - rect.top) * state.dpr;
+      const threshold = 18 * state.dpr;
+
+      for (const item of active) {
+        const points = visiblePoints(item.points);
+        if (!points.length) continue;
+
+        let lo = 0;
+        let hi = points.length - 1;
+        while (lo < hi) {
+          const mid = Math.floor((lo + hi) / 2);
+          if (points[mid][0] < dataX) lo = mid + 1;
+          else hi = mid;
+        }
+
+        const candidates = [points[lo], points[Math.max(0, lo - 1)]].filter(Boolean);
+        for (const point of candidates) {
+          const { px, py } = dataToScreen(point[0], point[1], plot);
+          const dist = Math.hypot(px - targetX, py - targetY);
+          if (dist <= threshold && (!best || dist < best.dist)) {
+            best = {
+              dist,
+              px,
+              py,
+              x: point[0],
+              y: point[1],
+              color: item.color,
+              label: item.label
+            };
+          }
+        }
+      }
+      return best;
+    }
+
+    function findNearestTimeX(clientX, clientY) {
+      const active = getActiveSeries();
+      if (!active.length) return null;
+
+      const { dataX } = screenToData(clientX, clientY);
+      let best = null;
+
+      for (const item of active) {
+        const points = visiblePoints(item.points);
+        if (!points.length) continue;
+
+        let lo = 0;
+        let hi = points.length - 1;
+        while (lo < hi) {
+          const mid = Math.floor((lo + hi) / 2);
+          if (points[mid][0] < dataX) lo = mid + 1;
+          else hi = mid;
+        }
+
+        const candidates = [points[lo], points[Math.max(0, lo - 1)]].filter(Boolean);
+        for (const point of candidates) {
+          const dist = Math.abs(point[0] - dataX);
+          if (!best || dist < best.dist) {
+            best = { x: point[0], dist };
+          }
+        }
+      }
+
+      return best ? best.x : Math.round(dataX);
+    }
+
+    function updateTooltip(clientX, clientY) {
+      const hit = findNearestPoint(clientX, clientY);
+      state.hoverPoint = hit;
+      if (!hit) {
+        elements.hoverTooltip.style.display = "none";
+        draw();
+        return;
+      }
+
+      const rect = elements.canvas.getBoundingClientRect();
+      elements.hoverTooltip.textContent =
+        `${hit.label}\n时间: ${formatNumber(hit.x)}\n显存: ${formatBytes(hit.y)}`;
+      elements.hoverTooltip.style.display = "block";
+      elements.hoverTooltip.style.left = `${Math.min(rect.width - 180, clientX - rect.left)}px`;
+      elements.hoverTooltip.style.top = `${Math.max(8, clientY - rect.top)}px`;
+      draw();
+    }
+
+    function setClickedPointDetail(timePoint, point) {
+      state.clickedPointTime = timePoint;
+      state.selectedPoint = point
+        ? { x: point.x, y: point.y, color: point.color, label: point.label }
+        : { x: timePoint, y: null, color: colors.hover, label: "点击时间点" };
+      state.clickedAliveRows = rowsAliveAtTimePoint(timePoint);
+      state.clickedPointRows = rowsForTimePoint(timePoint);
+      state.detailCurrentPage = 1;
+      if (!state.detailModeUserLocked) {
+        elements.detailMode.value = "clicked_point";
+      }
+      updateDetailTable();
+      draw();
+    }
+
+    function setSelectedRangeDetail(startTime, endTime) {
+      state.selectedRange = [Math.min(startTime, endTime), Math.max(startTime, endTime)];
+      state.selectedRangeRows = rowsForTimeRange(startTime, endTime);
+      state.detailCurrentPage = 1;
+      elements.detailMode.value = "selected_range";
+      updateDetailTable();
+    }
+
+    function renderReferenceLines() {
+      elements.lineList.innerHTML = "";
+      if (!state.referenceLines.length) {
+        const empty = document.createElement("div");
+        empty.className = "small";
+        empty.textContent = "还没有横线标记";
+        elements.lineList.appendChild(empty);
+        return;
+      }
+
+      state.referenceLines.forEach((line) => {
+        const item = document.createElement("div");
+        item.className = "line-item";
+
+        const meta = document.createElement("div");
+        meta.className = "line-meta";
+
+        const color = document.createElement("span");
+        color.className = "line-color";
+        color.style.background = line.color;
+
+        const text = document.createElement("span");
+        text.textContent = `${formatBytes(line.value)} (${formatNumber(line.value)} bytes)`;
+
+        meta.appendChild(color);
+        meta.appendChild(text);
+
+        const remove = document.createElement("button");
+        remove.type = "button";
+        remove.className = "line-remove";
+        remove.textContent = "删除";
+        remove.addEventListener("click", () => {
+          state.referenceLines = state.referenceLines.filter((item) => item.id !== line.id);
+          renderReferenceLines();
+          draw();
+        });
+
+        item.appendChild(meta);
+        item.appendChild(remove);
+        elements.lineList.appendChild(item);
+      });
+      updateDiffRefLineSelects();
+    }
+
+    function addReferenceLine(value) {
+      const color = elements.lineColorSelect.value || "#0f766e";
+      if (!Number.isFinite(value)) return;
+
+      state.referenceLines.push({
+        id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        value,
+        color
+      });
+      renderReferenceLines();
+      draw();
+    }
+
+    async function loadFile(file) {
+      elements.fileName.textContent = file.name;
+      setStatus(`正在流式读取 CSV... 文件大小 ${formatBytes(file.size || 0)}`);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const parsed = await parseCsvFile(file, (loaded, total, rowCount) => {
+        const percent = total ? `，${Math.min(100, (loaded / total) * 100).toFixed(1)}%` : "";
+        setStatus(`正在解析 CSV... 已读取 ${formatBytes(loaded)} / ${formatBytes(total || loaded)}${percent}\n已解析 ${formatNumber(rowCount)} 行`);
+      });
+      state.headers = parsed.headers;
+      state.columnOrder = parsed.headers.slice();
+      state.visibleHeaders = parsed.headers.filter((header) => DEFAULT_VISIBLE_HEADERS.includes(header));
+      if (!state.visibleHeaders.length) {
+        state.visibleHeaders = parsed.headers.slice(0, Math.min(8, parsed.headers.length));
+      }
+      state.rows = parsed.rows;
+
+      setStatus(`正在分析 ${formatNumber(parsed.rows.length)} 行数据...`);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      const result = analyzeRows(parsed.rows);
+
+      state.series = result;
+      state.detailModes = result.detailModes;
+      state.allRowsFromStart = buildRowsFromStart(parsed.rows);
+      state.clickedPointRows = [];
+      state.clickedAliveRows = [];
+      state.selectedRangeRows = [];
+      state.clickedPointTime = null;
+      state.selectedPoint = null;
+      state.selectedRange = null;
+      state.detailCurrentPage = 1;
+      state.detailFilters = {};
+      state.detailSort = { header: null, direction: null };
+      state.detailToolsOpen = {};
+      elements.detailMode.value = "all_allocations";
+      state.detailModeUserLocked = false;
+      state.fullRangeX = result.xRange;
+      state.fullRangeY = result.yRange[0] === result.yRange[1]
+        ? [result.yRange[0], result.yRange[1] + 1]
+        : result.yRange;
+      state.hoverPoint = null;
+      state.diffPointA = null;
+      state.diffPointB = null;
+      state.diffActiveA = [];
+      state.diffActiveB = [];
+      state.diffResults = null;
+      state.diffCategory = "added";
+      state.diffCurrentPage = 1;
+      state.diffHighlight = null;
+      elements.diffATime.value = "";
+      elements.diffBTime.value = "";
+      elements.diffRunBtn.disabled = true;
+      elements.diffCard.style.display = "none";
+      elements.peakInterpCard.style.display = "none";
+      elements.peakInterpContent.style.display = "none";
+      state.peakInterpResults = null;
+      state.peakInterpSelected = null;
+
+      elements.detailTabBar.style.display = "";
+      switchDetailTab("detail");
+
+      fitView();
+      renderColumnSelector();
+      updateDetailTable();
+
+      elements.statRows.textContent = formatNumber(parsed.rows.length);
+      elements.statTime.textContent = `${formatNumber(result.xRange[0])} - ${formatNumber(result.xRange[1])}`;
+      elements.statRealPeak.textContent = result.real.peak ? `${formatBytes(result.real.peak.value)} @ ${formatNumber(result.real.peak.time)}` : "-";
+      elements.statTheoryPeak.textContent = result.theory.peak ? `${formatBytes(result.theory.peak.value)} @ ${formatNumber(result.theory.peak.time)}` : "-";
+      elements.statActualPeak.textContent = result.actual.peak ? `${formatBytes(result.actual.peak.value)} @ ${formatNumber(result.actual.peak.time)}` : "-";
+
+      setStatus(
+        `分析完成\n` +
+        `总行数: ${formatNumber(parsed.rows.length)}\n` +
+        `申请量峰值: ${elements.statRealPeak.textContent}\n` +
+        `理论峰值: ${elements.statTheoryPeak.textContent}\n` +
+        `内存池峰值: ${elements.statActualPeak.textContent}`
+      );
+
+      try {
+        const snapshot = buildSnapshot(state.rows);
+        const b64 = jsonToBase64(snapshot);
+        state.memoryVizBase64 = b64;
+        state.memoryVizReady = true;
+        document.getElementById("btnLifetime").disabled = false;
+        const mvizStatus = document.getElementById("mvizStatus");
+        if (state.rows.length > 50000) {
+          mvizStatus.textContent = "数据量较大（" + state.rows.length + " 行），生命周期视图可能较卡，建议优先使用折线图查看全局趋势。";
+          mvizStatus.className = "";
+        } else {
+          mvizStatus.textContent = "";
+          mvizStatus.className = "ok";
+        }
+      } catch (err) {
+        console.error("MemoryViz data preparation failed:", err);
+        state.memoryVizReady = false;
+        state.memoryVizBase64 = null;
+        document.getElementById("btnLifetime").disabled = true;
+        document.getElementById("mvizStatus").textContent = "生命周期数据准备失败: " + err.message;
+        document.getElementById("mvizStatus").className = "error";
+      }
+    }
+
+    async function loadSelectedFile(file) {
+      if (!file) return;
+      try {
+        await loadFile(file);
+      } catch (error) {
+        console.error(error);
+        setStatus(`解析失败: ${error.message}`);
+      }
+    }
+
+    elements.fileInput.addEventListener("change", async (event) => {
+      await loadSelectedFile(event.target.files[0]);
+    });
+
+    window.addEventListener("dragover", (event) => {
+      if (!event.dataTransfer || !Array.from(event.dataTransfer.types).includes("Files")) return;
+      event.preventDefault();
+      event.dataTransfer.dropEffect = "copy";
+      setStatus("松开鼠标即可加载 CSV 文件");
+    });
+
+    window.addEventListener("drop", async (event) => {
+      if (!event.dataTransfer || !event.dataTransfer.files.length) return;
+      event.preventDefault();
+      const file = Array.from(event.dataTransfer.files).find((item) => {
+        return item.name.toLowerCase().endsWith(".csv") || item.type === "text/csv";
+      }) || event.dataTransfer.files[0];
+      await loadSelectedFile(file);
+    });
+
+    elements.showReal.addEventListener("change", fitView);
+    elements.showTheory.addEventListener("change", fitView);
+    elements.showActual.addEventListener("change", fitView);
+    elements.samplesPerPixel.addEventListener("change", draw);
+    elements.fitButton.addEventListener("click", fitView);
+    elements.resetYButton.addEventListener("click", resetY);
+    elements.statusText.addEventListener("mousedown", (event) => {
+      event.preventDefault();
+      const rect = elements.statusText.getBoundingClientRect();
+      const shellRect = elements.statusText.parentElement.getBoundingClientRect();
+      state.statusDrag = {
+        startX: event.clientX,
+        startY: event.clientY,
+        left: rect.left - shellRect.left,
+        top: rect.top - shellRect.top,
+        moved: false
+      };
+      elements.statusText.classList.add("dragging-summary");
+    });
+    elements.statusText.addEventListener("click", () => {
+      if (state.statusDrag && state.statusDrag.moved) return;
+      setStatusHidden(!state.statusHidden);
+    });
+    elements.addLineModeButton.addEventListener("click", () => {
+      state.lineAddMode = !state.lineAddMode;
+      elements.addLineModeButton.classList.toggle("active", state.lineAddMode);
+      elements.addLineModeButton.textContent = state.lineAddMode ? "退出画线" : "点图加线";
+      updateCanvasCursor();
+    });
+    elements.detailMode.addEventListener("change", () => {
+      state.detailModeUserLocked = true;
+      state.detailCurrentPage = 1;
+      updateDetailTable();
+    });
+    elements.exportButton.addEventListener("click", exportCurrentDetail);
+    elements.prevPageButton.addEventListener("click", () => {
+      state.detailCurrentPage = Math.max(1, state.detailCurrentPage - 1);
+      updateDetailTable();
+    });
+    elements.nextPageButton.addEventListener("click", () => {
+      const totalPages = Math.max(1, Math.ceil(state.detailRows.length / state.detailPageSize));
+      state.detailCurrentPage = Math.min(totalPages, state.detailCurrentPage + 1);
+      updateDetailTable();
+    });
+    elements.goPageButton.addEventListener("click", () => {
+      const totalPages = Math.max(1, Math.ceil(state.detailRows.length / state.detailPageSize));
+      const target = Number(elements.pageInput.value);
+      if (Number.isFinite(target) && target >= 1) {
+        state.detailCurrentPage = Math.min(totalPages, Math.floor(target));
+        updateDetailTable();
+      }
+    });
+    elements.pageInput.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        elements.goPageButton.click();
+      }
+    });
+
+    elements.canvas.addEventListener("wheel", (event) => {
+      if (!state.series.real && !state.series.theory && !state.series.actual) return;
+      event.preventDefault();
+      const { dataX, dataY } = screenToData(event.clientX, event.clientY);
+      const factor = event.deltaY < 0 ? 0.85 : 1.18;
+      applyZoom(factor, dataX, dataY, !event.shiftKey, event.shiftKey);
+      updateTooltip(event.clientX, event.clientY);
+    }, { passive: false });
+
+    elements.canvas.addEventListener("mousedown", (event) => {
+      if (!state.series.real && !state.series.theory && !state.series.actual) return;
+      const hitLineId = findReferenceLineAt(event.clientX, event.clientY);
+      if (!event.altKey && hitLineId) {
+        state.draggingReferenceLineId = hitLineId;
+        state.hoverReferenceLineId = hitLineId;
+        elements.canvas.classList.add("dragging");
+        updateCanvasCursor();
+        return;
+      }
+
+      const { px, py } = screenToData(event.clientX, event.clientY);
+      state.dragStart = {
+        px,
+        py,
+        viewX: [state.viewX[0], state.viewX[1]],
+        viewY: [state.viewY[0], state.viewY[1]]
+      };
+      if (event.altKey) {
+        state.selecting = true;
+        state.selection = { x: px, y: py, w: 0, h: 0 };
+      } else {
+        state.dragging = true;
+        elements.canvas.classList.add("dragging");
+      }
+      updateCanvasCursor();
+    });
+
+    window.addEventListener("mousemove", (event) => {
+      if (state.statusDrag) {
+        const dx = event.clientX - state.statusDrag.startX;
+        const dy = event.clientY - state.statusDrag.startY;
+        if (Math.hypot(dx, dy) > 4) state.statusDrag.moved = true;
+        setStatusPosition(state.statusDrag.left + dx, state.statusDrag.top + dy);
+      }
+
+      state.hoverReferenceLineId = findReferenceLineAt(event.clientX, event.clientY);
+      updateCanvasCursor();
+      updateTooltip(event.clientX, event.clientY);
+      if (state.draggingReferenceLineId) {
+        const current = screenToData(event.clientX, event.clientY);
+        const line = state.referenceLines.find((item) => item.id === state.draggingReferenceLineId);
+        if (line) {
+          line.value = Math.max(state.fullRangeY[0], Math.min(state.fullRangeY[1], current.dataY));
+          renderReferenceLines();
+          draw();
+        }
+        return;
+      }
+
+      if (!state.dragging && !state.selecting) return;
+
+      const current = screenToData(event.clientX, event.clientY);
+      const plot = getPlotRect();
+
+      if (state.dragging && state.dragStart) {
+        const dx = ((current.px - state.dragStart.px) / plot.width) * (state.dragStart.viewX[1] - state.dragStart.viewX[0]);
+        const dy = ((current.py - state.dragStart.py) / plot.height) * (state.dragStart.viewY[1] - state.dragStart.viewY[0]);
+        state.viewX = [state.dragStart.viewX[0] - dx, state.dragStart.viewX[1] - dx];
+        state.viewY = [state.dragStart.viewY[0] + dy, state.dragStart.viewY[1] + dy];
+        draw();
+      }
+
+      if (state.selecting && state.selection) {
+        state.selection.w = current.px - state.selection.x;
+        state.selection.h = current.py - state.selection.y;
+        draw();
+      }
+    });
+
+    window.addEventListener("mouseup", (event) => {
+      if (state.statusDrag) {
+        elements.statusText.classList.remove("dragging-summary");
+        setTimeout(() => {
+          state.statusDrag = null;
+        }, 0);
+      }
+
+      if (state.draggingReferenceLineId) {
+        state.draggingReferenceLineId = null;
+        elements.canvas.classList.remove("dragging");
+        updateCanvasCursor();
+        draw();
+        return;
+      }
+
+      let shouldPickPoint = false;
+      if (state.dragStart && !state.selecting) {
+        const current = screenToData(event.clientX, event.clientY);
+        const moveDistance = Math.hypot(current.px - state.dragStart.px, current.py - state.dragStart.py);
+        shouldPickPoint = moveDistance < 6 * state.dpr;
+      }
+
+      if (state.selecting && state.selection) {
+        const rect = elements.canvas.getBoundingClientRect();
+        const sx = Math.min(state.selection.x, state.selection.x + state.selection.w) / state.dpr + rect.left;
+        const ex = Math.max(state.selection.x, state.selection.x + state.selection.w) / state.dpr + rect.left;
+        const sy = Math.min(state.selection.y, state.selection.y + state.selection.h) / state.dpr + rect.top;
+        const ey = Math.max(state.selection.y, state.selection.y + state.selection.h) / state.dpr + rect.top;
+
+        if (Math.abs(ex - sx) > 8) {
+          const a = screenToData(sx, sy);
+          const b = screenToData(ex, ey);
+          state.viewX = [Math.min(a.dataX, b.dataX), Math.max(a.dataX, b.dataX)];
+          if (Math.abs(ey - sy) > 8) {
+            state.viewY = [Math.min(a.dataY, b.dataY), Math.max(a.dataY, b.dataY)];
+          }
+          setSelectedRangeDetail(a.dataX, b.dataX);
+        }
+      }
+
+      if (shouldPickPoint) {
+        if (state.lineAddMode) {
+          const current = screenToData(event.clientX, event.clientY);
+          addReferenceLine(current.dataY);
+          state.lineAddMode = false;
+          elements.addLineModeButton.classList.remove("active");
+          elements.addLineModeButton.textContent = "点图加线";
+          updateCanvasCursor();
+        } else {
+          const hit = findNearestPoint(event.clientX, event.clientY);
+          if (hit) {
+            setClickedPointDetail(hit.x, hit);
+          } else {
+            const timeX = findNearestTimeX(event.clientX, event.clientY);
+            if (timeX !== null) setClickedPointDetail(timeX);
+          }
+        }
+      }
+
+      state.dragging = false;
+      state.selecting = false;
+      state.dragStart = null;
+      state.selection = null;
+      elements.canvas.classList.remove("dragging");
+      updateCanvasCursor();
+      draw();
+    });
+
+    elements.canvas.addEventListener("mouseleave", () => {
+      state.hoverPoint = null;
+      state.hoverReferenceLineId = null;
+      elements.hoverTooltip.style.display = "none";
+      updateCanvasCursor();
+      draw();
+    });
+
+    /* ── Diff event handlers ── */
+
+    elements.diffATime.addEventListener("input", updateDiffRunButton);
+    elements.diffBTime.addEventListener("input", updateDiffRunButton);
+    elements.diffATime.addEventListener("change", updateDiffRunButton);
+    elements.diffBTime.addEventListener("change", updateDiffRunButton);
+
+    elements.diffASetClick.addEventListener("click", () => setDiffPointFromClick("A"));
+    elements.diffBSetClick.addEventListener("click", () => setDiffPointFromClick("B"));
+
+    elements.diffARefLine.addEventListener("change", () => {
+      const val = elements.diffARefLine.value;
+      if (val !== "") {
+        elements.diffATime.value = val;
+        updateDiffRunButton();
+      }
+    });
+    elements.diffBRefLine.addEventListener("change", () => {
+      const val = elements.diffBRefLine.value;
+      if (val !== "") {
+        elements.diffBTime.value = val;
+        updateDiffRunButton();
+      }
+    });
+
+    function switchDetailTab(tabName) {
+      const btns = elements.detailTabBar.querySelectorAll(".detail-tab-btn");
+      btns.forEach(b => b.classList.toggle("active", b.dataset.tab === tabName));
+      elements.detailCard.style.display = tabName === "detail" ? "" : "none";
+      elements.peakInterpCard.style.display = tabName === "interp" ? "" : "none";
+      elements.diffCard.style.display = tabName === "diff" ? "" : "none";
+    }
+    window.switchDetailTab = switchDetailTab;
+
+    elements.detailTabBar.addEventListener("click", (event) => {
+      const btn = event.target.closest(".detail-tab-btn");
+      if (!btn) return;
+      switchDetailTab(btn.dataset.tab);
+    });
+
+    elements.diffRunBtn.addEventListener("click", runDiffAnalysis);
+
+    elements.diffAggDimension.addEventListener("change", () => {
+      updateDiffAggTable();
+    });
+
+    elements.diffTabs.addEventListener("click", (event) => {
+      const tab = event.target.closest(".diff-tab");
+      if (!tab) return;
+      const category = tab.dataset.category;
+      if (category) {
+        // Toggle: clicking the active tab deselects it
+        state.diffCategory = state.diffCategory === category ? "" : category;
+        state.diffCurrentPage = 1;
+        updateDiffTabs();
+        updateDiffAggTable();
+        updateDiffDetailTable();
+      }
+    });
+
+    elements.diffPrevPage.addEventListener("click", () => {
+      state.diffCurrentPage = Math.max(1, state.diffCurrentPage - 1);
+      updateDiffDetailTable();
+    });
+    elements.diffNextPage.addEventListener("click", () => {
+      const rows = getDiffDetailRows();
+      const totalPages = Math.max(1, Math.ceil(rows.length / state.diffPageSize));
+      state.diffCurrentPage = Math.min(totalPages, state.diffCurrentPage + 1);
+      updateDiffDetailTable();
+    });
+    elements.diffGoPage.addEventListener("click", () => {
+      const rows = getDiffDetailRows();
+      const totalPages = Math.max(1, Math.ceil(rows.length / state.diffPageSize));
+      const target = Number(elements.diffPageInput.value);
+      if (Number.isFinite(target) && target >= 1) {
+        state.diffCurrentPage = Math.min(totalPages, Math.floor(target));
+        updateDiffDetailTable();
+      }
+    });
+    elements.diffPageInput.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") elements.diffGoPage.click();
+    });
+
+    elements.diffExportCSV.addEventListener("click", exportDiffCSV);
+    elements.diffExportJSON.addEventListener("click", exportDiffJSON);
+
+    elements.diffHighlightAdded.addEventListener("click", () => {
+      state.diffHighlight = state.diffHighlight === "added" ? null : "added";
+      draw();
+    });
+    elements.diffHighlightReleased.addEventListener("click", () => {
+      state.diffHighlight = state.diffHighlight === "released" ? null : "released";
+      draw();
+    });
+    elements.diffHighlightCommon.addEventListener("click", () => {
+      state.diffHighlight = state.diffHighlight === "common" ? null : "common";
+      draw();
+    });
+    elements.diffHighlightOff.addEventListener("click", () => {
+      state.diffHighlight = null;
+      draw();
+    });
+
+    /* ── Peak Interpreter event handlers ── */
+    elements.peakInterpRun.addEventListener("click", runPeakInterpreter);
+    elements.peakInterpDim.addEventListener("change", () => {
+      state.peakInterpDim = elements.peakInterpDim.value;
+      state.peakInterpSelected = null;
+      renderPeakInterpreter();
+    });
+    elements.peakInterpExportCSV.addEventListener("click", exportPeakInterpCSV);
+    elements.peakInterpExportJSON.addEventListener("click", exportPeakInterpJSON);
+
+    window.addEventListener("resize", resizeCanvas);
+    resizeCanvas();
+    renderReferenceLines();
+    updateDetailTable();
+    updateCanvasCursor();
+
+</script>
+<script type="module">
+const btnLineChart = document.getElementById("btnLineChart");
+const btnLifetime = document.getElementById("btnLifetime");
+const mvizStatus = document.getElementById("mvizStatus");
+const appDiv = document.querySelector(".app");
+
+let addLocalFiles = null;
+let mvizModuleLoaded = false;
+let mvizRendered = false;
+
+function setActiveView(mode) {
+  btnLineChart.classList.toggle("active", mode === "line");
+  btnLifetime.classList.toggle("active", mode === "lifetime");
+}
+
+function switchToLineChart() {
+  setActiveView("line");
+
+  // Use CSS class to hide all MemoryViz body-level elements
+  // (display:none !important overrides MemoryViz inline styles without destroying them)
+  document.body.classList.add("hide-mviz");
+
+  // Reset body layout back to main page defaults
+  document.documentElement.style.height = "";
+  document.body.style.height = "";
+  document.body.style.display = "";
+  document.body.style.flexDirection = "";
+  document.body.style.overflow = "";
+  const vsBar = document.querySelector(".view-switch-bar");
+  if (vsBar) vsBar.style.flexShrink = "";
+  mvizStatus.style.flexShrink = "";
+
+  appDiv.style.display = "";
+  disableMemoryVizStyles();
+}
+
+function switchToLifetime() {
+  if (!window.state || !window.state.memoryVizReady) {
+    mvizStatus.textContent = "请先加载 CSV 文件";
+    mvizStatus.className = "error";
+    return;
+  }
+
+  setActiveView("lifetime");
+
+  // Match original memory_viz_csv_tool.html: body as flex column with full viewport height
+  document.documentElement.style.height = "100%";
+  document.body.style.height = "100vh";
+  document.body.style.display = "flex";
+  document.body.style.flexDirection = "column";
+  document.body.style.overflow = "hidden";
+  const vsBar = document.querySelector(".view-switch-bar");
+  if (vsBar) vsBar.style.flexShrink = "0";
+  mvizStatus.style.flexShrink = "0";
+
+  appDiv.style.display = "none";
+  enableMemoryVizStyles();
+
+  if (!mvizModuleLoaded) {
+    // Hide MemoryViz elements during async loading (toolbar flashes otherwise)
+    document.body.classList.add("hide-mviz");
+    loadMemoryVizModule();
+    return;
+  }
+
+  if (!mvizRendered) {
+    document.body.classList.add("hide-mviz");
+    renderMemoryViz();
+    return;
+  }
+
+  // Already rendered — just un-hide and re-hide unwanted controls
+  document.body.classList.remove("hide-mviz");
+  hideMemoryVizFileUI();
+}
+
+async function loadMemoryVizModule() {
+  mvizStatus.textContent = "正在加载 MemoryViz...";
+  mvizStatus.className = "";
+
+  try {
+    // NOTE: import() does not support SRI (integrity attribute). We mitigate by
+    // pinning to a specific release version instead of @main (which is a moving target).
+    // For full SRI, a fetch()+crypto.subtle.verify()+blob URL approach would be needed.
+    const MVIZ_CDN_URL = "https://cdn.jsdelivr.net/gh/pytorch/pytorch@2.12.0/torch/utils/viz/MemoryViz.js";
+
+    const mod = await import(MVIZ_CDN_URL);
+    addLocalFiles = mod.add_local_files;
+    mvizModuleLoaded = true;
+    markMemoryVizStyles();
+    renderMemoryViz();
+  } catch (err) {
+    console.error("MemoryViz.js load failed:", err);
+    mvizStatus.textContent =
+      "MemoryViz 加载失败。请检查网络连接，或通过 HTTP 服务器访问本页面（python3 -m http.server 8888）。";
+    mvizStatus.className = "error";
+    switchToLineChart();
+  }
+}
+
+function renderMemoryViz() {
+  mvizStatus.textContent = "正在渲染时间线...";
+  mvizStatus.className = "";
+
+  try {
+    const b64 = window.state.memoryVizBase64;
+    const fileName = document.getElementById("fileName").textContent || "memory_data.csv";
+    addLocalFiles([{ name: fileName, base64: b64 }], "Active Memory Timeline");
+    mvizRendered = true;
+
+    // Remove hide-mviz so MemoryViz elements become visible (with their original inline styles intact)
+    document.body.classList.remove("hide-mviz");
+    hideMemoryVizFileUI();
+
+    mvizStatus.textContent = "";
+    mvizStatus.className = "ok";
+  } catch (err) {
+    console.error("MemoryViz render failed:", err);
+    mvizStatus.textContent = "MemoryViz 渲染失败: " + err.message;
+    mvizStatus.className = "error";
+  }
+}
+
+function hideMemoryVizFileUI() {
+  // 1. Hide file input (<input type="file" multiple>)
+  const fileInputs = document.querySelectorAll('input[type="file"][multiple]');
+  for (const input of fileInputs) {
+    if (input.id !== "fileInput") {
+      input.style.display = "none";
+    }
+  }
+
+  // 2. Hide "Drag and drop" placeholder div
+  const bodyChildren = document.body.children;
+  for (const child of bodyChildren) {
+    if (child.tagName === "DIV" && child.textContent && child.textContent.includes("Drag and drop")) {
+      child.style.display = "none";
+    }
+  }
+
+  // 3. Hide interaction checkbox label ("Require click to show trace")
+  const checkbox = document.getElementById("interaction-mode-toggle");
+  if (checkbox && checkbox.parentElement && checkbox.parentElement.tagName === "LABEL") {
+    checkbox.parentElement.style.display = "none";
+  }
+
+  // 4. Hide controls toolbar div (contains 3 select dropdowns: snapshot, view, gpu)
+  // The controls div has <select> as direct children (d3 append), and is a bare <div>
+  for (const child of bodyChildren) {
+    if (child.tagName === "DIV" && !child.id) {
+      const directSelects = child.querySelectorAll(":scope > select");
+      if (directSelects.length >= 2) {
+        child.style.display = "none";
+      }
+    }
+  }
+}
+
+function markMemoryVizStyles() {
+  const headStyles = document.head.querySelectorAll('style');
+  for (const style of headStyles) {
+    if (!style.hasAttribute('data-main-page')) {
+      style.setAttribute('data-mviz', '');
+    }
+  }
+}
+
+function disableMemoryVizStyles() {
+  for (const style of document.head.querySelectorAll('style[data-mviz]')) {
+    style.disabled = true;
+  }
+}
+
+function enableMemoryVizStyles() {
+  for (const style of document.head.querySelectorAll('style[data-mviz]')) {
+    style.disabled = false;
+  }
+}
+
+document.head.querySelectorAll('style').forEach(s => s.setAttribute('data-main-page', ''));
+
+btnLineChart.addEventListener("click", switchToLineChart);
+btnLifetime.addEventListener("click", switchToLifetime);
+
+window.switchToLineChart = switchToLineChart;
+window.switchToLifetime = switchToLifetime;
+</script>
+</body>
+</html>

--- a/scripts/train_lm.py
+++ b/scripts/train_lm.py
@@ -26,6 +26,7 @@ No edit to this file is required. Create
 for the resolution rules (built-in vs. fully-qualified external package).
 """
 # pylint: disable=wrong-import-position
+import logging
 import os
 
 # Pin the backend before importing hyper_parallel because platform objects are
@@ -41,6 +42,9 @@ init_logger()
 from hyper_parallel.trainer.config import parse_args, HyperTrainerConfig
 from hyper_parallel.trainer.utils.discovery import discover_model_spec
 from hyper_parallel.trainer.llm_trainer import LLMTrainer
+from hyper_parallel.platform.torch.dry_run import TorchDryRunRunner
+
+logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     args = parse_args(HyperTrainerConfig)
@@ -49,5 +53,9 @@ if __name__ == "__main__":
     # global registry that ``BaseTrainer.__init__`` then queries via
     # ``get_spec(args.model.name)``.
     discover_model_spec(args.model.name)
-    trainer = LLMTrainer(args)
-    trainer.train()
+    if args.train.dry_run.enabled:
+        report_path = TorchDryRunRunner(args).run()
+        logger.info("HyperDryRun report: %s", report_path)
+    else:
+        trainer = LLMTrainer(args)
+        trainer.train()

--- a/tests/ut/platform/torch/memory_analysis_behavior_test.js
+++ b/tests/ut/platform/torch/memory_analysis_behavior_test.js
@@ -1,0 +1,172 @@
+// Copyright 2026 Huawei Technologies Co., Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ============================================================================
+"use strict";
+
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+
+function extractFunction(source, functionName) {
+  const marker = `function ${functionName}(`;
+  const start = source.indexOf(marker);
+  assert(start >= 0, `Missing function in memory_analysis.html: ${functionName}`);
+  const bodyStart = source.indexOf("{", start + marker.length);
+  assert(bodyStart >= 0, `Missing function body: ${functionName}`);
+
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+  for (let index = bodyStart; index < source.length; index += 1) {
+    const character = source[index];
+    const nextCharacter = source[index + 1];
+    if (lineComment) {
+      if (character === "\n") lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (character === "*" && nextCharacter === "/") {
+        blockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+    if (quote !== null) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (character === "/" && nextCharacter === "/") {
+      lineComment = true;
+      index += 1;
+      continue;
+    }
+    if (character === "/" && nextCharacter === "*") {
+      blockComment = true;
+      index += 1;
+      continue;
+    }
+    if (character === "\"" || character === "'" || character === "`") {
+      quote = character;
+      continue;
+    }
+    if (character === "{") depth += 1;
+    if (character === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, index + 1);
+    }
+  }
+  throw new Error(`Unterminated function body: ${functionName}`);
+}
+
+function encodeCsvRow(values) {
+  return values.map((value) => {
+    const text = String(value);
+    return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+  }).join(",");
+}
+
+const repositoryRoot = path.resolve(__dirname, "../../../..");
+const viewerSource = fs.readFileSync(
+  path.join(repositoryRoot, "memory_analysis.html"),
+  "utf8"
+);
+const constantsStart = viewerSource.indexOf("const PERSISTENT_END_TIMESTAMP");
+const constantsEnd = viewerSource.indexOf("const DEFAULT_VISIBLE_HEADERS", constantsStart);
+assert(constantsStart >= 0 && constantsEnd > constantsStart, "Missing memory constants");
+const constantsSource = viewerSource.slice(constantsStart, constantsEnd);
+const functionNames = [
+  "isTrackedMemoryPool",
+  "parseCsvLine",
+  "parseCsv",
+  "extractUsers",
+  "arrayMax",
+  "parsePythonStack",
+  "buildSnapshot",
+  "buildSeries",
+  "computeBounds",
+  "analyzeRows",
+  "rowsAliveAtTimePoint",
+];
+const functionSource = functionNames
+  .map((functionName) => extractFunction(viewerSource, functionName))
+  .join("\n");
+const buildApi = new Function(
+  `${constantsSource}\n`
+  + "const state = { rows: [], fullRangeX: [0, 0] };\n"
+  + `${functionSource}\n`
+  + "return { parseCsv, analyzeRows, buildSnapshot, rowsAliveAtTimePoint, state };"
+);
+const api = buildApi();
+
+const headers = [
+  "start_time_stamp", "end_time_stamp", "device_addr", "stream_id",
+  "pool_type", "size", "actual_used_memory", "actual_peak_memory",
+  "file_name", "line_num", "type", "producer_task", "task_name",
+  "node_name", "graph_name", "user_tasks", "last_user_task",
+  "python_stack", "is_persistent", "is_small",
+];
+const persistentNodeName = 'aten."quoted",op';
+const csvText = [
+  encodeCsvRow(headers),
+  encodeCsvRow([
+    0, "9223372036854775807", "0xf00000000000", 7,
+    "FakeTensorLogicalMemoryPool", 10, 10, 10, "/tmp/a,b.py", 7,
+    "Activation", 0, "forward", persistentNodeName, "Model", "{1}", 1,
+    "File:/tmp/a,b.py;Line:7;Function:f", 1, 1,
+  ]),
+  encodeCsvRow([
+    1, 3, "0xf00000000200", 2, "FakeTensorLogicalMemoryPool", 20,
+    30, 30, "/tmp/model.py", 8, "Activation", 1, "forward",
+    "aten.add.Tensor", "Model", "{2}", 2,
+    "File:/tmp/model.py;Line:8;Function:g", 0, 1,
+  ]),
+].join("\n");
+
+const parsed = api.parseCsv(csvText);
+assert.strictEqual(parsed.rows.length, 2);
+assert.strictEqual(parsed.rows[0].node_name, persistentNodeName);
+assert.strictEqual(parsed.rows[0].file_name, "/tmp/a,b.py");
+
+const analysis = api.analyzeRows(parsed.rows);
+assert(analysis.real.points.length > 0, "Fake pool must produce a real series");
+assert.deepStrictEqual(analysis.real.peak, { time: 1, value: 30 });
+
+const snapshot = api.buildSnapshot(parsed.rows);
+const events = snapshot.device_traces[0];
+assert.strictEqual(events.length, 4);
+assert(events.some((event) => event.action === "alloc" && event.stream === 7));
+assert(events.some((event) => event.action === "alloc" && event.stream === 2));
+assert.strictEqual(events.filter((event) => event.action === "free_requested").length, 1);
+assert.strictEqual(events.filter((event) => event.action === "free_completed").length, 1);
+assert.strictEqual(snapshot.segments.length, 1);
+assert.strictEqual(snapshot.segments[0].blocks.length, 1);
+assert.strictEqual(snapshot.segments[0].blocks[0].frames[0].filename, "/tmp/a,b.py");
+
+api.state.rows = parsed.rows;
+api.state.fullRangeX = analysis.xRange;
+const aliveBeforeEnd = api.rowsAliveAtTimePoint(2);
+const aliveAtEnd = api.rowsAliveAtTimePoint(3);
+assert.strictEqual(aliveBeforeEnd.length, 2);
+assert.strictEqual(aliveAtEnd.length, 1);
+assert.strictEqual(aliveAtEnd[0].node_name, persistentNodeName);
+
+console.log("memory_analysis behavior contract passed");

--- a/tests/ut/platform/torch/test_dry_run.py
+++ b/tests/ut/platform/torch/test_dry_run.py
@@ -1,0 +1,1032 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Unit tests for Torch dry-run report generation and configuration helpers."""
+import csv
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from enum import Enum
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch import nn
+
+from tests.common.mark_utils import arg_mark
+from hyper_parallel import fully_shard
+from hyper_parallel.core.activation_checkpoint.recompute_state import (
+    create_recompute_contexts,
+)
+from hyper_parallel.models.spec.model_spec import ModelSpec
+from hyper_parallel.models.spec.registry import _SPEC_REGISTRY, register_spec
+from hyper_parallel.platform.torch.dry_run import (
+    TorchDryRunRunner,
+    _operator_phase,
+    build_memory_csv_rows,
+    build_memory_report,
+    write_memory_csv,
+    write_memory_report,
+)
+from hyper_parallel.platform.torch.fully_shard.param_group import HSDPParamGroup
+from hyper_parallel.platform.torch.platform import TorchPlatform
+from hyper_parallel.trainer.base import BaseTrainer
+from hyper_parallel.trainer.config import HyperTrainerConfig
+
+
+class _TinyBlock(nn.Module):
+    """Small transformer-like residual MLP used by the fake FSDP test."""
+
+    def __init__(self) -> None:
+        """Build the two linear projections."""
+        super().__init__()
+        self.linear1 = nn.Linear(16, 32)
+        self.linear2 = nn.Linear(32, 16)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Apply one residual MLP block."""
+        return hidden_states + self.linear2(torch.relu(self.linear1(hidden_states)))
+
+
+class _TinyLanguageModel(nn.Module):
+    """Two-layer causal LM that exercises parameters, activations, and CE."""
+
+    def __init__(self) -> None:
+        """Build embeddings, residual blocks, and the LM head."""
+        super().__init__()
+        self.config = SimpleNamespace(
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            tie_word_embeddings=False,
+        )
+        self.embed_tokens = nn.Embedding(64, 16)
+        self.layers = nn.ModuleList([_TinyBlock(), _TinyBlock()])
+        self.lm_head = nn.Linear(16, 64, bias=False)
+
+    def forward(
+            self,
+            input_ids: torch.Tensor,
+            labels: Optional[torch.Tensor] = None,
+            use_cache: bool = False,
+            **kwargs: Any,
+    ) -> Dict[str, torch.Tensor]:
+        """Return a Trainer-compatible loss/logits mapping."""
+        del use_cache, kwargs
+        hidden_states = self.embed_tokens(input_ids)
+        for layer in self.layers:
+            hidden_states = layer(hidden_states)
+        logits = self.lm_head(hidden_states)
+        loss = torch.nn.functional.cross_entropy(
+            logits[:, :-1].reshape(-1, logits.shape[-1]),
+            labels[:, 1:].reshape(-1),
+        )
+        return {"loss": loss, "logits": logits}
+
+
+def _build_tiny_model(args: Any) -> nn.Module:
+    """Build the fake FSDP integration model."""
+    del args
+    return _TinyLanguageModel()
+
+
+def _parallelize_tiny_model(model: nn.Module, mesh: Any, args: Any) -> nn.Module:
+    """Apply the same per-layer plus root FSDP pattern as production models."""
+    for layer in model.layers:
+        fully_shard(
+            layer,
+            mesh=mesh["fsdp"],
+            reshard_after_forward=args.train.accelerator.reshard_after_forward,
+        )
+    return fully_shard(
+        model,
+        mesh=mesh["fsdp"],
+        reshard_after_forward=args.train.accelerator.reshard_after_forward,
+    )
+
+
+def _parallelize_tiny_model_no_zero_copy(
+        model: nn.Module, mesh: Any, args: Any
+) -> nn.Module:
+    """Apply fused FSDP while explicitly preserving per-parameter storage."""
+    for layer in model.layers:
+        fully_shard(
+            layer,
+            mesh=mesh["fsdp"],
+            reshard_after_forward=args.train.accelerator.reshard_after_forward,
+            comm_fusion=True,
+            comm_fusion_zero_copy=False,
+        )
+    return fully_shard(
+        model,
+        mesh=mesh["fsdp"],
+        reshard_after_forward=args.train.accelerator.reshard_after_forward,
+        comm_fusion=True,
+        comm_fusion_zero_copy=False,
+    )
+
+
+class _Category(str, Enum):
+    PARAMETER = "Parameter"
+    ACTIVATION = "Activation"
+
+
+class _State(str, Enum):
+    PEAK_FORWARD = "Peak-Forward"
+
+
+class _ModuleStats:
+    def __init__(self, fqn: str, peak: int) -> None:
+        """Create deterministic module statistics for report tests."""
+        self.mod_fqn = fqn
+        self.parameter_mem = 128
+        self.buffer_mem = 16
+        self.input_mem = 32
+        self.output_mem = 64
+        self.local_peak = {"cuda:0": peak}
+        self.snapshots = {
+            _State.PEAK_FORWARD: [
+                {"cuda:0": {_Category.PARAMETER: 128, "Total": peak}}
+            ]
+        }
+
+
+class _Tracker:
+    def __init__(self) -> None:
+        """Create deterministic global and module memory snapshots."""
+        self.memory_tracking = {
+            "root": _ModuleStats("Model", 800),
+            "layer0": _ModuleStats("Model.layers.0", 900),
+            "layer1": _ModuleStats("Model.layers.1", 1000),
+        }
+        self._snapshots = {
+            "peak": {
+                "cuda:0": {
+                    _Category.PARAMETER: 400,
+                    _Category.ACTIVATION: 600,
+                    "Total": 1000,
+                },
+                "cpu": {_Category.ACTIVATION: 50, "Total": 50},
+            },
+            "current": {
+                "cuda:0": {_Category.PARAMETER: 400, "Total": 400},
+            },
+        }
+
+    def get_tracker_snapshot(self, snapshot_type: str) -> Dict[Any, Dict[Any, int]]:
+        """Return the requested deterministic tracker snapshot."""
+        return self._snapshots[snapshot_type]
+
+
+class TestDryRunReport(unittest.TestCase):
+    """Report output preserves byte precision and filters module hotspots."""
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_build_report_filters_modules_and_computes_headroom(self):
+        """Feature: Dry-run memory report.
+
+        Description: Build a filtered report with a configured memory capacity.
+        Expectation: Only target-device bytes determine peaks, headroom, and OOM risk.
+        """
+        report = build_memory_report(
+            tracker=_Tracker(),
+            metadata={"rank": 0},
+            device_type="cuda",
+            module_depth=3,
+            top_modules=1,
+            device_memory_gib=0.0000005,
+        )
+
+        self.assertEqual(report["summary"]["peak_bytes"], 1000, (
+            f"Expected CUDA peak 1000, got {report['summary']['peak_bytes']}"
+        ))
+        self.assertEqual(
+            report["summary"]["peak_breakdown_bytes"],
+            {"Activation": 600, "Parameter": 400},
+            f"Unexpected peak breakdown: {report['summary']}",
+        )
+        self.assertEqual(
+            report["summary"]["current_breakdown_bytes"],
+            {"Parameter": 400},
+            f"Unexpected current breakdown: {report['summary']}",
+        )
+        self.assertTrue(report["summary"]["oom_risk"], (
+            f"Expected OOM risk for capacity, got {report['summary']}"
+        ))
+        self.assertEqual(len(report["modules"]), 1, (
+            f"Expected one top module, got {report['modules']}"
+        ))
+        self.assertEqual(
+            report["modules"][0]["fqn"],
+            "Model.layers.1",
+            f"Unexpected hottest module: {report['modules']}",
+        )
+        self.assertIn(
+            "Peak-Forward",
+            report["modules"][0]["snapshots"],
+            f"Expected forward snapshot, got {report['modules'][0]}",
+        )
+        self.assertIn("cpu", report["devices"], (
+            f"Expected diagnostic CPU entry, got {report['devices']}"
+        ))
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_build_report_rejects_missing_target_device(self):
+        """Feature: Dry-run report validation.
+
+        Description: Build a report without a target-device memory snapshot.
+        Expectation: Validation rejects the incomplete snapshot instead of reporting success.
+        """
+        with self.assertRaisesRegex(ValueError, "observed no 'npu'"):
+            build_memory_report(
+                tracker=_Tracker(),
+                metadata={},
+                device_type="npu",
+                module_depth=0,
+                top_modules=0,
+            )
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_operator_phase_distinguishes_checkpoint_recompute(self):
+        """Feature: Operator phase classification.
+
+        Description: Exercise forward, backward, recompute, and optimizer runtime states.
+        Expectation: Each state maps to its distinct CSV phase.
+        """
+        tracker = SimpleNamespace(
+            _in_opt=False,
+            _mod_tracker=SimpleNamespace(is_bw=False),
+        )
+        self.assertEqual(_operator_phase(tracker), "forward")
+        tracker._mod_tracker.is_bw = True
+        self.assertEqual(_operator_phase(tracker), "backward")
+
+        _, recompute_context = create_recompute_contexts()
+        with recompute_context:
+            self.assertEqual(_operator_phase(tracker), "recompute")
+            tracker._in_opt = True
+            self.assertEqual(_operator_phase(tracker), "optimizer")
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_write_report_creates_valid_json_without_temp_file(self):
+        """Feature: Atomic JSON report output.
+
+        Description: Write a report into a missing nested directory.
+        Expectation: The final JSON is valid and no temporary file remains.
+        """
+        report = {"schema_version": 1, "status": "ok"}
+        with tempfile.TemporaryDirectory() as tmp:
+            destination = os.path.join(tmp, "nested", "rank_0.json")
+            result = write_memory_report(report, destination)
+            with open(result, encoding="utf-8") as report_file:
+                loaded = json.load(report_file)
+            remaining = os.listdir(os.path.dirname(result))
+
+        self.assertEqual(loaded, report, (
+            f"Round-tripped report differs: expected={report}, actual={loaded}"
+        ))
+        self.assertEqual(remaining, ["rank_0.json"], (
+            f"Atomic writer left temporary files: {remaining}"
+        ))
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_csv_rows_match_mindspore_memory_block_shape(self):
+        """Feature: MindSpore-compatible memory-block CSV.
+
+        Description: Convert a logical operator storage record into a CSV row.
+        Expectation: The row keeps operator data and omits topology and summary fields.
+        """
+        memory_blocks = [{
+            "start_time_stamp": 0,
+            "end_time_stamp": 3,
+            "device_addr": "0xf00000000000",
+            "stream_id": 0,
+            "pool_type": "FakeTensorLogicalMemoryPool",
+            "size": 500,
+            "actual_used_memory": 1000,
+            "actual_peak_memory": 1200,
+            "file_name": "/workspace/model.py",
+            "line_num": 42,
+            "type": "Activation",
+            "producer_task": 0,
+            "task_name": "forward",
+            "node_name": "aten.relu.default",
+            "graph_name": "Model.layers.1",
+            "user_tasks": [1, 2],
+            "python_stack": "File:/workspace/model.py;Line:42;Function:forward",
+            "is_persistent": 0,
+            "is_small": 1,
+        }]
+        report = build_memory_report(
+            tracker=_Tracker(),
+            metadata={
+                "rank": 1,
+                "world_size": 2,
+                "device_type": "npu",
+                "simulation_device_type": "cuda",
+            },
+            device_type="cuda",
+            module_depth=3,
+            top_modules=1,
+            device_memory_gib=0.0000005,
+            memory_blocks=memory_blocks,
+        )
+        rows = build_memory_csv_rows(report)
+
+        self.assertEqual(len(rows), 1, f"Expected one storage row, got {rows}")
+        self.assertEqual(rows[0]["node_name"], "aten.relu.default", (
+            f"Unexpected operator CSV row: {rows[0]}"
+        ))
+        self.assertEqual(rows[0]["size"], 500, f"Unexpected size: {rows[0]}")
+        self.assertEqual(rows[0]["user_tasks"], "{1-2}", (
+            f"Unexpected user task encoding: {rows[0]}"
+        ))
+        self.assertEqual(rows[0]["last_user_task"], 2, (
+            f"Unexpected last user task: {rows[0]}"
+        ))
+        self.assertNotIn("rank", rows[0], f"CSV retained topology data: {rows[0]}")
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_write_csv_creates_parseable_file_without_temp_file(self):
+        """Feature: Atomic CSV report output.
+
+        Description: Write one memory block into a missing nested directory.
+        Expectation: The result is parseable, zero-indexed, and has no temporary file.
+        """
+        report = build_memory_report(
+            tracker=_Tracker(),
+            metadata={"rank": 0, "world_size": 2},
+            device_type="cuda",
+            module_depth=0,
+            top_modules=0,
+            memory_blocks=[{
+                "start_time_stamp": 0,
+                "end_time_stamp": 1,
+                "device_addr": "0xf00000000000",
+                "size": 64,
+                "node_name": "aten.empty.memory_format",
+                "user_tasks": [],
+                "python_stack": "File:/workspace/model.py;Line:1;Function:forward",
+            }],
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            destination = os.path.join(tmp, "nested", "rank_0_memory.csv")
+            result = write_memory_csv(report, destination)
+            with open(result, encoding="utf-8", newline="") as report_file:
+                rows = list(csv.DictReader(report_file))
+            remaining = os.listdir(os.path.dirname(result))
+
+        self.assertEqual(len(rows), 1, f"Expected one CSV memory block, got {rows}")
+        self.assertEqual(rows[0]["start_time_stamp"], "0", (
+            f"Expected zero-based logical timestamp, got {rows[0]}"
+        ))
+        self.assertEqual(remaining, ["rank_0_memory.csv"], (
+            f"Atomic writer left temporary files: {remaining}"
+        ))
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_memory_analysis_executes_dry_run_csv_contract(self):
+        """Feature: Memory visualization compatibility.
+
+        Description: Execute the viewer parser and analysis functions against dry-run CSV data.
+        Expectation: Fake pools, lifetimes, quoting, and snapshot conversion satisfy the contract.
+        """
+        node_binary = shutil.which("node")
+        if node_binary is None:
+            self.skipTest("Node.js is required for the HTML behavior contract")
+        repository_root = Path(__file__).resolve().parents[4]
+        test_script = (
+            repository_root
+            / "tests/ut/platform/torch/memory_analysis_behavior_test.js"
+        )
+        completed = subprocess.run(
+            [node_binary, str(test_script)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.returncode,
+            0,
+            "memory_analysis.html behavior contract failed:\n"
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}",
+        )
+
+
+class TestDryRunWorldSize(unittest.TestCase):
+    """Logical world-size inference follows ParallelDims' product contract."""
+
+    @staticmethod
+    def _args(
+            world_size: Optional[int] = None,
+            dp_shard: Optional[int] = 2,
+            legacy_dp: Optional[int] = None,
+    ) -> Any:
+        accelerator = SimpleNamespace(
+            dp=legacy_dp,
+            dp_replicate=2,
+            dp_shard=dp_shard,
+            cp=2,
+            tp=2,
+            pp=1,
+            ep=1,
+        )
+        dry_run = SimpleNamespace(world_size=world_size)
+        return SimpleNamespace(
+            train=SimpleNamespace(accelerator=accelerator, dry_run=dry_run)
+        )
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_explicit_world_size_wins(self):
+        """Feature: Dry-run world-size resolution.
+
+        Description: Configure an explicit logical world size.
+        Expectation: The runner preserves the explicit value.
+        """
+        args = self._args(world_size=64, dp_shard=-1)
+        actual = TorchDryRunRunner._resolve_world_size(args)
+        self.assertEqual(actual, 64, (
+            f"Expected explicit world size 64, got {actual}"
+        ))
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_parallel_product_is_inferred(self):
+        """Feature: Dry-run world-size inference.
+
+        Description: Configure fully explicit parallel dimensions without world size.
+        Expectation: The runner infers the product of all parallel degrees.
+        """
+        args = self._args()
+        actual = TorchDryRunRunner._resolve_world_size(args)
+        self.assertEqual(actual, 16, (
+            f"Expected inferred world size 16, got {actual}"
+        ))
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_auto_dp_requires_world_size(self):
+        """Feature: Dry-run world-size validation.
+
+        Description: Leave both data-parallel degree and world size automatic.
+        Expectation: The runner requests an explicit world size.
+        """
+        args = self._args(dp_shard=-1)
+        with self.assertRaisesRegex(ValueError, "world_size is required"):
+            TorchDryRunRunner._resolve_world_size(args)
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_torch_26_is_rejected(self):
+        """Feature: Torch version validation.
+
+        Description: Prepare a run with a Torch version lacking required fake tracking.
+        Expectation: Validation fails before distributed setup.
+        """
+        with self.assertRaisesRegex(RuntimeError, "PyTorch >= 2.7"):
+            TorchDryRunRunner._check_torch_version(
+                SimpleNamespace(__version__="2.6.0")
+            )
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_pipeline_parallel_is_rejected(self):
+        """Feature: Parallel-mode validation.
+
+        Description: Enable pipeline parallelism for a dry-run.
+        Expectation: Validation rejects the unsupported schedule.
+        """
+        args = HyperTrainerConfig()
+        args.train.accelerator.pp = 2
+        args.train.accelerator.dp_shard = 1
+        args.train.dry_run.world_size = 2
+        with self.assertRaisesRegex(NotImplementedError, "pipeline parallelism"):
+            TorchDryRunRunner(args)._prepare_args(
+                SimpleNamespace(__version__="2.7.1")
+            )
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_unvalidated_parallel_axis_is_rejected(self):
+        """Feature: Parallel-mode validation.
+
+        Description: Enable an unvalidated tensor-parallel axis.
+        Expectation: Phase 1 rejects the configuration rather than emitting a report.
+        """
+        args = HyperTrainerConfig()
+        args.train.accelerator.tp = 2
+        args.train.accelerator.dp_shard = 1
+        args.train.dry_run.world_size = 2
+        with self.assertRaisesRegex(NotImplementedError, "FSDP .* only"):
+            TorchDryRunRunner(args)._prepare_args(
+                SimpleNamespace(__version__="2.7.1")
+            )
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_full_activation_checkpoint_is_allowed(self):
+        """Feature: Full activation checkpoint dry-run.
+
+        Description: Enable full per-layer activation recomputation.
+        Expectation: Validation accepts the supported checkpoint mode.
+        """
+        args = HyperTrainerConfig()
+        args.train.accelerator.dp_shard = 1
+        args.train.dry_run.world_size = 1
+        args.train.gradient_checkpointing.activation_checkpoint = "full"
+        prepared = TorchDryRunRunner(args)._prepare_args(
+            SimpleNamespace(__version__="2.7.1")
+        )
+        self.assertEqual(
+            prepared.train.gradient_checkpointing.activation_checkpoint,
+            "full",
+        )
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_selective_activation_checkpoint_is_rejected(self):
+        """Feature: Selective activation checkpoint validation.
+
+        Description: Enable selective activation recomputation.
+        Expectation: Validation fails until selective policies are supported.
+        """
+        args = HyperTrainerConfig()
+        args.train.gradient_checkpointing.activation_checkpoint = "selective"
+        with self.assertRaisesRegex(NotImplementedError, "full activation"):
+            TorchDryRunRunner(args)._prepare_args(
+                SimpleNamespace(__version__="2.7.1")
+            )
+
+
+class TestDryRunTrainerIntegration(unittest.TestCase):
+    """BaseTrainer keeps shape setup but skips checkpoint tensor loading."""
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_post_parallelize_skips_weights_during_dry_run(self):
+        """Feature: Dry-run model materialization.
+
+        Description: Post-process a meta model with a configured weights path.
+        Expectation: Fake shards are materialized without loading checkpoint tensors.
+        """
+        trainer = BaseTrainer.__new__(BaseTrainer)
+        trainer.args = SimpleNamespace(
+            train=SimpleNamespace(
+                init_device="meta",
+                dry_run=SimpleNamespace(enabled=True),
+            ),
+            model=SimpleNamespace(weights_path="/not/read/checkpoint"),
+        )
+        trainer.model = MagicMock()
+
+        with patch.object(trainer, "_materialize_and_init_shards") as materialize, \
+             patch.object(trainer, "_load_weights") as load_weights, \
+             patch.object(trainer, "_maybe_downcast_frozen_params") as downcast, \
+             patch.object(trainer, "_maybe_cast_trainable_params") as cast:
+            trainer._post_parallelize()
+
+        materialize.assert_called_once_with()
+        load_weights.assert_not_called()
+        downcast.assert_called_once_with()
+        cast.assert_called_once_with()
+        trainer.model.train.assert_called_once_with()
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_torch_device_type_falls_back_to_cuda_without_torch_npu(self):
+        """Feature: Torch device-type discovery.
+
+        Description: Query the platform while the torch.npu extension is absent.
+        Expectation: CUDA is selected without accessing a missing NPU attribute.
+        """
+        had_npu = hasattr(torch, "npu")
+        saved_npu = getattr(torch, "npu", None)
+        if had_npu:
+            delattr(torch, "npu")
+        try:
+            actual = TorchPlatform().device_type()
+        finally:
+            if had_npu:
+                torch.npu = saved_npu
+        self.assertEqual(actual, "cuda", (
+            f"Expected CUDA fallback without torch.npu, got {actual}"
+        ))
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_torch_op_overload_name_is_canonical(self):
+        """Feature: Torch operator-name normalization.
+
+        Description: Resolve the name of an in-place optimizer overload.
+        Expectation: The canonical YAML registry name excludes overload suffixes.
+        """
+        actual = TorchPlatform.get_op_name(torch.ops.aten.lerp_.Scalar)
+        self.assertEqual(actual, "lerp_", (
+            f"Expected canonical overload name 'lerp_', got {actual!r}"
+        ))
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_non_torch_backend_fails_before_distributed_setup(self):
+        """Feature: Dry-run backend validation.
+
+        Description: Start the Torch runner with the MindSpore backend configured.
+        Expectation: The error report identifies the backend before process-group setup.
+        """
+        with tempfile.TemporaryDirectory() as output_dir:
+            args = HyperTrainerConfig()
+            args.train.backend = "mindspore"
+            args.train.dry_run.output_dir = output_dir
+            with self.assertRaisesRegex(RuntimeError, "supports train.backend='torch'"):
+                TorchDryRunRunner(args).run()
+            with open(os.path.join(output_dir, "rank_0.json"), encoding="utf-8") as report_file:
+                report = json.load(report_file)
+
+        self.assertEqual(report["status"], "error", f"Unexpected report: {report}")
+        self.assertEqual(
+            report["error"]["type"],
+            "NotImplementedError",
+            f"Unexpected error report: {report}",
+        )
+        self.assertFalse(torch.distributed.is_initialized(), (
+            "Unsupported backend unexpectedly initialized a process group"
+        ))
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_error_report_write_failure_preserves_original_error(self):
+        """Feature: Dry-run error reporting.
+
+        Description: Fail both execution and the fallback report writer.
+        Expectation: The original execution error is preserved and the I/O error is logged.
+        """
+        args = HyperTrainerConfig()
+        args.train.backend = "mindspore"
+        with patch(
+                "hyper_parallel.platform.torch.dry_run.write_memory_report",
+                side_effect=OSError("disk full"),
+        ), self.assertLogs(
+                "hyper_parallel.platform.torch.dry_run", level="WARNING"
+        ) as captured:
+            with self.assertRaisesRegex(RuntimeError, "supports train.backend='torch'"):
+                TorchDryRunRunner(args).run()
+
+        self.assertTrue(any(
+            "disk full" in message for message in captured.output
+        ), f"Expected report-write diagnostic, got {captured.output}")
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_existing_process_group_is_rejected_and_preserved(self):
+        """Feature: Dry-run process-group ownership.
+
+        Description: Invoke the runner while a caller-owned process group exists.
+        Expectation: The runner rejects the call and leaves the existing group intact.
+        """
+        TorchPlatform.init_dry_run_process_group(world_size=1, rank=0)
+        try:
+            with tempfile.TemporaryDirectory() as output_dir:
+                args = HyperTrainerConfig()
+                args.train.dry_run.output_dir = output_dir
+                with self.assertRaisesRegex(RuntimeError, "before a real or fake"):
+                    TorchDryRunRunner(args).run()
+            self.assertTrue(torch.distributed.is_initialized(), (
+                "Runner destroyed the caller's existing process group"
+            ))
+        finally:
+            torch.distributed.destroy_process_group()
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_parallelize_error_writes_error_report_and_cleans_process_group(self):
+        """Feature: Dry-run failure cleanup.
+
+        Description: Run a model spec without the required parallelization callback.
+        Expectation: An error report is written and the fake process group is destroyed.
+        """
+        spec_name = "test_tiny_dry_run_without_parallelize"
+        register_spec(
+            spec_name,
+            ModelSpec(name=spec_name, build_model_fn=_build_tiny_model),
+        )
+        try:
+            with tempfile.TemporaryDirectory() as output_dir:
+                args = HyperTrainerConfig()
+                args.model.name = spec_name
+                args.train.accelerator.dp_shard = 2
+                args.train.dry_run.enabled = True
+                args.train.dry_run.world_size = 2
+                args.train.dry_run.output_dir = output_dir
+
+                with self.assertRaisesRegex(RuntimeError, "must define parallelize_fn"):
+                    TorchDryRunRunner(args).run()
+                with open(os.path.join(output_dir, "rank_0.json"), encoding="utf-8") as report_file:
+                    report = json.load(report_file)
+        finally:
+            _SPEC_REGISTRY.pop(spec_name, None)
+
+        self.assertEqual(report["status"], "error", f"Unexpected report: {report}")
+        self.assertEqual(
+            report["stage"], "parallelize", f"Unexpected error stage: {report}"
+        )
+        self.assertFalse(torch.distributed.is_initialized(), (
+            "Dry-run failure leaked its fake process group"
+        ))
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_fake_fsdp_step_runs_on_available_simulation_device(self):
+        """Feature: End-to-end FSDP dry-run.
+
+        Description: Execute world-size one and two fake training steps with memory tracking.
+        Expectation: Reports contain sharded memory, operator lifetimes, and clean global state.
+        """
+        # This end-to-end scenario intentionally keeps setup and cross-report
+        # invariants together so cleanup is covered by one try/finally scope.
+        # lizard forgives(NLOC, CCN)
+        spec_name = "test_tiny_dry_run_fsdp"
+        register_spec(
+            spec_name,
+            ModelSpec(
+                name=spec_name,
+                build_model_fn=_build_tiny_model,
+                parallelize_fn=_parallelize_tiny_model,
+            ),
+        )
+        try:
+            reports = []
+            deterministic_before = torch.are_deterministic_algorithms_enabled()
+            deterministic_env_names = (
+                "ASCEND_LAUNCH_BLOCKING",
+                "CUDA_LAUNCH_BLOCKING",
+                "CUBLAS_WORKSPACE_CONFIG",
+                "FLASH_ATTENTION_DETERMINISTIC",
+                "HCCL_DETERMINISTIC",
+                "PYTHONHASHSEED",
+            )
+            deterministic_env_before = {
+                name: os.environ.get(name) for name in deterministic_env_names
+            }
+            with tempfile.TemporaryDirectory() as output_dir:
+                args = HyperTrainerConfig()
+                args.model.name = spec_name
+                args.data.max_seq_len = 8
+                args.train.micro_batch_size = 2
+                args.train.global_batch_size = 4
+                args.train.init_device = "cpu"
+                args.train.accelerator.dp_shard = 2
+                args.train.accelerator.comm_fusion = True
+                args.train.mixed_precision.enabled = True
+                args.train.mixed_precision.param_dtype = "bfloat16"
+                args.train.mixed_precision.reduce_dtype = "float32"
+                args.train.optimizer.foreach = False
+                args.train.optimizer.max_grad_norm = 0
+                args.train.debug.deterministic = True
+                args.train.dry_run.enabled = True
+                args.train.dry_run.world_size = 2
+                args.train.dry_run.device_type = "npu"
+                args.train.dry_run.output_dir = output_dir
+
+                args.train.accelerator.dp_shard = 1
+                args.train.global_batch_size = 2
+                args.train.dry_run.world_size = 1
+                args.train.dry_run.rank = 0
+                world_one_path = TorchDryRunRunner(args).run()
+                with open(world_one_path, encoding="utf-8") as report_file:
+                    world_one_report = json.load(report_file)
+
+                args.train.accelerator.dp_shard = 2
+                args.train.global_batch_size = 4
+                args.train.dry_run.world_size = 2
+                for rank in (0, 1):
+                    args.train.dry_run.rank = rank
+                    report_path = TorchDryRunRunner(args).run()
+                    with open(report_path, encoding="utf-8") as report_file:
+                        reports.append(json.load(report_file))
+
+                args.train.dry_run.rank = 0
+                args.train.accelerator.reshard_after_forward = False
+                args.train.mixed_precision.enabled = False
+                fp32_report_path = TorchDryRunRunner(args).run()
+                with open(fp32_report_path, encoding="utf-8") as report_file:
+                    fp32_no_reshard_report = json.load(report_file)
+                fp32_csv_path = os.path.splitext(fp32_report_path)[0] + "_memory.csv"
+                with open(fp32_csv_path, encoding="utf-8", newline="") as report_file:
+                    fp32_csv_rows = list(csv.DictReader(report_file))
+        finally:
+            _SPEC_REGISTRY.pop(spec_name, None)
+
+        npu_handle = getattr(torch, "npu", None)
+        expected_simulation_device = (
+            "npu"
+            if npu_handle is not None and npu_handle.is_available()
+            else "cpu"
+        )
+        for rank, report in enumerate(reports):
+            self.assertEqual(report["status"], "ok", (
+                f"Expected successful rank {rank} report, got {report}"
+            ))
+            self.assertGreater(report["summary"]["peak_bytes"], 0, (
+                f"Expected a positive fake-device peak, got {report['summary']}"
+            ))
+            breakdown = report["summary"]["peak_breakdown_bytes"]
+            self.assertIn("Parameter", breakdown, f"Missing Parameter: {breakdown}")
+            self.assertIn("Activation", breakdown, f"Missing Activation: {breakdown}")
+            self.assertIn("Gradient", breakdown, f"Missing Gradient: {breakdown}")
+            current_breakdown = report["summary"]["current_breakdown_bytes"]
+            self.assertGreater(current_breakdown.get("Parameter", 0), 0, (
+                f"Expected a resident FSDP parameter shard, got {current_breakdown}"
+            ))
+            self.assertGreater(current_breakdown.get("Optstate", 0), 0, (
+                f"Expected AdamW state after the optimizer step, got {current_breakdown}"
+            ))
+            self.assertGreater(
+                report["summary"]["peak_bytes"],
+                current_breakdown["Parameter"],
+                f"Expected all-gather/step peak above resident shard: {report['summary']}",
+            )
+            persistent_activation_bytes = sum(
+                block["size"]
+                for block in report["memory_blocks"]
+                if block["type"] == "Activation" and block["is_persistent"]
+            )
+            self.assertLessEqual(
+                persistent_activation_bytes,
+                current_breakdown.get("Activation", 0),
+                "Operator output lifetimes must not retain released activations: "
+                f"persistent={persistent_activation_bytes}, current={current_breakdown}",
+            )
+            persistent_output_bytes = sum(
+                block["size"]
+                for block in report["memory_blocks"]
+                if block["is_persistent"]
+            )
+            self.assertLessEqual(
+                persistent_output_bytes,
+                report["summary"]["current_bytes"],
+                "Persistent operator outputs must fit in tracker current memory: "
+                f"persistent={persistent_output_bytes}, summary={report['summary']}",
+            )
+            memory_changes = {}
+            for block in report["memory_blocks"]:
+                start = block["start_time_stamp"]
+                memory_changes[start] = memory_changes.get(start, 0) + block["size"]
+                if not block["is_persistent"]:
+                    end = block["end_time_stamp"]
+                    memory_changes[end] = memory_changes.get(end, 0) - block["size"]
+            logical_current = 0
+            logical_peak = 0
+            for task_index in sorted(memory_changes):
+                logical_current += memory_changes[task_index]
+                logical_peak = max(logical_peak, logical_current)
+            self.assertLessEqual(
+                logical_peak,
+                report["summary"]["peak_bytes"],
+                "Operator lifetime peak must fit in the MemTracker peak: "
+                f"lifetime={logical_peak}, summary={report['summary']}",
+            )
+            self.assertEqual(
+                report["metadata"]["parallel"]["dp_shard"],
+                2,
+                f"Unexpected topology metadata: {report['metadata']}",
+            )
+            self.assertEqual(
+                report["metadata"]["rank"], rank,
+                f"Unexpected rank metadata: {report['metadata']}",
+            )
+            self.assertEqual(
+                report["metadata"]["device_type"], "npu",
+                f"Unexpected target device: {report['metadata']}",
+            )
+            self.assertEqual(
+                report["metadata"]["simulation_device_type"],
+                expected_simulation_device,
+                f"Unexpected simulation device: {report['metadata']}",
+            )
+            has_cpu_fallback_caveat = any(
+                "simulated with cpu FakeTensors" in limitation
+                for limitation in report["limitations"]
+            )
+            self.assertEqual(
+                has_cpu_fallback_caveat,
+                expected_simulation_device == "cpu",
+                f"Unexpected CPU fallback caveat: {report['limitations']}",
+            )
+
+        world_one_parameter = world_one_report["summary"]["current_breakdown_bytes"]["Parameter"]
+        world_two_parameter = reports[0]["summary"]["current_breakdown_bytes"]["Parameter"]
+        self.assertEqual(world_one_parameter, 2 * world_two_parameter, (
+            "Expected FSDP2 local parameter bytes to be half of world-size=1, "
+            f"got world1={world_one_parameter}, world2={world_two_parameter}"
+        ))
+        self.assertEqual(
+            fp32_no_reshard_report["status"],
+            "ok",
+            f"Expected fp32/no-reshard success, got {fp32_no_reshard_report}",
+        )
+        self.assertFalse(
+            fp32_no_reshard_report["metadata"]["reshard_after_forward"],
+            f"Expected no-reshard metadata, got {fp32_no_reshard_report['metadata']}",
+        )
+        self.assertGreater(
+            fp32_no_reshard_report["summary"]["current_breakdown_bytes"].get("Parameter", 0),
+            0,
+            f"Expected resident fp32 parameter shard, got {fp32_no_reshard_report['summary']}",
+        )
+        memory_blocks = fp32_no_reshard_report["memory_blocks"]
+        self.assertGreater(len(memory_blocks), 0, "Expected operator storage records")
+        self.assertTrue(any(
+            "test_dry_run.py" in block["python_stack"]
+            for block in memory_blocks
+        ), "Expected live model Python frames in operator records")
+        self.assertTrue(any(
+            row["node_name"] and row["device_addr"].startswith("0x")
+            for row in fp32_csv_rows
+        ), f"Expected logical memory-block CSV rows, got {fp32_csv_rows[:5]}")
+        self.assertEqual(min(
+            int(row["start_time_stamp"]) for row in fp32_csv_rows
+        ), 0, "Logical memory-block timestamps did not start at zero")
+        self.assertNotIn("record_type", fp32_csv_rows[0], (
+            f"CSV retained the old summary/operator schema: {fp32_csv_rows[0]}"
+        ))
+        self.assertFalse(torch.distributed.is_initialized(), (
+            "Successful dry-runs leaked the fake process group"
+        ))
+        self.assertEqual(
+            torch.are_deterministic_algorithms_enabled(),
+            deterministic_before,
+            "Dry-run changed the caller's deterministic-algorithm setting",
+        )
+        deterministic_env_after = {
+            name: os.environ.get(name) for name in deterministic_env_names
+        }
+        self.assertEqual(
+            deterministic_env_after,
+            deterministic_env_before,
+            "Dry-run changed deterministic environment variables: "
+            f"before={deterministic_env_before}, after={deterministic_env_after}",
+        )
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_zero_copy_disabled_preserves_normal_fsdp_storage_path(self):
+        """Feature: FSDP zero-copy configuration.
+
+        Description: Run dry-run with communication-fusion zero-copy disabled.
+        Expectation: No flat parameter buffer is created and resident parameters remain tracked.
+        """
+        spec_name = "test_tiny_dry_run_no_zero_copy"
+        register_spec(
+            spec_name,
+            ModelSpec(
+                name=spec_name,
+                build_model_fn=_build_tiny_model,
+                parallelize_fn=_parallelize_tiny_model_no_zero_copy,
+            ),
+        )
+        flat_buffer_calls = []
+        original_init_flat_buffer = HSDPParamGroup._init_flat_param_buffer
+
+        def _track_flat_buffer_init(param_group: HSDPParamGroup) -> None:
+            flat_buffer_calls.append(param_group.enable_zero_copy)
+            original_init_flat_buffer(param_group)
+
+        try:
+            with tempfile.TemporaryDirectory() as output_dir:
+                args = HyperTrainerConfig()
+                args.model.name = spec_name
+                args.data.max_seq_len = 8
+                args.train.micro_batch_size = 2
+                args.train.global_batch_size = 4
+                args.train.init_device = "cpu"
+                args.train.accelerator.dp_shard = 2
+                args.train.optimizer.foreach = False
+                args.train.optimizer.max_grad_norm = 0
+                args.train.dry_run.enabled = True
+                args.train.dry_run.world_size = 2
+                args.train.dry_run.output_dir = output_dir
+
+                with patch.object(
+                        HSDPParamGroup,
+                        "_init_flat_param_buffer",
+                        new=_track_flat_buffer_init,
+                ):
+                    report_path = TorchDryRunRunner(args).run()
+                with open(report_path, encoding="utf-8") as report_file:
+                    report = json.load(report_file)
+        finally:
+            _SPEC_REGISTRY.pop(spec_name, None)
+
+        self.assertEqual(report["status"], "ok", f"Unexpected report: {report}")
+        self.assertEqual(flat_buffer_calls, [], (
+            "Dry-run initialized a flat parameter buffer even though "
+            "comm_fusion_zero_copy=False"
+        ))
+        self.assertGreater(
+            report["summary"]["current_breakdown_bytes"].get("Parameter", 0),
+            0,
+            f"Expected tracked resident parameters, got {report['summary']}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ut/platform/torch/test_platform.py
+++ b/tests/ut/platform/torch/test_platform.py
@@ -27,13 +27,14 @@ from types import SimpleNamespace
 import numpy as np
 import torch
 
+from tests.common.mark_utils import arg_mark
 from hyper_parallel.platform.torch.platform import TorchPlatform
 from hyper_parallel.platform.torch.dtensor import DTensorBase
 
 
 class TestTorchPlatformCore(unittest.TestCase):
     """Unit tests for TorchPlatform core functionality.
-    
+
     Tests cover device and distributed environment management,
     distributed communication primitives, parameter management,
     and tensor operations.
@@ -41,7 +42,7 @@ class TestTorchPlatformCore(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures before each test method.
-        
+
         Configures the environment and initializes the TorchPlatform instance.
         """
         os.environ["HYPER_PARALLEL_PLATFORM"] = "torch"
@@ -111,33 +112,36 @@ class TestTorchPlatformCore(unittest.TestCase):
             [(fake_dtensor, "local-shard"), (fake_dtensor._local_tensor, "local-shard")],
         )
 
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
     @mock.patch('hyper_parallel.platform.torch.platform.TorchPlatform.get_device_handle')
     def test_device_type(self, mock_get_device_handle):
-        """Test device type detection logic.
-        
-        Verifies that the platform correctly identifies different device types
-        (NPU and CUDA) based on the device handle.
-        
+        """Feature: Torch device-type detection.
+
+        Description: Resolve NPU and CUDA handles, including a wheel without torch.npu.
+        Expectation: Handles map to the correct backend and missing NPU support falls back to CUDA.
+
         Args:
             mock_get_device_handle: Mock for the get_device_handle method.
         """
         # Test NPU device
-        mock_get_device_handle.return_value = torch.npu
-        self.assertEqual(self.platform.device_type(), "npu")
+        fake_npu = object()
+        with patch.object(torch, "npu", fake_npu, create=True):
+            mock_get_device_handle.return_value = fake_npu
+            self.assertEqual(self.platform.device_type(), "npu")
 
         # Test CUDA device
         mock_get_device_handle.return_value = torch.cuda
         self.assertEqual(self.platform.device_type(), "cuda")
 
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
     @mock.patch('hyper_parallel.platform.torch.platform._get_default_group')
     @mock.patch('torch.distributed.init_process_group')
     def test_init_process_group(self, mock_init, mock_get_default):
-        """Test distributed process group initialization logic.
-        
-        Verifies that the platform properly initializes the distributed
-        environment when not already initialized, and avoids reinitialization
-        when already initialized.
-        
+        """Feature: Torch process-group initialization.
+
+        Description: Initialize with and without an existing default process group.
+        Expectation: Initialization occurs exactly once and never replaces an existing group.
+
         Args:
             mock_init: Mock for torch.distributed.init_process_group.
             mock_get_default: Mock for _get_default_group function.
@@ -155,14 +159,15 @@ class TestTorchPlatformCore(unittest.TestCase):
         TorchPlatform.init_process_group()
         mock_init.assert_not_called()
 
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
     @mock.patch('hyper_parallel.platform.torch.platform.TorchPlatform.get_rank')
     @mock.patch('torch.distributed.new_group')
     def test_split_group(self, mock_new_group, mock_get_rank):
-        """Test process group splitting logic.
-        
-        Verifies that the platform correctly splits the default process group
-        into subgroups based on provided rank lists.
-        
+        """Feature: Torch process-group splitting.
+
+        Description: Split a logical rank list while no cached groups exist.
+        Expectation: Every subgroup is created and the current rank receives its group.
+
         Args:
             mock_new_group: Mock for torch.distributed.new_group.
             mock_get_rank: Mock for TorchPlatform.get_rank.
@@ -172,7 +177,8 @@ class TestTorchPlatformCore(unittest.TestCase):
         mock_new_group.return_value = mock_group
 
         split_ranks = [[0, 1], [2, 3], [4, 5], [6, 7]]
-        result = TorchPlatform.split_group(split_ranks=split_ranks)
+        with patch.object(TorchPlatform, "get_created_group", return_value=None):
+            result = TorchPlatform.split_group(split_ranks=split_ranks)
 
         self.assertEqual(mock_new_group.call_count, 4)
         self.assertEqual(result, mock_group)
@@ -184,13 +190,14 @@ class TestTorchPlatformCore(unittest.TestCase):
         with self.assertRaises(ValueError):
             TorchPlatform.split_group(split_ranks=None)
 
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
     @mock.patch('torch.distributed.nn.functional.all_gather')
     def test_differentiable_all_gather_concat(self, mock_all_gather):
-        """Test differentiable all_gather and concatenation logic.
-        
-        Verifies that the platform correctly performs all_gather operation
-        and concatenates results along the specified dimension.
-        
+        """Feature: Differentiable all-gather.
+
+        Description: Gather local tensors and concatenate the returned shards.
+        Expectation: The output shape and values follow the requested concatenation dimension.
+
         Args:
             mock_all_gather: Mock for torch.distributed.nn.functional.all_gather.
         """
@@ -209,13 +216,14 @@ class TestTorchPlatformCore(unittest.TestCase):
         expected = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [7.0, 8.0]])
         self.assertTrue(torch.allclose(result, expected))
 
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
     @mock.patch('torch.distributed.nn.functional.all_reduce')
     def test_differentiable_all_reduce(self, mock_all_reduce):
-        """Test differentiable all_reduce logic.
-        
-        Verifies that the platform correctly performs all_reduce operation
-        with the specified reduction operation.
-        
+        """Feature: Differentiable all-reduce.
+
+        Description: Reduce a tensor with the requested logical operation.
+        Expectation: The operation and process group are forwarded to Torch correctly.
+
         Args:
             mock_all_reduce: Mock for torch.distributed.nn.functional.all_reduce.
         """
@@ -227,15 +235,16 @@ class TestTorchPlatformCore(unittest.TestCase):
         result = TorchPlatform.differentiable_all_reduce(tensor, op='sum', group=None)
         self.assertTrue(torch.allclose(result, mock_result))
 
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
     @mock.patch('torch.distributed.nn.functional.reduce_scatter')
     @mock.patch('torch.chunk')
     @mock.patch('torch.empty')
     def test_differentiable_reduce_scatter(self, mock_empty, mock_chunk, mock_reduce_scatter):
-        """Test differentiable reduce_scatter logic.
-        
-        Verifies that the platform correctly performs reduce_scatter operation
-        with both sum and average reduction operations.
-        
+        """Feature: Differentiable reduce-scatter.
+
+        Description: Reduce and scatter input chunks for sum and average operations.
+        Expectation: Torch receives the correct chunks, group, and reduction mode.
+
         Args:
             mock_empty: Mock for torch.empty.
             mock_chunk: Mock for torch.chunk.
@@ -264,13 +273,14 @@ class TestTorchPlatformCore(unittest.TestCase):
         expected_avg = torch.tensor([3.0, 7.0])  # sum / 2
         self.assertTrue(torch.allclose(result, expected_avg))
 
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
     @mock.patch('torch.distributed.all_reduce')
     def test_all_reduce_non_contiguous(self, mock_all_reduce):
-        """Test all_reduce handling of non-contiguous tensors.
-        
-        Verifies that the platform correctly handles non-contiguous tensors
-        by converting them to contiguous before performing all_reduce.
-        
+        """Feature: Non-contiguous all-reduce.
+
+        Description: Reduce a non-contiguous tensor through the platform wrapper.
+        Expectation: A contiguous buffer is reduced and copied back to the original view.
+
         Args:
             mock_all_reduce: Mock for torch.distributed.all_reduce.
         """
@@ -442,11 +452,12 @@ class TestTorchPlatformCore(unittest.TestCase):
         self.assertTrue(torch.allclose(output_buffer, torch.ones_like(output_buffer)))
         self.assertTrue(torch.allclose(x.grad, torch.zeros_like(x)))
 
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
     def test_search_parameter_by_name(self):
-        """Test parameter search by name logic.
-        
-        Verifies that the platform correctly searches for parameters
-        in nested model structures using dot notation.
+        """Feature: Parameter lookup.
+
+        Description: Search nested model parameters using a dotted name.
+        Expectation: Existing parameters are returned and missing paths are handled consistently.
         """
 
         # Create nested model structure
@@ -479,11 +490,12 @@ class TestTorchPlatformCore(unittest.TestCase):
         result = TorchPlatform.search_parameter_by_name(model, "non_existent")
         self.assertIsNone(result)
 
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
     def test_update_parameter_by_name(self):
-        """Test parameter update by name logic.
-        
-        Verifies that the platform correctly updates model parameters
-        using the result from search_parameter_by_name.
+        """Feature: Parameter replacement.
+
+        Description: Replace a nested model parameter selected by dotted name.
+        Expectation: The target parameter is updated without changing unrelated parameters.
         """
 
         class SimpleModel(torch.nn.Module):
@@ -501,15 +513,16 @@ class TestTorchPlatformCore(unittest.TestCase):
         self.assertIsNot(model.weight, old_param)
         self.assertIs(model.weight, new_param)
 
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
     @mock.patch('hyper_parallel.platform.torch.platform.Parameter')
     @mock.patch('hyper_parallel.core.dtensor.dtensor.DTensor.from_local')
     @mock.patch('hyper_parallel.core.dtensor.layout._get_slice_tensor_by_layout')
     def test_set_layout_into_parameter(self, mock_get_slice, mock_dtensor_from_local, mock_parameter):
-        """Test parameter layout setting logic.
-        
-        Verifies that the platform correctly sets tensor layouts into parameters
-        and handles error cases appropriately.
-        
+        """Feature: Parameter layout assignment.
+
+        Description: Apply a DTensor layout to a parameter and exercise invalid inputs.
+        Expectation: Valid layouts create the expected local shard and invalid layouts fail clearly.
+
         Args:
             mock_get_slice: Mock for _get_slice_tensor_by_layout function.
             mock_dtensor_from_local: Mock for DTensor.from_local method.
@@ -540,11 +553,12 @@ class TestTorchPlatformCore(unittest.TestCase):
 
             TorchPlatform.set_layout_into_parameter(MagicMock(spec=DTensor), mock_layout)
 
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
     def test_cast_fp_tensor(self):
-        """Test floating-point tensor type casting logic.
-        
-        Verifies that the platform correctly casts tensors to different
-        floating-point types and handles edge cases.
+        """Feature: Floating-point tensor casting.
+
+        Description: Cast floating and non-floating tensor values through the platform helper.
+        Expectation: Eligible tensors change dtype and ineligible values remain unchanged.
         """
         # Test different floating point type conversions
         tensor32 = torch.randn(2, 2, dtype=torch.float32)
@@ -565,11 +579,12 @@ class TestTorchPlatformCore(unittest.TestCase):
         result = self.platform.cast_fp_tensor(torch.float32, non_tensor)
         self.assertIs(result, non_tensor)  # Should return the same object
 
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
     def test_apply_to_tensors(self):
-        """Test recursive tensor processing logic.
-        
-        Verifies that the platform correctly applies functions recursively
-        to tensors within nested data structures.
+        """Feature: Recursive tensor transformation.
+
+        Description: Apply a function to tensors nested in common Python containers.
+        Expectation: Every tensor is transformed while container structure and scalar values remain intact.
         """
         # Create test data with different container types
         test_data = {

--- a/tests/ut/trainer/test_config.py
+++ b/tests/ut/trainer/test_config.py
@@ -43,9 +43,11 @@ from typing import Optional
 
 os.environ["HYPER_PARALLEL_PLATFORM"] = "torch"
 
+from tests.common.mark_utils import arg_mark
 from hyper_parallel.trainer.config import (
     AcceleratorConfig,
     DataConfig,
+    DryRunConfig,
     HyperTrainerConfig,
     ModelConfig,
     MonitorConfig,
@@ -225,8 +227,13 @@ class TestHyperTrainerConfigPostInit(unittest.TestCase):
             f"train_steps must mirror train.max_steps, got {cfg.train_steps}"
         ))
 
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
     def test_defaults_are_strict_three_tier(self):
-        """Default construction holds the three top-level slots: model/data/train."""
+        """Feature: Trainer configuration defaults.
+
+        Description: Construct the strict three-tier configuration without overrides.
+        Expectation: Nested sections include a disabled dry-run configuration with documented defaults.
+        """
         cfg = HyperTrainerConfig()
         self.assertIsInstance(cfg.model, ModelConfig)
         self.assertIsInstance(cfg.data, DataConfig)
@@ -234,6 +241,29 @@ class TestHyperTrainerConfigPostInit(unittest.TestCase):
         self.assertIsInstance(cfg.train.accelerator, AcceleratorConfig)
         self.assertEqual(cfg.train.accelerator.moe_token_dispatcher_type, "all_to_all")
         self.assertEqual(cfg.train.accelerator.npu_nums_per_device, 8)
+        self.assertIsInstance(cfg.train.dry_run, DryRunConfig)
+        self.assertFalse(cfg.train.dry_run.enabled)
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_dry_run_rejects_invalid_values(self):
+        """Feature: Dry-run configuration validation.
+
+        Description: Construct dry-run configurations with invalid boundary values.
+        Expectation: Every invalid value raises ValueError during construction.
+        """
+        invalid_kwargs = (
+            {"world_size": 0},
+            {"rank": -1},
+            {"device_type": "cpu"},
+            {"output_dir": ""},
+            {"module_depth": -1},
+            {"top_modules": -1},
+            {"device_memory_gib": 0},
+        )
+        for kwargs in invalid_kwargs:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaises(ValueError):
+                    DryRunConfig(**kwargs)
 
     def test_monitor_defaults(self):
         """Monitor scalar-output config defaults are disabled and non-invasive."""
@@ -341,6 +371,43 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(cfg.train.accelerator.ep, 4)
         self.assertEqual(cfg.train.accelerator.moe_token_dispatcher_type, "deredundency")
         self.assertEqual(cfg.train.accelerator.npu_nums_per_device, 2)
+
+    @arg_mark(plat_marks=["cpu_linux"], level_mark="level0", card_mark="allcards", essential_mark="essential")
+    def test_dry_run_yaml_plus_cli_override(self):
+        """Feature: Dry-run configuration parsing.
+
+        Description: Parse nested YAML fields and override selected values from the CLI.
+        Expectation: CLI values take precedence while untouched YAML values remain intact.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            yaml_path = os.path.join(tmp, "cfg.yaml")
+            self._write_yaml(
+                """
+                train:
+                  dry_run:
+                    enabled: false
+                    world_size: 4
+                    rank: 1
+                    device_type: npu
+                    output_dir: reports
+                """,
+                yaml_path,
+            )
+            sys.argv = [
+                "prog",
+                yaml_path,
+                "--train.dry_run.enabled=true",
+                "--train.dry_run.rank=3",
+                "--train.dry_run.device_memory_gib=64.0",
+            ]
+            cfg = parse_args(HyperTrainerConfig)
+
+        self.assertTrue(cfg.train.dry_run.enabled)
+        self.assertEqual(cfg.train.dry_run.world_size, 4)
+        self.assertEqual(cfg.train.dry_run.rank, 3)
+        self.assertEqual(cfg.train.dry_run.device_type, "npu")
+        self.assertEqual(cfg.train.dry_run.output_dir, "reports")
+        self.assertEqual(cfg.train.dry_run.device_memory_gib, 64.0)
 
     def test_invalid_bool_string_in_cli_raises(self):
         """An unrecognised bool alias on a bool field must surface a ValueError.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

----

**What does this PR do / why do we need it**:

本 PR 为 Torch Trainer 新增 HyperDryRun，用于在不执行真实设备计算的情况下，
模拟分布式训练步骤并估算目标 rank 的逻辑张量显存。

现有静态公式难以覆盖 FSDP 参数聚合、激活、梯度、优化器状态及重计算产生的动态峰值。
本功能复用模型构建与 `parallelize_fn`，通过 FakeTensor、FakeProcessGroup 和 MemTracker
执行一次逻辑训练步骤，输出可定位到算子的显存生命周期数据。

主要变更：

- 新增 `train.dry_run` 配置及 `scripts/train_lm.py` 一键入口。
- 新增 `TorchDryRunRunner`，支持单进程模拟指定 `world_size` 和 `rank`。
- 支持 FSDP、`reshard_after_forward`、混合精度及 full activation checkpoint。
- selective checkpoint、PP、TP/CP/EP、CPU offload 等未验证组合保持 fail-fast。
- 适配 FakeTensor 下的 DTensor 包装、FSDP flat buffer 和相关算子分发。
- 输出 JSON 分析报告和兼容 `ms_memory_block.csv` 的算子级 CSV。
- CSV 使用从零递增的逻辑时间、512 字节对齐虚拟地址及实时 Python stack。
- `memory_analysis.html` 支持加载 dry-run CSV、生命周期和内存曲线分析。
- 新增设计文档，说明统计口径、支持矩阵、限制、校准结果和后续规划。

本次共变更 17 个文件，新增 7,944 行，删除 107 行。

----

**Which issue(s) this PR fixes**:

Fixes #

----

**Test Plan and Test result：What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

- 相关配置、平台和 dry-run UT：78 passed。
- DTensor、Layout、elementwise 和 FSDP 回归：215 passed。
- `memory_analysis.html` Node.js 行为契约：PASS。
- Pylint、Lizard、测试规范及 `git diff --check`：PASS。
- Qwen 8 层 full activation checkpoint 实跑生成 20,417 条算子记录。
- phase 包含 forward 4,341、backward 11,458、recompute 4,186、optimizer 432。
- 逻辑峰值为 15,067,528,806 bytes，NPU HBM 最大增量约 65 MB，
  退出后恢复基线，未产生约 15 GB 的真实设备分配。
- 按提交者选择，创建 PR 阶段的 UT/ST 门禁均跳过。

----

**Self-checklist**:

- [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
- [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
- [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
- [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
- [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓


<!-- atomgit-backport-meta -->
atomgit_repo: mindspore/hyper-parallel
atomgit_mr: 1059
source_branch: hyper-parallel-dry-run
source_url: https://gitcode.com/mindspore/hyper-parallel/merge_requests/1059
<!-- /atomgit-backport-meta -->
