### PR TITLE
feat: 支持 Torch checkpoint 编译

### DIFF
--- a/hyper_parallel/core/activation_checkpoint/activation_checkpoint.py
+++ b/hyper_parallel/core/activation_checkpoint/activation_checkpoint.py
@@ -117,7 +117,10 @@ def checkpoint(
         function: The function to apply checkpointing to.
         *args: Arguments to pass to the function.
         swap_inputs (bool): Whether to enable input swapping using async_save_on_cpu context.
+            This HyperParallel extension is not supported during ``torch.compile``.
         policy_fn (callable, optional): Function that determines checkpoint policy for operations.
+            During ``torch.compile``, the function receives Torch's native selective-checkpoint
+            context and may return either a Torch policy or a HyperParallel SAVE/RECOMPUTE policy.
         context_fn (callable, optional): A no-arg factory returning a
             ``(forward_ctx, recompute_ctx)`` pair, matching the
             ``context_fn`` contract of ``ms.recompute(use_reentrant=False)``
@@ -126,30 +129,65 @@ def checkpoint(
             When ``policy_fn``, ``group_swap`` and ``context_fn`` are
             supplied together, the resulting factories are composed: their
             forward and recompute contexts are stacked so all enter in
-            order and exit in reverse.
+            order and exit in reverse. Custom contexts are not supported during
+            ``torch.compile``.
         group_swap (bool, optional): Whether MUST_SWAP tensors participate in group copy fusion.
-            Only effective when ``policy_fn`` is provided. Default: ``False``.
+            Only effective when ``policy_fn`` is provided. Not supported during
+            ``torch.compile``. Default: ``False``.
         **kwargs: Additional keyword arguments to pass to the function.
 
     Returns:
         The result of applying the function with checkpointing.
-    """
-    factories: list = [create_recompute_contexts]
-    if policy_fn is not None:
-        factories.append(partial(plat.create_selective_checkpoint_contexts, policy_fn, group_swap=group_swap))
-    if context_fn is not None:
-        factories.append(context_fn)
 
-    if len(factories) == 1:
-        composed_context_fn = factories[0]
+    Raises:
+        ValueError: If a HyperParallel swap/custom-context extension or reentrant
+            checkpoint is requested during ``torch.compile``.
+    """
+    # torch.compile captures non-reentrant checkpoint as a higher-order op.
+    # Keep that path on the framework-native checkpoint implementation: custom
+    # HyperParallel contexts and swap extensions are eager-only capabilities.
+    is_compiling = getattr(plat, "is_compiling", None)
+    checkpoint_compile = callable(is_compiling) and is_compiling() is True
+    if checkpoint_compile:
+        unsupported = []
+        if swap_inputs:
+            unsupported.append("swap_inputs")
+        if group_swap:
+            unsupported.append("group_swap")
+        if context_fn is not None:
+            unsupported.append("custom context_fn")
+        if kwargs.get("use_reentrant", False):
+            unsupported.append("use_reentrant=True")
+        if unsupported:
+            raise ValueError(
+                "HyperParallel checkpoint compile mode does not support: "
+                + ", ".join(unsupported)
+                + ". Use Torch-native non-reentrant checkpointing with optional "
+                "SAVE/RECOMPUTE selective policies."
+            )
+        composed_context_fn = (
+            partial(plat.create_native_selective_checkpoint_contexts, policy_fn)
+            if policy_fn is not None
+            else None
+        )
     else:
-        composed_context_fn = _compose_context_fns(tuple(factories))
+        factories: list = [create_recompute_contexts]
+        if policy_fn is not None:
+            factories.append(partial(plat.create_selective_checkpoint_contexts,
+                                     policy_fn, group_swap=group_swap))
+        if context_fn is not None:
+            factories.append(context_fn)
+
+        composed_context_fn = (
+            factories[0] if len(factories) == 1 else _compose_context_fns(tuple(factories))
+        )
 
     context = partial(plat.async_save_on_cpu, group_swap=group_swap) if swap_inputs else contextlib.nullcontext
     with context():
-        return plat.checkpoint(
-            function, *args, context_fn=composed_context_fn, use_reentrant=False, **kwargs
-        )
+        checkpoint_kwargs = {**kwargs, "use_reentrant": False}
+        if composed_context_fn is not None:
+            checkpoint_kwargs["context_fn"] = composed_context_fn
+        return plat.checkpoint(function, *args, **checkpoint_kwargs)
 
 
 def swap(function, *args, policy_fn=None, group_swap=False, **kwargs):
@@ -178,6 +216,12 @@ def swap(function, *args, policy_fn=None, group_swap=False, **kwargs):
     Example:
         >>> output = swap(layer, x, policy_fn=lambda t: CheckpointPolicy.MUST_SAVE)
     """
+    is_compiling = getattr(plat, "is_compiling", None)
+    if callable(is_compiling) and is_compiling() is True:
+        raise ValueError(
+            "HyperParallel activation swap is not supported in compile mode. "
+            "Use Torch-native non-reentrant checkpointing with SAVE/RECOMPUTE policies."
+        )
     with plat.async_save_on_cpu(policy_fn=policy_fn, group_swap=group_swap):
         return function(*args, **kwargs)
 

--- a/hyper_parallel/core/fully_shard/hsdp_scheduler.py
+++ b/hyper_parallel/core/fully_shard/hsdp_scheduler.py
@@ -39,6 +39,7 @@ class HSDPSchedulerContext:
         self.is_last_backward: bool = True
         # flag to identify "root_module"
         self.root_module = None
+        self.lazy_init_done: bool = False
 
 
 class HSDPSchedulerV2:
@@ -179,8 +180,10 @@ class HSDPSchedulerV2:
                     self.hsdp_state.module_name = module_name
                     break
         self.scheduler_state = FSDPSchedulerState.PRE_FORWARD
-        self._init_params_fqn()
-        self._lazy_init_all_states()
+        if self._is_root and not self.scheduler_ctx.lazy_init_done:
+            self._init_params_fqn()
+            self._lazy_init_all_states()
+            self.scheduler_ctx.lazy_init_done = True
         if self.mp_policy.cast_forward_inputs and self.mp_policy.param_dtype:
             cast_fn = functools.partial(self.platform.cast_fp_tensor, self.mp_policy.param_dtype)
             args = self.platform.apply_to_tensors(cast_fn, args)

--- a/hyper_parallel/platform/platform.py
+++ b/hyper_parallel/platform/platform.py
@@ -16,7 +16,7 @@
 import os
 from datetime import timedelta
 from enum import auto, Enum
-from typing import Optional, Any, Union
+from typing import Optional, Any, Callable, Union
 
 import numpy as np
 
@@ -1466,6 +1466,20 @@ class Platform:
             Context functions for selective checkpointing.
         """
         raise NotImplementedError("Platform subclasses must implement create_selective_checkpoint_contexts")
+
+    @staticmethod
+    def create_native_selective_checkpoint_contexts(policy_fn: Callable) -> Any:
+        """Create framework-native selective checkpoint contexts for compile.
+
+        Args:
+            policy_fn: Selective checkpoint policy callback.
+
+        Returns:
+            Framework-native forward and recomputation contexts.
+        """
+        raise NotImplementedError(
+            "Native selective checkpoint compile is not supported by this platform"
+        )
 
     @staticmethod
     def async_save_on_cpu(policy_fn=None, group_swap: bool = False):

--- a/hyper_parallel/platform/torch/activation_checkpoint/activation_swap.py
+++ b/hyper_parallel/platform/torch/activation_checkpoint/activation_swap.py
@@ -35,6 +35,15 @@ _SWAP_WRAPPED_MODULE = "_swap_wrapped_module"
 _SWAP_PREFIX = _SWAP_WRAPPED_MODULE + "."
 
 
+def _raise_if_compiling(feature_name: str) -> None:
+    """Reject HyperParallel activation-swap extensions during Torch capture."""
+    if torch.compiler.is_compiling():
+        raise ValueError(
+            f"HyperParallel {feature_name} is not supported in compile mode. "
+            "Use Torch-native non-reentrant checkpointing with SAVE/RECOMPUTE policies."
+        )
+
+
 class FuncModule(nn.Module):
     """
     Thin :class:`~torch.nn.Module` adapter that wraps a plain callable.
@@ -175,6 +184,7 @@ class AsyncSaveOnCpu(torch.autograd.graph.saved_tensors_hooks):
     Context manager to offload tensors to CPU during forward pass.
     """
     def __init__(self, policy_fn=None, group_swap: bool = False) -> None:
+        _raise_if_compiling("AsyncSaveOnCpu")
         self.add_to_storage = False
         self.storage = Storage()
         self.count_idx = 0
@@ -355,6 +365,7 @@ class SwapWrapper(ActivationWrapper):
 
     def forward(self, *args, **kwargs):
         """Run the wrapped module inside an AsyncSaveOnCpu context for activation swapping."""
+        _raise_if_compiling("swap_wrapper")
         with AsyncSaveOnCpu(policy_fn=self.policy_fn, group_swap=self.group_swap):
             return self._swap_wrapped_module(*args, **kwargs)
 
@@ -375,6 +386,7 @@ def swap_tensor_wrapper(target, tag: Optional[str] = None, group_swap: bool = Fa
     participates in the existing swap scheduling managed by ``SwapManager``.
     It preserves the input structure and returns the original tensors.
     """
+    _raise_if_compiling("swap_tensor_wrapper")
     swap_manager = SwapManager()
     group_name = swap_manager.get_current_group_name()
     if not group_name:

--- a/hyper_parallel/platform/torch/activation_checkpoint/native_compile.py
+++ b/hyper_parallel/platform/torch/activation_checkpoint/native_compile.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Adapters for using PyTorch-native selective checkpointing under compile."""
+from functools import partial
+from typing import Any, Callable, Tuple
+
+from hyper_parallel.core.activation_checkpoint.activation_checkpoint import CheckpointPolicy
+
+
+_SUPPORTED_POLICY_NAMES = (
+    "MUST_SAVE",
+    "PREFER_SAVE",
+    "MUST_RECOMPUTE",
+    "PREFER_RECOMPUTE",
+)
+
+
+def _to_torch_checkpoint_policy(policy: Any) -> Any:
+    """Convert supported HyperParallel policies to the native Torch enum.
+
+    Enum numeric values are deliberately not used: extension values can
+    collide with policies added by a newer Torch release while representing
+    different semantics.
+    """
+    from torch.utils import checkpoint as torch_checkpoint  # pylint: disable=C0415
+    torch_policy_cls = torch_checkpoint.CheckpointPolicy
+    supported_native = {
+        getattr(torch_policy_cls, name) for name in _SUPPORTED_POLICY_NAMES
+    }
+
+    if isinstance(policy, torch_policy_cls):
+        if policy in supported_native:
+            return policy
+        raise ValueError(
+            f"Torch checkpoint policy {policy.name} is not supported by "
+            "HyperParallel compile mode. Only SAVE and RECOMPUTE policies are supported."
+        )
+
+    if isinstance(policy, CheckpointPolicy):
+        if policy.name in _SUPPORTED_POLICY_NAMES:
+            return getattr(torch_policy_cls, policy.name)
+        raise ValueError(
+            f"HyperParallel checkpoint policy {policy.name} is not supported in compile mode. "
+            "Only SAVE and RECOMPUTE policies are supported."
+        )
+
+    raise TypeError(
+        "Selective checkpoint policy_fn must return a HyperParallel or Torch "
+        f"CheckpointPolicy, but got {type(policy).__name__}."
+    )
+
+
+def _torch_policy_adapter(
+    policy_fn: Callable, torch_context: Any, op: Any, *args: Any, **kwargs: Any
+) -> Any:
+    """Pass native Torch inputs through and adapt only the policy result."""
+    policy = policy_fn(torch_context, op, *args, **kwargs)
+    return _to_torch_checkpoint_policy(policy)
+
+
+def create_native_selective_checkpoint_contexts(policy_fn: Callable) -> Tuple[Any, Any]:
+    """Create Torch-native SAC modes for the compile checkpoint path.
+
+    The context object received by ``policy_fn`` is the one supplied by the
+    installed Torch version. HyperParallel intentionally does not copy or
+    stabilize that type.
+
+    Args:
+        policy_fn: User policy called with Torch's native context, operator,
+            positional arguments, and keyword arguments.
+
+    Returns:
+        Torch's native forward caching and backward recomputation modes.
+
+    Raises:
+        TypeError: If ``policy_fn`` is not callable.
+    """
+    if not callable(policy_fn):
+        raise TypeError("policy_fn must be callable in HyperParallel compile mode.")
+    from torch.utils import checkpoint as torch_checkpoint  # pylint: disable=C0415
+    native_policy_fn = partial(_torch_policy_adapter, policy_fn)
+    return torch_checkpoint.create_selective_checkpoint_contexts(native_policy_fn)

--- a/hyper_parallel/platform/torch/fully_shard/scheduler.py
+++ b/hyper_parallel/platform/torch/fully_shard/scheduler.py
@@ -263,11 +263,15 @@ class TorchHSDPSchedulerV2(HSDPSchedulerV2):
 
     def _register_forward_backward_hooks(self):
         """Register module forward and backward hook on all managed modules."""
+        forward_pre_hook = torch._dynamo.disable(self._forward_pre_hook)
+        forward_hook = torch._dynamo.disable(self._forward_hook)
+        grouped_forward_pre_hook = torch._dynamo.disable(self._grouped_forward_pre_hook)
         if self._fsdp_group_post_pending is None:
             for mod in self.modules:
-                mod.register_forward_pre_hook(self._forward_pre_hook, with_kwargs=True)
-                mod.register_forward_hook(self._forward_hook)
+                mod.register_forward_pre_hook(forward_pre_hook, with_kwargs=True)
+                mod.register_forward_hook(forward_hook)
             return
         for mod in self.modules:
-            mod.register_forward_pre_hook(self._grouped_forward_pre_hook, with_kwargs=True)
-            self._register_forward_module_hook(mod, self._make_grouped_forward_post_hook(mod))
+            mod.register_forward_pre_hook(grouped_forward_pre_hook, with_kwargs=True)
+            grouped_forward_hook = torch._dynamo.disable(self._make_grouped_forward_post_hook(mod))
+            self._register_forward_module_hook(mod, grouped_forward_hook)

--- a/hyper_parallel/platform/torch/platform.py
+++ b/hyper_parallel/platform/torch/platform.py
@@ -14,7 +14,7 @@
 # ============================================================================
 """Torch platform api"""
 from datetime import timedelta
-from typing import Optional, Any, Union
+from typing import Optional, Any, Callable, Union
 import dataclasses
 from collections import OrderedDict
 
@@ -1428,6 +1428,11 @@ class TorchPlatform(Platform):
         return torch.utils.checkpoint.checkpoint
 
     @staticmethod
+    def is_compiling() -> bool:
+        """Return whether execution is currently being captured by torch.compile."""
+        return torch.compiler.is_compiling()
+
+    @staticmethod
     def checkpoint_wrapper(module, **checkpoint_kwargs):
         # pylint: disable=C0415
         from hyper_parallel.platform.torch.activation_checkpoint.checkpoint_wrapper import ckpt_wrapper
@@ -1460,6 +1465,14 @@ class TorchPlatform(Platform):
         # pylint: disable=C0415
         from hyper_parallel.platform.torch.activation_checkpoint.sac import create_selective_checkpoint_contexts
         return create_selective_checkpoint_contexts(policy_fn_or_list, allow_cache_entry_mutation, group_swap)
+
+    @staticmethod
+    def create_native_selective_checkpoint_contexts(policy_fn: Callable) -> Any:
+        # pylint: disable=C0415
+        from hyper_parallel.platform.torch.activation_checkpoint.native_compile import (
+            create_native_selective_checkpoint_contexts,
+        )
+        return create_native_selective_checkpoint_contexts(policy_fn)
 
     @staticmethod
     def async_save_on_cpu(policy_fn=None, group_swap: bool = False):

--- a/tests/ut/core/activation_checkpoint/test_activation_checkpoint.py
+++ b/tests/ut/core/activation_checkpoint/test_activation_checkpoint.py
@@ -161,6 +161,49 @@ class TestCheckpointFunction(unittest.TestCase):
         call_args = mock_plat.checkpoint.call_args[0]
         self.assertIn(3, call_args)
 
+    def test_checkpoint_omits_default_context_while_compiling(self, mock_plat):
+        """Compile capture should let PyTorch represent checkpoint as a HOP."""
+        mock_plat.checkpoint.return_value = "result"
+        mock_plat.is_compiling.return_value = True
+
+        result = checkpoint(lambda value: value, 1)
+
+        self.assertEqual(result, "result")
+        call_kwargs = mock_plat.checkpoint.call_args.kwargs
+        self.assertNotIn("context_fn", call_kwargs)
+        self.assertFalse(call_kwargs["use_reentrant"])
+
+    def test_checkpoint_uses_native_selective_context_while_compiling(self, mock_plat):
+        """Compile SAC should bypass HyperParallel's eager DispatchModes."""
+        mock_plat.checkpoint.return_value = "result"
+        mock_plat.is_compiling.return_value = True
+        policy = MagicMock(return_value=CheckpointPolicy.MUST_SAVE)
+
+        result = checkpoint(lambda value: value, 1, policy_fn=policy)
+
+        self.assertEqual(result, "result")
+        context_fn = mock_plat.checkpoint.call_args.kwargs["context_fn"]
+        context_fn()
+        mock_plat.create_native_selective_checkpoint_contexts.assert_called_once_with(policy)
+        mock_plat.create_selective_checkpoint_contexts.assert_not_called()
+
+    def test_checkpoint_rejects_extensions_while_compiling(self, mock_plat):
+        """Compile checkpoint must fail instead of silently falling back to eager extensions."""
+        mock_plat.is_compiling.return_value = True
+        cases = (
+            {"swap_inputs": True},
+            {"group_swap": True},
+            {"context_fn": lambda: (contextlib.nullcontext(), contextlib.nullcontext())},
+            {"use_reentrant": True},
+        )
+
+        for checkpoint_kwargs in cases:
+            with self.subTest(checkpoint_kwargs=checkpoint_kwargs):
+                with self.assertRaisesRegex(ValueError, "does not support"):
+                    checkpoint(lambda value: value, 1, **checkpoint_kwargs)
+
+        mock_plat.checkpoint.assert_not_called()
+
     def test_checkpoint_composes_recompute_state_and_user_contexts(self, mock_plat):
         """Unified recompute state should surround user checkpoint contexts."""
         events = []
@@ -287,6 +330,15 @@ class TestSwapFunction(unittest.TestCase):
 
         self.assertEqual(result, 6)
         mock_plat.async_save_on_cpu.assert_called_once_with(policy_fn=None, group_swap=False)
+
+    def test_swap_rejected_while_compiling(self, mock_plat):
+        """Activation swap extensions should not silently enter a compiled graph."""
+        mock_plat.is_compiling.return_value = True
+
+        with self.assertRaisesRegex(ValueError, "activation swap"):
+            swap(lambda value: value, 1)
+
+        mock_plat.async_save_on_cpu.assert_not_called()
 
 
 class _BaseWrapperModule(torch.nn.Module):

--- a/tests/ut/platform/torch/activation_checkpoint/test_activation_swap.py
+++ b/tests/ut/platform/torch/activation_checkpoint/test_activation_swap.py
@@ -129,6 +129,14 @@ class TestSwapWrapper(unittest.TestCase):
         self.assertIn("layer.bias", parameter_names)
         self.assertTrue(all("_swap_wrapped_module" not in name for name in parameter_names))
 
+    def test_forward_rejected_while_compiling(self):
+        """SwapWrapper should fail explicitly during Torch graph capture."""
+        wrapper = swap_wrapper(_TinyModule())
+
+        with patch.object(torch.compiler, "is_compiling", return_value=True):
+            with self.assertRaisesRegex(ValueError, "swap_wrapper"):
+                wrapper(torch.randn(2, 2))
+
 
 class TestAsyncSaveOnCpu(unittest.TestCase):
     """Unit tests for AsyncSaveOnCpu."""
@@ -152,6 +160,12 @@ class TestAsyncSaveOnCpu(unittest.TestCase):
                 (x * x).sum()
 
         fake_manager.add_storage.assert_called_once()
+
+    def test_rejected_while_compiling(self):
+        """Direct async-save contexts should fail explicitly during capture."""
+        with patch.object(torch.compiler, "is_compiling", return_value=True):
+            with self.assertRaisesRegex(ValueError, "AsyncSaveOnCpu"):
+                AsyncSaveOnCpu()
 
 
 class TestSwapTensorWrapper(unittest.TestCase):
@@ -196,6 +210,12 @@ class TestSwapTensorWrapper(unittest.TestCase):
         self.assertIs(result["x"], target["x"])
         self.assertIs(result["meta"][1], target["meta"][1])
         fake_manager.add_storage.assert_called_once()
+
+    def test_rejected_while_compiling(self):
+        """Tensor-level swap registration should fail explicitly during capture."""
+        with patch.object(torch.compiler, "is_compiling", return_value=True):
+            with self.assertRaisesRegex(ValueError, "swap_tensor_wrapper"):
+                swap_tensor_wrapper(torch.ones(2))
 
 
 if __name__ == "__main__":

--- a/tests/ut/platform/torch/activation_checkpoint/test_checkpoint_wrapper.py
+++ b/tests/ut/platform/torch/activation_checkpoint/test_checkpoint_wrapper.py
@@ -171,6 +171,10 @@ class TestCkptWrapper(unittest.TestCase):
 
         self.assertIsInstance(result, CheckpointWrapper)
 
+    def test_forward_is_available_to_torch_dynamo(self):
+        """Checkpoint wrapper must remain traceable so checkpoint becomes a HOP."""
+        self.assertFalse(getattr(CheckpointWrapper.forward, "_torchdynamo_disable", False))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ut/platform/torch/activation_checkpoint/test_native_compile.py
+++ b/tests/ut/platform/torch/activation_checkpoint/test_native_compile.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Huawei Technologies Co., Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Tests for the Torch-native selective checkpoint compile adapter."""
+import os
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+import torch.utils.checkpoint as torch_checkpoint
+
+os.environ["HYPER_PARALLEL_PLATFORM"] = "torch"
+
+from hyper_parallel.core.activation_checkpoint import CheckpointPolicy, checkpoint
+from hyper_parallel.platform.torch.activation_checkpoint.native_compile import (
+    _to_torch_checkpoint_policy,
+    _torch_policy_adapter,
+    create_native_selective_checkpoint_contexts,
+)
+
+
+class TestNativeCompilePolicyAdapter(unittest.TestCase):
+    """Validate the deliberately narrow compile policy compatibility layer."""
+
+    def test_converts_supported_hyper_parallel_policies_by_name(self):
+        for policy_name in (
+                "MUST_SAVE", "PREFER_SAVE", "MUST_RECOMPUTE", "PREFER_RECOMPUTE"):
+            with self.subTest(policy_name=policy_name):
+                result = _to_torch_checkpoint_policy(getattr(CheckpointPolicy, policy_name))
+                self.assertIs(result, getattr(torch_checkpoint.CheckpointPolicy, policy_name))
+
+    def test_preserves_supported_native_torch_policies(self):
+        for policy_name in (
+                "MUST_SAVE", "PREFER_SAVE", "MUST_RECOMPUTE", "PREFER_RECOMPUTE"):
+            with self.subTest(policy_name=policy_name):
+                policy = getattr(torch_checkpoint.CheckpointPolicy, policy_name)
+                self.assertIs(_to_torch_checkpoint_policy(policy), policy)
+
+    def test_rejects_bool_and_unknown_return_types(self):
+        for policy in (True, False, 0, "MUST_SAVE", None):
+            with self.subTest(policy=policy):
+                with self.assertRaisesRegex(TypeError, "must return"):
+                    _to_torch_checkpoint_policy(policy)
+
+    def test_rejects_hyper_parallel_swap(self):
+        with self.assertRaisesRegex(ValueError, "MUST_SWAP"):
+            _to_torch_checkpoint_policy(CheckpointPolicy.MUST_SWAP)
+
+    def test_rejects_torch_offload_policies_when_present(self):
+        for policy_name in ("MUST_CPU_OFFLOAD", "PREFER_CPU_OFFLOAD"):
+            policy = getattr(torch_checkpoint.CheckpointPolicy, policy_name, None)
+            if policy is None:
+                continue
+            with self.subTest(policy_name=policy_name):
+                with self.assertRaisesRegex(ValueError, policy_name):
+                    _to_torch_checkpoint_policy(policy)
+
+    def test_passes_native_context_and_operator_to_user_policy(self):
+        native_context = object()
+        op = object()
+        policy_fn = MagicMock(return_value=CheckpointPolicy.MUST_SAVE)
+
+        result = _torch_policy_adapter(policy_fn, native_context, op, 1, flag=True)
+
+        self.assertIs(result, torch_checkpoint.CheckpointPolicy.MUST_SAVE)
+        policy_fn.assert_called_once_with(native_context, op, 1, flag=True)
+
+    def test_creates_torch_native_selective_contexts(self):
+        policy_fn = MagicMock(return_value=CheckpointPolicy.PREFER_RECOMPUTE)
+
+        forward_mode, recompute_mode = create_native_selective_checkpoint_contexts(policy_fn)
+
+        self.assertIsInstance(forward_mode, torch.utils._python_dispatch.TorchDispatchMode)
+        self.assertIsInstance(recompute_mode, torch.utils._python_dispatch.TorchDispatchMode)
+
+    def test_requires_callable_policy(self):
+        with self.assertRaisesRegex(TypeError, "callable"):
+            create_native_selective_checkpoint_contexts(CheckpointPolicy.MUST_SAVE)
+
+    def test_selective_checkpoint_compiles_with_aot_autograd(self):
+        """Native SAC should survive Dynamo capture and AOTAutograd backward tracing."""
+        received_contexts = []
+
+        def policy_fn(context, op, *args, **kwargs):  # pylint: disable=W0613
+            received_contexts.append(context)
+            if op == torch.ops.aten.mm.default:
+                return CheckpointPolicy.MUST_SAVE
+            return CheckpointPolicy.PREFER_RECOMPUTE
+
+        class Block(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear1 = torch.nn.Linear(8, 16)
+                self.linear2 = torch.nn.Linear(16, 8)
+
+            def checkpointed_body(self, value):
+                return self.linear2(torch.nn.functional.gelu(self.linear1(value)))
+
+            def forward(self, value):
+                return checkpoint(self.checkpointed_body, value, policy_fn=policy_fn)
+
+        model = Block()
+        compiled_model = torch.compile(model, backend="aot_eager", fullgraph=True)
+        inputs = torch.randn(4, 8, requires_grad=True)
+
+        compiled_model(inputs).square().mean().backward()
+
+        self.assertTrue(received_contexts)
+        self.assertTrue(all(isinstance(context, torch_checkpoint.SelectiveCheckpointContext)
+                            for context in received_contexts))
+        self.assertTrue(torch.isfinite(inputs.grad).all())
+        self.assertTrue(all(parameter.grad is not None for parameter in model.parameters()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ut/platform/torch/fully_shard/test_fully_shard_register_hook.py
+++ b/tests/ut/platform/torch/fully_shard/test_fully_shard_register_hook.py
@@ -606,8 +606,12 @@ class TestTorchSchedulerSetup(unittest.TestCase):
         scheduler.modules = (module,)
         scheduler._fsdp_group_post_pending = None
         scheduler._register_forward_backward_hooks()
-        module.register_forward_pre_hook.assert_called_once_with(scheduler._forward_pre_hook, with_kwargs=True)
-        module.register_forward_hook.assert_called_once_with(scheduler._forward_hook)
+        forward_pre_hook = module.register_forward_pre_hook.call_args.args[0]
+        forward_hook = module.register_forward_hook.call_args.args[0]
+        self.assertTrue(getattr(forward_pre_hook, "_torchdynamo_disable", False))
+        self.assertTrue(getattr(forward_hook, "_torchdynamo_disable", False))
+        module.register_forward_pre_hook.assert_called_once_with(forward_pre_hook, with_kwargs=True)
+        module.register_forward_hook.assert_called_once_with(forward_hook)
 
         module_a = MagicMock()
         module_b = MagicMock()
@@ -615,8 +619,14 @@ class TestTorchSchedulerSetup(unittest.TestCase):
         scheduler._fsdp_group_post_pending = set()
         scheduler._register_forward_module_hook = MagicMock()
         scheduler._register_forward_backward_hooks()
-        module_a.register_forward_pre_hook.assert_called_once_with(scheduler._grouped_forward_pre_hook, with_kwargs=True)
-        module_b.register_forward_pre_hook.assert_called_once_with(scheduler._grouped_forward_pre_hook, with_kwargs=True)
+        grouped_pre_hook_a = module_a.register_forward_pre_hook.call_args.args[0]
+        grouped_pre_hook_b = module_b.register_forward_pre_hook.call_args.args[0]
+        self.assertTrue(getattr(grouped_pre_hook_a, "_torchdynamo_disable", False))
+        self.assertTrue(getattr(grouped_pre_hook_b, "_torchdynamo_disable", False))
+        module_a.register_forward_pre_hook.assert_called_once_with(grouped_pre_hook_a, with_kwargs=True)
+        module_b.register_forward_pre_hook.assert_called_once_with(grouped_pre_hook_b, with_kwargs=True)
+        for call in scheduler._register_forward_module_hook.call_args_list:
+            self.assertTrue(getattr(call.args[1], "_torchdynamo_disable", False))
         self.assertEqual(scheduler._register_forward_module_hook.call_count, 2)
 
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

----

**What does this PR do / why do we need it**:

Torch 版本升级后，HyperParallel 自维护的选择重计算 DispatchMode
难以及时兼容 Torch checkpoint、Dynamo 和 AOTAutograd 的内部演进。

本 PR 为 Torch checkpoint 增加编译场景适配，使重计算区域能够被
`torch.compile` 捕获，并交由 Torch 原生 checkpoint 机制处理。

主要改动如下：

- 普通重计算在编译时使用 Torch 非 reentrant checkpoint，不再叠加
  HyperParallel 的 eager recompute context。
- 选择重计算通过 `create_selective_checkpoint_contexts` 使用 Torch
  原生 context，用户的 `policy_fn` 直接接收当前 Torch 版本的 context。
- 支持 HyperParallel 和 Torch 的 `MUST_SAVE`、`PREFER_SAVE`、
  `MUST_RECOMPUTE`、`PREFER_RECOMPUTE` 策略。
- 策略枚举按名称转换，避免枚举数值与新版本 Torch 策略发生语义冲突。
- bool、`MUST_SWAP`、CPU offload 和未知策略类型会显式报错。
- 编译场景显式拦截 `swap_inputs`、`group_swap`、自定义 `context_fn`、
  reentrant checkpoint 及 activation swap 扩展。
- FSDP forward hooks 保持在编译图外，避免参数通信和调度逻辑进入
  Transformer layer 的计算图。
- FSDP lazy initialization 调整为仅由 root scheduler 执行一次。
- `CheckpointWrapper.forward` 保持可被 Dynamo 捕获，使 checkpoint
  能够表示为 `tag_activation_checkpoint`。

本 PR 共修改 12 个文件，新增 423 行，删除 26 行，包含实现及对应 UT，
不包含模型调试开关、图 dump 工具或实验训练配置。

----

**Which issue(s) this PR fixes**:

Fixes #

----

**Test Plan and Test result：What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**：

- Torch 2.12 相关 activation checkpoint 和 FSDP UT：83 passed。
- CPU `aot_eager`、`fullgraph=True` 下完成选择重计算前向和反向。
- 验证 `policy_fn` 收到 Torch 原生 `SelectiveCheckpointContext`。
- 两卡 NPU、纯 FSDP、逐 Transformer layer `aot_eager` 编译完成 3 step。
- 训练 loss 分别为 126.80566406、127.47026825、121.88893127。
- 捕获图包含 `tag_activation_checkpoint`，且未包含 FSDP collective。

----

**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

- [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
- [ ] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
- [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
- [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
- [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- atomgit-backport-meta -->
atomgit_repo: mindspore/hyper-parallel
atomgit_mr: 1049
source_branch: test/torch-compile
source_url: https://gitcode.com/mindspore/hyper-parallel/merge_requests/1049
<!-- /atomgit-backport-meta -->
