### PR TITLE
feat(pipeline): add fsdp_comm_first to mask VPP HSDP comms with warmup bubble

### DIFF
--- a/hyper_parallel/core/fully_shard/api.py
+++ b/hyper_parallel/core/fully_shard/api.py
@@ -230,6 +230,14 @@ class HSDPModule:
                 return _UnshardHandle(hsdp_state=hsdp_state)
         return None
 
+    def wait_for_unshard(self) -> None:
+        """wait for all asynchronously launched unshard communications"""
+        if not self.hsdp_scheduler:
+            raise ValueError("hsdp_scheduler is None")
+        hsdp_state = self.hsdp_scheduler.hsdp_state
+        if hsdp_state:
+            hsdp_state.wait_for_unshard()
+
     def load_state_dict(
         self,
         state_dict: Mapping[str, Any],

--- a/hyper_parallel/core/pipeline_parallel/mpipe/schedule.py
+++ b/hyper_parallel/core/pipeline_parallel/mpipe/schedule.py
@@ -102,7 +102,8 @@ class ScheduleMPipeTranspose(ScheduleInterleaved1F1B):
                  kwargs_batch_dim: "Optional[BatchDimSpec]" = None,
                  output_concat_dim: Optional[int] = None,
                  overlap_p2p: bool = False,
-                 swap: bool = False) -> None:
+                 swap: bool = False,
+                 fsdp_comm_first: bool = False) -> None:
         """Build an interleaved-1F1B schedule that transposes the preprocess block.
 
         Args:
@@ -117,6 +118,9 @@ class ScheduleMPipeTranspose(ScheduleInterleaved1F1B):
             output_concat_dim (Optional[int]): Output concatenation dim (forwarded to the base).
             overlap_p2p (bool): Whether to overlap P2P (forwarded to the base).
             swap (bool): Whether to enable activation swapping (forwarded to the base).
+            fsdp_comm_first (bool): Front-load every local chunk's HSDP all-gather
+                at the schedule head, masked by the warmup bubble (forwarded to
+                the base).
         """
         if not isinstance(num_transpose_layers, int) or num_transpose_layers < 0:
             raise ValueError(
@@ -145,7 +149,8 @@ class ScheduleMPipeTranspose(ScheduleInterleaved1F1B):
                          output_concat_dim=output_concat_dim,
                          overlap_p2p=overlap_p2p,
                          overlap_b_f=False,
-                         swap=swap)
+                         swap=swap,
+                         fsdp_comm_first=fsdp_comm_first)
         self._executor = None
         self._setup_mpipe_execution()
 

--- a/hyper_parallel/core/pipeline_parallel/scheduler.py
+++ b/hyper_parallel/core/pipeline_parallel/scheduler.py
@@ -49,6 +49,11 @@ class MetaStepType(Enum):
     FSDP_RESHARD = auto()
     FSDP_REDUCE_GRAD = auto()
     FSDP_WAIT_REDUCE_GRAD = auto()
+    # fsdp_comm_first mode: async all-gather launch at the schedule head
+    # (masked by the VPP warmup bubble) + the blocking wait inserted right
+    # before each chunk's first compute step.
+    FSDP_UNSHARD_ASYNC = auto()
+    FSDP_UNSHARD_WAIT = auto()
     SWAP_SET_GROUP = auto()
     SWAP_LAUNCH_OFFLOAD = auto()
     SWAP_WAIT_OFFLOAD = auto()
@@ -234,6 +239,20 @@ def _exec_fsdp_unshard(stage):
             module.unshard()
 
 
+def _exec_fsdp_unshard_async(stage):
+    """Asynchronously launch the stage's HSDP all-gathers without a host wait."""
+    for _, module in platform.get_cells_and_names(stage.submodule):
+        if isinstance(module, HSDPModule):
+            module.unshard(async_op=True)
+
+
+def _exec_fsdp_unshard_wait(stage):
+    """Wait out the stage's in-flight async all-gathers and swap in unsharded views."""
+    for _, module in platform.get_cells_and_names(stage.submodule):
+        if isinstance(module, HSDPModule):
+            module.wait_for_unshard()
+
+
 def _exec_fsdp_reshard(stage):
     """Reshard every HSDPModule in the stage's submodule tree."""
     for _, module in platform.get_cells_and_names(stage.submodule):
@@ -259,6 +278,8 @@ _FSDP_STEP_HANDLERS = {
     MetaStepType.FSDP_RESHARD: _exec_fsdp_reshard,
     MetaStepType.FSDP_REDUCE_GRAD: _exec_fsdp_reduce_grad,
     MetaStepType.FSDP_WAIT_REDUCE_GRAD: _exec_fsdp_wait_reduce_grad,
+    MetaStepType.FSDP_UNSHARD_ASYNC: _exec_fsdp_unshard_async,
+    MetaStepType.FSDP_UNSHARD_WAIT: _exec_fsdp_unshard_wait,
 }
 
 
@@ -320,11 +341,16 @@ class PipelineScheduleRuntime(ABC):
                  output_concat_dim=None,
                  overlap_p2p=False,
                  swap=False,
-                 p2p_transport="auto"):
+                 p2p_transport="auto",
+                 fsdp_comm_first=False):
         if p2p_transport not in self._P2P_TRANSPORTS:
             raise ValueError(
                 f"p2p_transport must be one of {self._P2P_TRANSPORTS}, got "
                 f"{p2p_transport!r}"
+            )
+        if not isinstance(fsdp_comm_first, bool):
+            raise ValueError(
+                f"fsdp_comm_first should be a bool, got {type(fsdp_comm_first)}"
             )
         self.stages = self._check_stages(stages)
         self.micro_batch_num = micro_batch_num
@@ -339,6 +365,15 @@ class PipelineScheduleRuntime(ABC):
         self._stage_num = self.stages[0].stage_num
         self._stage_to_rank_index = None
         self._overlap_p2p = overlap_p2p
+        # ``fsdp_comm_first``: front-load every local chunk's HSDP parameter
+        # all-gather at the very head of this rank's schedule as async
+        # launches, so the comms are masked by the pipeline warmup bubble
+        # (VPP ranks sit idle waiting for their first activations there).
+        # A blocking wait is injected right before each chunk's first compute
+        # step; resharding happens once at the schedule tail.  Trades peak
+        # memory (all local chunks unsharded concurrently) for removing the
+        # mid-schedule unshard/reshard churn of the default windowed mode.
+        self._fsdp_comm_first = fsdp_comm_first
         self.exec_order = {}
         self._init_stages()
         self._build_stage_to_rank_index()
@@ -444,7 +479,10 @@ class PipelineScheduleRuntime(ABC):
         # micro-batch. The root API applies the setting recursively.
         for stage in self.stages:
             stage.submodule.set_reshard_after_forward(False)
-        rank_actions = add_fsdp_unshard_reshard(self.exec_order[current_rank], managed_stage_indices)
+        if getattr(self, "_fsdp_comm_first", False):
+            rank_actions = add_fsdp_comm_first(self.exec_order[current_rank], managed_stage_indices)
+        else:
+            rank_actions = add_fsdp_unshard_reshard(self.exec_order[current_rank], managed_stage_indices)
         self.exec_order[current_rank] = add_fsdp_reduce_grad(
             rank_actions,
             managed_stage_indices,
@@ -1705,13 +1743,15 @@ class ScheduleGPipe(PipelineScheduleRuntime):
                  args_batch_dim=None,
                  kwargs_batch_dim=None,
                  output_concat_dim=None,
-                 swap=False):
+                 swap=False,
+                 fsdp_comm_first=False):
         super().__init__(stages,
                          micro_batch_num,
                          args_batch_dim=args_batch_dim,
                          kwargs_batch_dim=kwargs_batch_dim,
                          output_concat_dim=output_concat_dim,
-                         swap=swap)
+                         swap=swap,
+                         fsdp_comm_first=fsdp_comm_first)
         self.build_exec_order()
 
     def _build_stage_to_rank_index(self) -> None:
@@ -1749,13 +1789,15 @@ class Schedule1F1B(PipelineScheduleRuntime):
                  args_batch_dim=None,
                  kwargs_batch_dim=None,
                  output_concat_dim=None,
-                 swap=False):
+                 swap=False,
+                 fsdp_comm_first=False):
         super().__init__(stages,
                          micro_batch_num,
                          args_batch_dim=args_batch_dim,
                          kwargs_batch_dim=kwargs_batch_dim,
                          output_concat_dim=output_concat_dim,
-                         swap=swap)
+                         swap=swap,
+                         fsdp_comm_first=fsdp_comm_first)
         self.build_exec_order()
 
     def _build_stage_to_rank_index(self) -> None:
@@ -1843,7 +1885,17 @@ class ScheduleInterleaved1F1B(PipelineScheduleRuntime):
       issued once dx and the paired forward finish instead of waiting
       out the full backward.
 
-    The two overlap flags are independent and can be combined.
+    * ``fsdp_comm_first=True`` (HSDP stages only): front-load every
+      local chunk's HSDP parameter all-gather at the very head of the
+      rank's schedule as async launches, so the comms are masked by the
+      warmup bubble (the rank is idle waiting for its first activation
+      recv while the comm stream drains the all-gathers); a blocking
+      wait lands right before each chunk's first compute step and all
+      chunks stay unsharded until one tail reshard.  Trades peak memory
+      (all local chunks unsharded concurrently) for removing the
+      mid-schedule unshard/reshard churn of the default windowed mode.
+
+    The overlap flags are independent and can be combined.
 
     Example:
         >>> # Plain interleaved 1F1B
@@ -1862,7 +1914,8 @@ class ScheduleInterleaved1F1B(PipelineScheduleRuntime):
                  overlap_b_f=False,
                  swap=False,
                  enable_dxdw_split=False,
-                 p2p_transport="auto"):
+                 p2p_transport="auto",
+                 fsdp_comm_first=False):
         super().__init__(stages,
                          micro_batch_num,
                          args_batch_dim=args_batch_dim,
@@ -1870,7 +1923,8 @@ class ScheduleInterleaved1F1B(PipelineScheduleRuntime):
                          output_concat_dim=output_concat_dim,
                          overlap_p2p=overlap_p2p,
                          swap=swap,
-                         p2p_transport=p2p_transport)
+                         p2p_transport=p2p_transport,
+                         fsdp_comm_first=fsdp_comm_first)
         # _overlap_b_f selects between plain F/B emission and OVERLAP_B_F
         # pairing in the 1F1B steady-state phase.  Must be set before
         # ``construct_stage_exec_order`` is called below.
@@ -2475,6 +2529,74 @@ def add_fsdp_unshard_reshard(actions, managed_stage_indices, max_active_stages=3
 
     while active_stages:
         fsdp_actions.append(MetaStep(None, MetaStepType.FSDP_RESHARD, active_stages.pop(0)))
+    return fsdp_actions
+
+
+def add_fsdp_comm_first(actions, managed_stage_indices):
+    """Front-load every managed chunk's HSDP all-gather at the schedule head.
+
+    ``fsdp_comm_first`` mode for VPP (interleaved) schedules.  The default
+    windowed injection (:func:`add_fsdp_unshard_reshard`) issues a *blocking*
+    unshard a few compute steps ahead of first use, which keeps the comm time
+    on the critical path; and with more local chunks than the lookahead window
+    it re-reshards/re-unshards chunks every round.  This mode instead:
+
+    * emits one ``FSDP_UNSHARD_ASYNC`` per managed chunk at the very head of
+      the rank's order — the launches are non-blocking, so while the rank sits
+      in its warmup bubble waiting for the first activation recv, the comm
+      stream is already draining the all-gathers;
+    * emits an ``FSDP_UNSHARD_WAIT`` immediately before each chunk's first
+      compute action, so compute only stalls if the bubble was shorter than
+      the comm;
+    * keeps every chunk unsharded through the whole run and reshards once at
+      the tail (no mid-schedule churn).
+
+    Trade-off: all local chunks' unsharded parameter buffers are resident
+    concurrently, so peak memory grows with the number of local chunks.
+    Gradient reduction stays where it must be (after each chunk's final
+    backward) and is unaffected.
+
+    Args:
+        actions: The rank's MetaStep list (send/recv + compute).
+        managed_stage_indices: Stage indices owned by this rank that are
+            HSDPModules.
+
+    Returns:
+        The rewritten MetaStep list with head async unshards, pre-compute
+        waits and tail reshards.
+    """
+    if not managed_stage_indices:
+        return actions
+
+    # Chunks in first-compute order (dict preserves insertion order).
+    first_compute_stage_indices = {}
+    for action in actions:
+        for leaf_step in iter_leaf_meta_steps(action):
+            if leaf_step.type not in _COMPUTE_META_STEP_TYPES:
+                continue
+            if leaf_step.stage_index in managed_stage_indices:
+                first_compute_stage_indices.setdefault(leaf_step.stage_index, True)
+
+    fsdp_actions = [
+        MetaStep(None, MetaStepType.FSDP_UNSHARD_ASYNC, stage_index)
+        for stage_index in first_compute_stage_indices
+    ]
+    waited_stage_indices = set()
+    for action in actions:
+        for leaf_step in iter_leaf_meta_steps(action):
+            if leaf_step.type not in _COMPUTE_META_STEP_TYPES:
+                continue
+            if leaf_step.stage_index not in first_compute_stage_indices:
+                continue
+            if leaf_step.stage_index in waited_stage_indices:
+                continue
+            waited_stage_indices.add(leaf_step.stage_index)
+            fsdp_actions.append(
+                MetaStep(None, MetaStepType.FSDP_UNSHARD_WAIT, leaf_step.stage_index)
+            )
+        fsdp_actions.append(action)
+    for stage_index in first_compute_stage_indices:
+        fsdp_actions.append(MetaStep(None, MetaStepType.FSDP_RESHARD, stage_index))
     return fsdp_actions
 
 

--- a/tests/ut/core/pipeline_parallel/test_fsdp_config.py
+++ b/tests/ut/core/pipeline_parallel/test_fsdp_config.py
@@ -266,3 +266,147 @@ def test_fsdp_stage_launches_deferred_reduction_and_delegates_terminal_wait() ->
     root.hsdp_scheduler.hsdp_state.post_backward.assert_called_once_with()
     root.hsdp_scheduler.hsdp_state.reduce_params.assert_called_once_with()
     root.hsdp_scheduler.wait_for_pending_reductions.assert_called_once_with()
+
+
+@arg_mark(
+    plat_marks=["cpu_linux"],
+    level_mark="level0",
+    card_mark="onecard",
+    essential_mark="essential",
+)
+def test_fsdp_comm_first_frontloads_async_unshards_and_waits_before_first_compute() -> None:
+    """
+    Feature: Pipeline FSDP comm-first injection.
+    Description: Every managed chunk's all-gather launches at the schedule head
+        as async steps, a wait lands right before each chunk's first compute,
+        and resharding happens once at the tail.
+    Expectation: Head async unshards in first-compute order, pre-compute waits,
+        no mid-schedule reshard/unshard churn, tail reshards.
+    """
+    overlap_step = scheduler_module.MetaStep(
+        None,
+        scheduler_module.MetaStepType.OVERLAP_B_F,
+        None,
+        sub_steps=(
+            scheduler_module.MetaStep(0, scheduler_module.MetaStepType.BWD, 0),
+            scheduler_module.MetaStep(0, scheduler_module.MetaStepType.FWD, 2),
+        ),
+    )
+    actions = [
+        scheduler_module.MetaStep(0, scheduler_module.MetaStepType.FWD_RECV, 0),
+        scheduler_module.MetaStep(0, scheduler_module.MetaStepType.FWD, 0),
+        scheduler_module.MetaStep(0, scheduler_module.MetaStepType.FWD_RECV, 1),
+        scheduler_module.MetaStep(0, scheduler_module.MetaStepType.FWD, 1),
+        scheduler_module.MetaStep(0, scheduler_module.MetaStepType.FWD, 9),
+        overlap_step,
+        scheduler_module.MetaStep(0, scheduler_module.MetaStepType.FWD, 3),
+        scheduler_module.MetaStep(0, scheduler_module.MetaStepType.BWD, 3),
+    ]
+
+    result = scheduler_module.add_fsdp_comm_first(
+        actions,
+        managed_stage_indices={0, 1, 2, 3},
+    )
+
+    assert result == [
+        scheduler_module.MetaStep(None, scheduler_module.MetaStepType.FSDP_UNSHARD_ASYNC, 0),
+        scheduler_module.MetaStep(None, scheduler_module.MetaStepType.FSDP_UNSHARD_ASYNC, 1),
+        scheduler_module.MetaStep(None, scheduler_module.MetaStepType.FSDP_UNSHARD_ASYNC, 2),
+        scheduler_module.MetaStep(None, scheduler_module.MetaStepType.FSDP_UNSHARD_ASYNC, 3),
+        actions[0],
+        scheduler_module.MetaStep(None, scheduler_module.MetaStepType.FSDP_UNSHARD_WAIT, 0),
+        actions[1],
+        actions[2],
+        scheduler_module.MetaStep(None, scheduler_module.MetaStepType.FSDP_UNSHARD_WAIT, 1),
+        actions[3],
+        actions[4],
+        scheduler_module.MetaStep(None, scheduler_module.MetaStepType.FSDP_UNSHARD_WAIT, 2),
+        overlap_step,
+        scheduler_module.MetaStep(None, scheduler_module.MetaStepType.FSDP_UNSHARD_WAIT, 3),
+        actions[6],
+        actions[7],
+        scheduler_module.MetaStep(None, scheduler_module.MetaStepType.FSDP_RESHARD, 0),
+        scheduler_module.MetaStep(None, scheduler_module.MetaStepType.FSDP_RESHARD, 1),
+        scheduler_module.MetaStep(None, scheduler_module.MetaStepType.FSDP_RESHARD, 2),
+        scheduler_module.MetaStep(None, scheduler_module.MetaStepType.FSDP_RESHARD, 3),
+    ]
+
+
+@arg_mark(
+    plat_marks=["cpu_linux"],
+    level_mark="level0",
+    card_mark="onecard",
+    essential_mark="essential",
+)
+def test_fsdp_comm_first_handlers_launch_async_and_wait_on_caller_thread() -> None:
+    """
+    Feature: Pipeline FSDP comm-first control steps.
+    Description: FSDP_UNSHARD_ASYNC launches the all-gather without a host wait
+        and FSDP_UNSHARD_WAIT drains it before the first compute.
+    Expectation: unshard(async_op=True) and wait_for_unshard run on the caller
+        thread against every HSDPModule in the stage tree.
+    """
+    module = MagicMock()
+    stage = SimpleNamespace(submodule=module)
+
+    with patch.object(scheduler_module, "HSDPModule", MagicMock), patch.object(
+        scheduler_module.platform,
+        "get_cells_and_names",
+        return_value=[("", module)],
+    ):
+        scheduler_module._exec_fsdp_unshard_async(stage)
+        scheduler_module._exec_fsdp_unshard_wait(stage)
+
+    module.unshard.assert_called_once_with(async_op=True)
+    module.wait_for_unshard.assert_called_once_with()
+
+
+@arg_mark(
+    plat_marks=["cpu_linux"],
+    level_mark="level0",
+    card_mark="onecard",
+    essential_mark="essential",
+)
+def test_fsdp_comm_first_selected_via_schedule_flag() -> None:
+    """
+    Feature: Pipeline FSDP comm-first wiring.
+    Description: Setting fsdp_comm_first on the schedule switches injection to
+        the head async-unshard mode.
+    Expectation: The rewritten order starts with one FSDP_UNSHARD_ASYNC per
+        local chunk and contains no windowed FSDP_UNSHARD step.
+    """
+    stage_indices = [0, 1, 2, 3]
+    stages = [
+        SimpleNamespace(stage_index=stage_index, submodule=_FakeHSDPModule())
+        for stage_index in stage_indices
+    ]
+    schedule = object.__new__(scheduler_module.Schedule1F1B)
+    schedule.stages = stages
+    schedule._stage_to_rank_index = {stage_index: 0 for stage_index in stage_indices}
+    schedule.micro_batch_num = 2
+    schedule._fsdp_comm_first = True
+    schedule.exec_order = {
+        0: [
+            scheduler_module.MetaStep(0, scheduler_module.MetaStepType.FWD, stage_index)
+            for stage_index in stage_indices
+        ] + [
+            scheduler_module.MetaStep(0, scheduler_module.MetaStepType.BWD, stage_index)
+            for stage_index in reversed(stage_indices)
+        ]
+    }
+
+    with patch.object(scheduler_module, "HSDPModule", _FakeHSDPModule):
+        schedule._inject_local_fsdp_actions()
+
+    rewritten = schedule.exec_order[0]
+    assert [
+        (step.type, step.stage_index) for step in rewritten[:4]
+    ] == [
+        (scheduler_module.MetaStepType.FSDP_UNSHARD_ASYNC, 0),
+        (scheduler_module.MetaStepType.FSDP_UNSHARD_ASYNC, 1),
+        (scheduler_module.MetaStepType.FSDP_UNSHARD_ASYNC, 2),
+        (scheduler_module.MetaStepType.FSDP_UNSHARD_ASYNC, 3),
+    ]
+    assert all(
+        step.type != scheduler_module.MetaStepType.FSDP_UNSHARD for step in rewritten
+    )


### PR DESCRIPTION
Paired: [GitHub #123](https://github.com/mindspore-ai/hyper-parallel/pull/123) ↔ [GitCode !1554](https://gitcode.com/mindspore/hyper-parallel/merge_requests/1554)

**What type of PR is this?**

/kind feature

----

**What does this PR do / why do we need it**:

VPP（Interleaved 1F1B）训练中，HSDP 参数 all-gather 通信默认由窗口式注入（`add_fsdp_unshard_reshard`）在首次计算前若干步以**阻塞式**发出，通信时间落在关键路径上；且本地 chunk 数超过前瞻窗口时，每轮都会出现多余的 reshard/unshard 反复通信。

本 PR 新增可选参数 `fsdp_comm_first`：将本 rank 每个 chunk 的 HSDP 参数 all-gather **全部前置到调度序列最开头异步发射**，此时 rank 正处于 warmup bubble（等待首个 activation recv 的空闲期），通信在通信流上与 bubble 并行掩盖；在每个 chunk 首次计算动作前插入阻塞等待（bubble 不足时才真正等待）；整个 run 期间 chunk 保持 unsharded，仅在调度尾部做一次 reshard，消除中途通信抖动。梯度 reduce 位置不变（仍在各 chunk 最后一次 backward 之后）。

机制：

- 新增 `FSDP_UNSHARD_ASYNC` / `FSDP_UNSHARD_WAIT` 两种 MetaStep 类型及 handler（异步发射 / 首算前等待）
- 新增 `add_fsdp_comm_first` 注入函数：头部按首次计算顺序发射各 chunk 的 ASYNC unshard，首个计算动作前插入 WAIT，尾部统一 RESHARD
- `HSDPModule` 新增公开接口 `wait_for_unshard()`
- 参数透传：`PipelineScheduleRuntime` / `ScheduleGPipe` / `Schedule1F1B` / `ScheduleInterleaved1F1B` / `ScheduleMPipeTranspose` 均支持 `fsdp_comm_first=False`（默认关闭，保持既有行为）

用法：`ScheduleInterleaved1F1B(stages, mb, ..., fsdp_comm_first=True)`

权衡说明：该模式下所有本地 chunk 的 unsharded 参数缓冲同时驻留，峰值内存随本地 chunk 数增长（换取通信与 bubble 的完全掩盖）。

----

**Which issue(s) this PR fixes**:

Fixes #

----

**Test Plan and Test result：What scenarios were tested, and what were the verification results（Function, performance, reliability, etc.）**:

- 新增 UT（`tests/ut/core/pipeline_parallel/test_fsdp_config.py`）：
  - 注入顺序：头部按首次计算顺序前置 ASYNC unshard、首算前插入 WAIT、尾部统一 RESHARD、无中途 unshard/reshard 抖动、非托管 stage 不受影响（含 OVERLAP_B_F 复合步骤的子步骤遍历）
  - handler 行为：`unshard(async_op=True)` 异步发射、`wait_for_unshard` 在调用线程等待
  - 调度 flag 接线：`fsdp_comm_first=True` 切换到头部异步模式
- 本机 `pytest tests/ut/core/pipeline_parallel/`：55 passed, 1 skipped
- ST/性能验证（NPU 环境真实 VPP 训练对比）由门禁流水线与后续真机验证补充

----

**Self-checklist**：（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

- [ ] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
- [x] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
- [ ] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
- [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
- [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- atomgit-backport-meta -->
atomgit_repo: mindspore/hyper-parallel
atomgit_mr: 1338
source_branch: feat/vpp-hsdp-comm-first
source_url: https://gitcode.com/mindspore/hyper-parallel/merge_requests/1338
<!-- /atomgit-backport-meta -->
