### PR TITLE
fix: apply targeted memory and correctness fixes

### DIFF
--- a/hyper_parallel/components/losses/_vocab_parallel_cross_entropy.py
+++ b/hyper_parallel/components/losses/_vocab_parallel_cross_entropy.py
@@ -379,7 +379,13 @@ class DistributedCrossEntropyFunction(torch.autograd.Function):
         ignore_mask = target_flat != ignore_index
 
         if weight is not None:
-            sample_weights = weight[target_flat]
+            # Ignore positions may contain -100, which is not a valid class
+            # index. Use a harmless index there; their gradients are masked
+            # below and therefore do not contribute to the result.
+            safe_target = torch.where(
+                ignore_mask, target_flat, torch.zeros_like(target_flat)
+            )
+            sample_weights = weight[safe_target]
         else:
             sample_weights = None
 
@@ -394,13 +400,11 @@ class DistributedCrossEntropyFunction(torch.autograd.Function):
 
         if reduction == "none":
             grad_scale_expanded = grad_scale.unsqueeze(-1)
-            if sample_weights is not None:
-                grad_scale_expanded = grad_scale_expanded * sample_weights.unsqueeze(-1)
-            grad_input = softmax_local * grad_scale_expanded
         else:
-            if sample_weights is not None:
-                grad_scale = grad_scale * sample_weights.unsqueeze(-1)
-            grad_input = softmax_local * grad_scale.unsqueeze(-1)
+            grad_scale_expanded = grad_scale.reshape(1, 1)
+        if sample_weights is not None:
+            grad_scale_expanded = grad_scale_expanded * sample_weights.unsqueeze(-1)
+        grad_input = softmax_local * grad_scale_expanded
 
         local_targets = torch.where(in_vocab_mask, target_flat - vocab_start, torch.zeros_like(target_flat))
 
@@ -408,12 +412,13 @@ class DistributedCrossEntropyFunction(torch.autograd.Function):
             row_indices = torch.arange(batch_size, device=target.device, dtype=torch.long)
 
             if reduction == "none":
+                grad_values = -grad_scale
                 if sample_weights is not None:
-                    grad_values = -grad_scale * sample_weights
-                else:
-                    grad_values = -grad_scale
+                    grad_values = grad_values * sample_weights
             else:
                 grad_values = -grad_scale.expand_as(target_flat)
+                if sample_weights is not None:
+                    grad_values = grad_values * sample_weights
 
             grad_input = grad_input.contiguous()
             grad_input[row_indices[in_vocab_mask], local_targets[in_vocab_mask]] += grad_values[in_vocab_mask]

--- a/hyper_parallel/components/losses/masked_ce.py
+++ b/hyper_parallel/components/losses/masked_ce.py
@@ -60,7 +60,7 @@ class MaskedCrossEntropy:
             with torch.no_grad():
                 if mask.device != labels.device:
                     mask = mask.to(labels.device)
-                labels.masked_fill_(mask.view(-1) == 0, self.ignore_index)
+                labels = labels.masked_fill(mask.view(-1) == 0, self.ignore_index)
 
         if self.fp32_upcast:
             logits = logits.float()

--- a/hyper_parallel/components/modules/grouped_experts.py
+++ b/hyper_parallel/components/modules/grouped_experts.py
@@ -387,7 +387,7 @@ class GroupedExperts(nn.Module):
                 permuted, gate_up_proj, bias=None, group_list=self._group_list, group_type=0, group_list_type=0,
             )
             if self.add_bias:
-                b1 = self.bias1.view(self.num_local_experts, 1, -1)
+                b1 = self.bias1.view(self.num_local_experts, -1)
                 fc1_output = fc1_output + torch.repeat_interleave(b1, self._tokens_per_expert_gmm, dim=0)
         else:
             gate_up_proj_2d = gate_up_proj.view(self.hidden_size, -1)
@@ -410,7 +410,7 @@ class GroupedExperts(nn.Module):
                 fc1_output, down_proj, bias=None, group_list=self._group_list, group_type=0, group_list_type=0,
             )
             if self.add_bias:
-                b2 = self.bias2.view(self.num_local_experts, 1, -1)
+                b2 = self.bias2.view(self.num_local_experts, -1)
                 fc2_output = fc2_output + torch.repeat_interleave(
                     b2, self._tokens_per_expert_gmm, dim=0,
                 )

--- a/hyper_parallel/data/parallel/build_barrier.py
+++ b/hyper_parallel/data/parallel/build_barrier.py
@@ -71,3 +71,9 @@ class OnlineDatasetBarrier:
             timeout=self.timeout,
             wait_all_ranks=True,
         )
+
+    def close(self) -> None:
+        """Release the auxiliary process group after a dataset build."""
+        if self._gloo_group is not None and dist.is_initialized():
+            dist.destroy_process_group(self._gloo_group)
+        self._gloo_group = None

--- a/hyper_parallel/data/parallel/dataloader_parallel.py
+++ b/hyper_parallel/data/parallel/dataloader_parallel.py
@@ -203,7 +203,16 @@ def build_dataset_for_dataloader(
         local_dataset = dataset_factory()
 
     if barrier_needed:
-        dataloader_context.barrier()
+        try:
+            dataloader_context.barrier()
+        finally:
+            # Dataset-specific barriers may own a temporary auxiliary group.
+            # Close it after all ranks have crossed the barrier so repeated
+            # dataset builds do not retain process groups and file handles.
+            barrier_owner = getattr(dataloader_context.barrier, "__self__", None)
+            close = getattr(barrier_owner, "close", None)
+            if close is not None:
+                close()
 
     if not builds_cache_first and owns_dataset:
         local_dataset = dataset_factory()

--- a/hyper_parallel/data/tools/offline_preparation.py
+++ b/hyper_parallel/data/tools/offline_preparation.py
@@ -307,30 +307,32 @@ class Partition:
         pack_to_seq_len = getattr(self.args, "pack_to_seq_len", None)
         chunk_size = pack_to_seq_len + 1 if pack_to_seq_len is not None else None
         token_buffers = {key: [] for key in keys}
-        with open(input_file_name, "r", encoding="utf-8") as fin:
-            encoded_docs = pool.imap(encoder.encode, fin, 32)
-            for i, (doc, sentence_lens, bytes_processed) in enumerate(encoded_docs, start=1):
-                if self.args.find_optimal_num_workers and i > self.args.max_documents:
-                    break
-                total_bytes_processed += bytes_processed
-                for key in keys:
-                    if chunk_size is None:
-                        builders[key].add_document(doc[key], sentence_lens[key])
-                        continue
-                    token_buffers[key].extend(doc[key])
-                    complete_length = len(token_buffers[key]) // chunk_size * chunk_size
-                    for offset in range(0, complete_length, chunk_size):
-                        chunk = token_buffers[key][offset : offset + chunk_size]
-                        builders[key].add_document(chunk, [chunk_size])
-                    del token_buffers[key][:complete_length]
-                self.print_processing_stats(i, proc_start, total_bytes_processed)
+        try:
+            with open(input_file_name, "r", encoding="utf-8") as fin:
+                encoded_docs = pool.imap(encoder.encode, fin, 32)
+                for i, (doc, sentence_lens, bytes_processed) in enumerate(encoded_docs, start=1):
+                    if self.args.find_optimal_num_workers and i > self.args.max_documents:
+                        break
+                    total_bytes_processed += bytes_processed
+                    for key in keys:
+                        if chunk_size is None:
+                            builders[key].add_document(doc[key], sentence_lens[key])
+                            continue
+                        token_buffers[key].extend(doc[key])
+                        complete_length = len(token_buffers[key]) // chunk_size * chunk_size
+                        for offset in range(0, complete_length, chunk_size):
+                            chunk = token_buffers[key][offset : offset + chunk_size]
+                            builders[key].add_document(chunk, [chunk_size])
+                        del token_buffers[key][:complete_length]
+                    self.print_processing_stats(i, proc_start, total_bytes_processed)
 
-        keys = self.args.json_keys
-        for key in keys:
-            builders[key].finalize(output_idx_files[key])
-
-        pool.close()
-        pool.join()
+            for key in keys:
+                builders[key].finalize(output_idx_files[key])
+        finally:
+            for builder in builders.values():
+                builder.data_file.close()
+            pool.close()
+            pool.join()
 
         return self.performance
 

--- a/hyper_parallel/distributed/_builder/forward_rewriter.py
+++ b/hyper_parallel/distributed/_builder/forward_rewriter.py
@@ -954,11 +954,14 @@ def _wrap_inner_attention(module, cp_mesh, *, spec=None, mesh=None,
     # Record the pre-rewrite state for failure rollback: an in-place wrapper
     # writes an instance attribute, so __dict__ holds the full mutation.
     saved_state = {"forward": target.__dict__.get("forward", _MISSING)}
+    committed_secondaries = []
     try:
         primary, secondaries = _classify_rewrite_result(
             apply_fn(), target, name)
         for request in secondaries:
-            _commit_forward_rewrite(request)
+            committed_secondaries.append(
+                (request.target, _commit_forward_rewrite(request))
+            )
         if primary is None:
             # In-place contract (external @inner_wrapper wrappers). Detect
             # "a replacement really happened": attribute access on a bound
@@ -974,7 +977,7 @@ def _wrap_inner_attention(module, cp_mesh, *, spec=None, mesh=None,
             # In-repo discipline: the wrapper returned its replacement, the
             # rewriter commits the companion attributes and installs.
             saved_state.update({
-                attr: getattr(target, attr, _MISSING)
+                attr: target.__dict__.get(attr, _MISSING)
                 for attr in primary.companion_attrs
             })
             for attr, value in primary.companion_attrs.items():
@@ -998,6 +1001,9 @@ def _wrap_inner_attention(module, cp_mesh, *, spec=None, mesh=None,
     except Exception:
         # Failure rollback: restore every attribute written during the
         # rewrite so a half-installed wrapper never survives.
+        for secondary_target, secondary_state in reversed(committed_secondaries):
+            for attr, saved in secondary_state.items():
+                _restore_attr(secondary_target, attr, saved)
         for attr, saved in saved_state.items():
             _restore_attr(target, attr, saved)
         raise
@@ -1105,7 +1111,7 @@ def _commit_forward_rewrite(request):
     target = request.target
     saved = {
         "forward": target.__dict__.get("forward", _MISSING),
-        **{name: getattr(target, name, _MISSING)
+        **{name: target.__dict__.get(name, _MISSING)
            for name in request.companion_attrs},
     }
     try:
@@ -1116,6 +1122,7 @@ def _commit_forward_rewrite(request):
         for attr_name, value in saved.items():
             _restore_attr(target, attr_name, value)
         raise
+    return saved
 
 
 def _classify_rewrite_result(returned, target, wrapper_name):

--- a/hyper_parallel/distributed/context_parallel/wrappers.py
+++ b/hyper_parallel/distributed/context_parallel/wrappers.py
@@ -252,6 +252,7 @@ def _prepare_hybrid_sdpa_kwargs(
 
 def _cp_sdpa_call(orig_sdpa, cp_mesh, q, k, v, kwargs):
     """CP-aware SDPA: K/V all-gather + D-04 offset-aware causal mask."""
+    q, k, v, kwargs = _normalize_hf_sdpa_gqa(q, k, v, kwargs)
     cp_dim = 2  # sequence dim of the [B, N, S, H] layout
     global_k, global_v = flex_cp_allgather(
         k.contiguous(), v.contiguous(), cp_dim, cp_mesh)

--- a/hyper_parallel/trainer/callbacks/profiling_callback.py
+++ b/hyper_parallel/trainer/callbacks/profiling_callback.py
@@ -68,9 +68,12 @@ class ProfilingCallback(Callback):
 
     def on_step_end(self, state: TrainerState, **kwargs: Any) -> None:
         """Advance the profiler schedule after one complete optimizer step."""
-        del state, kwargs
+        del kwargs
         if self.profiler is not None:
             self.profiler.step()
+            if state.global_step >= self.config.end_step:
+                self.profiler.stop()
+                self.profiler = None
 
     def on_train_end(self, state: TrainerState, **kwargs: Any) -> None:
         """Stop the profiler and flush any pending trace output."""

--- a/hyper_parallel/trainer/runtime/distributed.py
+++ b/hyper_parallel/trainer/runtime/distributed.py
@@ -246,8 +246,12 @@ def destroy_process_group() -> None:
         from hyper_parallel.core.dtensor.tensor_redistribution import _tensor_redistribution  # pylint: disable=C0415
         from hyper_parallel.core.fully_shard.hsdp_param import _GROUP_INFO_CACHE  # pylint: disable=C0415
         from hyper_parallel.platform.platform import EXISTING_COMM_GROUPS  # pylint: disable=C0415
+        from hyper_parallel.platform.torch.platform import (  # pylint: disable=C0415
+            _P2P_MULTI_STREAM_GROUPS,
+        )
 
         EXISTING_COMM_GROUPS.clear()
+        _P2P_MULTI_STREAM_GROUPS.clear()
         _DEVICE_MESH_MAP.clear()
         _LAYOUT_CACHE.clear()
         _GROUP_INFO_CACHE.clear()

--- a/hyper_parallel/trainer/runtime/profiling.py
+++ b/hyper_parallel/trainer/runtime/profiling.py
@@ -69,11 +69,14 @@ class ProfilerWithMem:
     # delegate ctx-manager behaviour
     def __enter__(self) -> Any:
         """Enter the wrapped profiler's context manager."""
-        return self._p.__enter__()
+        self.start()
+        return self
 
     def __exit__(self, *a: Any) -> Any:
         """Exit the wrapped profiler's context manager."""
-        return self._p.__exit__(*a)
+        del a
+        self.stop()
+        return False
 
     def start(self) -> Any:
         """Start profiling and begin recording the allocator history."""
@@ -83,9 +86,10 @@ class ProfilerWithMem:
 
     def stop(self) -> Any:
         """Stop profiling and stop recording the allocator history."""
-        out = self._p.stop()
-        get_torch_device().memory._record_memory_history(enabled=None)  # step recording memory snapshot
-        return out
+        try:
+            return self._p.stop()
+        finally:
+            get_torch_device().memory._record_memory_history(enabled=None)
 
     def step(self, *a: Any, **kw: Any) -> Any:
         """Advance the wrapped profiler by one step."""

--- a/hyper_parallel/trainer/vlm_trainer.py
+++ b/hyper_parallel/trainer/vlm_trainer.py
@@ -188,7 +188,8 @@ class VLMTrainer:
         total_loss = 0.0
         total_loss_dict = defaultdict(int)
 
-        for micro_step, (model_inputs, loss_inputs) in enumerate(training_batches):
+        for micro_step, batch in enumerate(training_batches):
+            model_inputs, loss_inputs = batch
             self.base.model_reshard(micro_step, num_micro_steps)
             self.base.configure_fsdp_gradient_sync(
                 micro_step,
@@ -200,6 +201,10 @@ class VLMTrainer:
                 for name, token_count in self.base.current_token_counts.items()
             }
             loss, loss_dict = self.base.forward_backward_step(model_inputs)
+
+            # Release each device batch as soon as its backward pass completes;
+            # prefetching all micro-batches must not pin them until step end.
+            training_batches[micro_step] = None
 
             total_loss += loss.item()
             for loss_name, loss_value in loss_dict.items():


### PR DESCRIPTION
Paired: [GitHub #133](https://github.com/mindspore-ai/hyper-parallel/pull/133) ↔ [GitCode !1397](https://gitcode.com/mindspore/hyper-parallel/merge_requests/1397)

## 变更说明

基于最新 `upstream/master`，针对内存 Bug 扫描报告中四位用户归属的问题做小范围修复：

- 修正词表并行交叉熵反向中的 ignore index 越界索引和 class weight 广播形状错误。
- 修正 MaskedCrossEntropy 原地修改调用方 labels 的别名问题。
- 修正 NPU grouped experts bias 的额外维度广播。
- 为离线数据转换、在线数据 barrier、forward 重写失败回滚补齐资源/状态清理。
- 在 HF CP SDPA 路径统一 GQA 头布局，清理 P2P 通信缓存。
- VLM 微批处理在反向后释放设备 batch 引用；profiling 在窗口结束及异常退出时停止内存记录。

这些改动均位于已有生命周期或错误路径，不改变正常计算公式和通信算法。

## 四位用户问题逐项复核

| 用户 | 报告 finding | 扫描出来的问题信息 | 是否改 | 原因 |
|---|---|---|---:|---|
| yaoyifan1@huawei.com | `_vocab_parallel_cross_entropy.py:382` | ignore_index 未过滤即索引 weight，可能错权重或越界 | 是 | 使用安全索引并保留 mask 语义 |
| yaoyifan1@huawei.com | `_vocab_parallel_cross_entropy.py:402` | weight 广播为 `[B,B,V]`，可能 OOM/形状错误 | 是 | 改为二维 per-sample scale |
| yaoyifan1@huawei.com | `masked_ce.py:63` | 原地写入调用方 labels，造成标签污染 | 是 | 使用非原地 masked_fill |
| 821372701@qq.com | `grouped_experts.py:391` | bias 维度导致 `[T,T,F]` 广播 | 是 | 修正为二维 expert bias |
| yaoyifan1@huawei.com | `build_barrier.py:55` | Online Dataset 重建时 Gloo group 不释放 | 是 | barrier 后显式销毁临时 group |
| yaoyifan1@huawei.com | `offline_preparation.py:286` | 编码异常时 pool、bin 文件句柄不清理 | 是 | finally 关闭 builder 文件和 pool |
| yaoyifan1@huawei.com | `forward_rewriter.py:960` | secondary rewrite 失败后半安装状态残留 | 是 | 纳入逆序原子回滚 |
| yaoyifan1@huawei.com | `context_parallel/attention.py:207` | DSA ContextVar 可能跨 step 持有大张量 | 否 | 生命周期改造可能进入热路径，避免性能风险 |
| yaoyifan1@huawei.com | `context_parallel/wrappers.py:538` | HF GQA 各 rank K/V shape 可能不一致 | 是 | CP SDPA 前统一 KV 头布局 |
| yaoyifan1@huawei.com | `trainer/runtime/distributed.py:250` | P2P group 缓存未随进程组销毁 | 是 | destroy 时同步清理缓存 |
| yaoyifan1@huawei.com | `trainer/runtime/profiling.py:81` | allocator history 在异常/上下文退出时可能残留 | 是 | stop/退出保证关闭记录 |
| jiahao2676@gmail.com | `trainer/vlm_trainer.py:181` | 预取的微批设备张量持有到 step 末 | 是 | 反向完成后断开 batch 引用 |
| 821372701@qq.com | `grouped_matmul.py:118` | 特定 gemm_fusion/main_grad 组合可能消费未初始化 grad | 否 | 依赖下游契约，当前证据不足 |
| yaoyifan1@huawei.com | `hifloat8_grouped_linear.py:129` | 已安装 hook 后转换可能丢 hook | 否 | 仅受限调用顺序，默认路径未证实 |
| jiahao2676@gmail.com | `build_data_transform.py:112` | 特定多图/视频占位符排列可能错配 | 否 | 需完整样本契约，避免扩大数据变换 |
| yaoyifan1@huawei.com | `forward_rewriter.py:1224` | local-compute 转换异常可能半安装 | 否 | 需更大范围回滚设计 |
| yaoyifan1@huawei.com | `parameter_sharding.py:131` | validate unwrap 中途异常可能残留 | 否 | 受限异常路径，暂不改变生命周期接口 |
| yaoyifan1@huawei.com | `parameter_sharding.py:412` | tied 参数与 FSDP2 offload/reshard 组合可能悬空 | 否 | 需确认底层参数替换契约 |
| yaoyifan1@huawei.com | `distributed/apply.py:136` | 重复 apply 可能形成 wrapper 链 | 否 | 拒绝/卸载会扩大 API 行为 |
| yaoyifan1@huawei.com | `checkpoint_loader.py:971` | 特定模型重建参数时快照守卫可能失效 | 否 | 数据丢失路径依赖具体模型实现 |
| yaoyifan1@huawei.com | `profiling_callback.py:57` | 正常长训练中 profiling window 后仍记录 | 是 | 窗口结束主动 stop |
| 821372701@qq.com | `aux_loss.py:43` | 未 detach 的 scale 可能钉住 autograd 图 | 否 | 仓内无调用方证据，属 hypothetical |
| sherry0329@126.com | `expert_parallel.py:1111` | dispatch/combine context 可能跨 step 残留 | 否 | 防御性路径，需配合反向生命周期 |
| yaoyifan1@huawei.com | `model_builder.py:608` | 裸 id 跨对象析构可能误判 | 否 | 已有 swap 保护，地址复用仅理论推断 |
| yaoyifan1@huawei.com | `qwen3_moe/adapter/attention.py:51` | device mask 缓存只增不减 | 否 | 条目有界且很小，热路径清理会增加开销 |
| yaoyifan1@huawei.com | `context_parallel_async.py:381` | wrapper 自引用环依赖 cyclic GC 回收 | 否 | 未发现禁用 GC 证据 |

## 验证

- `git diff --check`：通过
- `python3 -m compileall -q hyper_parallel`：通过
- `autogit check`：环境缺少 pip，无法安装 pylint，未执行
- pytest：环境未安装 pytest/torch，未执行

<!-- bot4-pr-sync-meta
schema_version: 1
source: gitcode
gitcode_repo: mindspore/hyper-parallel
gitcode_mr: 1397
github_repo: mindspore-ai/hyper-parallel
github_pr: 133
github_branch: sync/pr-1397
-->

<!-- atomgit-backport-meta -->
atomgit_repo: mindspore/hyper-parallel
atomgit_mr: 1397
source_branch: fix/targeted-memory-scan
source_url: https://gitcode.com/mindspore/hyper-parallel/merge_requests/1397
<!-- /atomgit-backport-meta -->
